### PR TITLE
make hexToRgba recognize CSS custom properties

### DIFF
--- a/src/utils/hex-to-rgba/index.js
+++ b/src/utils/hex-to-rgba/index.js
@@ -34,7 +34,6 @@ export default function hexToRGBA( hex, alpha ) {
 		}
 	}
 
-
 	if ( ! alpha && 0 !== alpha ) {
 		return hex;
 	}

--- a/src/utils/hex-to-rgba/index.js
+++ b/src/utils/hex-to-rgba/index.js
@@ -10,6 +10,31 @@ export default function hexToRGBA( hex, alpha ) {
 		return '';
 	}
 
+	/**
+	 * Detect CSS variables in form of var(--color) and get their current
+	 * values from the :root selector.
+	 */
+	if ( hex.indexOf( 'var(' ) > -1 ) {
+		let variableName = hex.match('--[a-zA-Z0-9]*')[0]
+
+		hex = window.getComputedStyle( document.documentElement )
+			.getPropertyValue( variableName ) || '#fff'
+
+		if ( hex.indexOf( 'rgb' ) > -1) {
+			const rgba = hex.replace( /^rgba?\(|\s+|\)$/g, '' ).split( ',' );
+
+			hex = `#${(
+				( 1 << 24 ) +
+				( parseInt( rgba[ 0 ] ) << 16 ) +
+				( parseInt( rgba[ 1 ] ) << 8 ) +
+				parseInt( rgba[ 2 ] )
+			)
+				.toString( 16 )
+				.slice( 1 )}`;
+		}
+	}
+
+
 	if ( ! alpha && 0 !== alpha ) {
 		return hex;
 	}


### PR DESCRIPTION
Solves the problem of applying the opacity onto the colors from the Gutenberg color palette, when the color palette contains a CSS Custom Property. It expects the css variable to be defined on the `:root` element.

How to test:

Apply this palette to Gutenberg:

```php
add_theme_support( 'editor-color-palette', [
    [
        'name' => __( 'Palette Color 1', 'blocksy' ),
        'slug' => 'palette-color-1',
        'color' => 'var(--paletteColor1)',
    ],

    [
        'name' => __( 'Palette Color 2', 'blocksy' ),
        'slug' => 'palette-color-2',
        'color' => 'var(--paletteColor2)',
    ],

    [
        'name' => __( 'Palette Color 3', 'blocksy' ),
        'slug' => 'palette-color-3',
        'color' => 'var(--paletteColor3)',
    ],

    [
        'name' => __( 'Palette Color 4', 'blocksy' ),
        'slug' => 'palette-color-4',
        'color' => 'var(--paletteColor4, #fff)',
    ],

    [
        'name' => __( 'Palette Color 5', 'blocksy' ),
        'slug' => 'palette-color-5',
        'color' => 'var(--paletteColor5, rgba(0, 0, 0, 0.5))',
    ]
]);
```

With that in place, define these CSS variables from:

```css
:root {
  --paletteColor1: red;
  --paletteColor2: green;
  --paletteColor3: blue;
  --paletteColor4: pink;
  --paletteColor5: black;
}
```

With this in place, `hexToRgba()` will be able to apply the opacity correctly. I'll be happy to change the implementation if this somehow doesn't fit the project's guidelines and rules.

---

This approach for the Color Palette is used in [Blocksy](https://wordpress.org/themes/blocksy/) and there were no problems with this up until now. Hope this fix could be included in Kadence Blocks for a better compatibility between the two tools.

A similar PR was applied on [Stackable](https://github.com/gambitph/Stackable/pull/706) and [Kadence](https://github.com/kadencewp/kadence-blocks/pull/106) blocks and runs with success so far.

---

_Note_: Kadence and Stackable lack the support for defaults and rgba values in defaults. The code in this PR offers this. Happy to update the implementation as the review moves ahead.