### PR TITLE
Always inline CSS on AMP pages to avoid needing to fetch

### DIFF
--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -76,10 +76,17 @@ class GenerateBlocks_Enqueue_CSS {
 	 */
 	public function mode() {
 		// Check if we're using file mode or inline mode.
-		// Default to file mode and falback to inline if file mode is not possible.
+		// Default to file mode and fallback to inline if file mode is not possible.
 		$mode = apply_filters( 'generateblocks_css_print_method', 'file' );
 
-		if ( ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) || is_preview() ) {
+		if (
+			( function_exists( 'is_customize_preview' ) && is_customize_preview() )
+			||
+			is_preview()
+			||
+			// AMP inlines all CSS, so inlining from the start improves CSS processing performance.
+			( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() )
+		) {
 			return 'inline';
 		}
 


### PR DESCRIPTION
The AMP plugin inlines all CSS into the `style[amp-custom]` element. External stylesheets referenced by `link` elements get fetched and are then processed (minification and tree shaking). Having them be inline from the start avoids the need to fetch them from the filesystem (or worse) over HTTP.