### PR TITLE
Process widget content for block styling

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -254,3 +254,26 @@ function generateblocks_do_shape_divider( $output, $attributes ) {
 
 	return $output;
 }
+
+add_filter( 'generateblocks_do_content', 'generateblocks_do_widget_styling' );
+/**
+ * Process all widget content for potential styling.
+ *
+ * @since 1.4.0
+ * @param string $content The existing content to process.
+ */
+function generateblocks_do_widget_styling( $content ) {
+	$widget_data = generateblocks_get_all_widget_data();
+
+	foreach ( (array) $widget_data as $widget_area => $widget_data ) {
+		if ( ! empty( $widget_data ) ) {
+			foreach ( (array) $widget_data as $key => $data ) {
+				if ( ! empty( $data->content ) ) {
+					$content .= $data->content;
+				}
+			}
+		}
+	}
+
+	return $content;
+}


### PR DESCRIPTION
First try at this. It works, but I don't love it.

Some issues:

* It processes ALL widgets, even ones that don't appear on the current page. This means we're adding CSS to all pages for GB blocks that might not appear there.
* Performance impact?
* If the CSS is being served via an external file, that file needs to be regenerated every time a widget area is saved or the changes won't take place.

I think this opens the need for us to have a mechanism to always serve certain CSS inline vs. in the external file. CSS for widgets shouldn't be included in the external file.