### PR TITLE
Style our blocks in the widget areas

### DIFF
--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -45,6 +45,7 @@ class GenerateBlocks_Enqueue_CSS {
 		add_action( 'save_post', array( $this, 'post_update_option' ), 10, 2 );
 		add_action( 'save_post_wp_block', array( $this, 'wp_block_update' ), 10, 2 );
 		add_action( 'init', array( $this, 'enqueue_assets' ) );
+		add_filter( 'widget_update_callback', array( $this, 'force_file_regen_on_widget_save' ) );
 	}
 
 	/**
@@ -434,6 +435,17 @@ class GenerateBlocks_Enqueue_CSS {
 	 */
 	public function update_saved_time() {
 		update_option( 'generateblocks_dynamic_css_time', time() );
+	}
+
+	/**
+	 * Force CSS files to regenerate after a widget has been saved.
+	 *
+	 * @param array $instance The current widget instance's settings.
+	 */
+	public function force_file_regen_on_widget_save( $instance ) {
+		update_option( 'generateblocks_dynamic_css_posts', array() );
+
+		return $instance;
 	}
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -746,3 +746,35 @@ function generateblocks_get_svg_shapes() {
 		)
 	);
 }
+
+/**
+ * Get the widget data for a specified widget area.
+ *
+ * @since 1.3.4
+ */
+function generateblocks_get_widget_data() {
+	global $wp_registered_sidebars, $wp_registered_widgets;
+
+	$output = array();
+	$sidebar_widgets = wp_get_sidebars_widgets();
+
+	foreach ( $wp_registered_sidebars as $sidebar ) {
+		if ( empty( $sidebar['id'] ) || ! isset( $sidebar_widgets[ $sidebar['id'] ] ) ) {
+			continue;
+		}
+
+		$widget_ids = $sidebar_widgets[ $sidebar['id'] ];
+
+		foreach ( (array) $widget_ids as $id ) {
+			// The name of the option in the database is the name of the widget class.
+			$option_name = $wp_registered_widgets[ $id ]['callback'][0]->option_name;
+
+			// Widget data is stored as an associative array. To get the right data we need to get the right key which is stored in $wp_registered_widgets.
+			$key = $wp_registered_widgets[ $id ]['params'][0]['number'];
+			$widget_data = get_option( $option_name );
+			$output[] = (object) $widget_data[ $key ];
+		}
+	}
+
+	return $output;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -746,35 +746,3 @@ function generateblocks_get_svg_shapes() {
 		)
 	);
 }
-
-/**
- * Get the widget data for a specified widget area.
- *
- * @since 1.3.4
- */
-function generateblocks_get_widget_data() {
-	global $wp_registered_sidebars, $wp_registered_widgets;
-
-	$output = array();
-	$sidebar_widgets = wp_get_sidebars_widgets();
-
-	foreach ( $wp_registered_sidebars as $sidebar ) {
-		if ( empty( $sidebar['id'] ) || ! isset( $sidebar_widgets[ $sidebar['id'] ] ) ) {
-			continue;
-		}
-
-		$widget_ids = $sidebar_widgets[ $sidebar['id'] ];
-
-		foreach ( (array) $widget_ids as $id ) {
-			// The name of the option in the database is the name of the widget class.
-			$option_name = $wp_registered_widgets[ $id ]['callback'][0]->option_name;
-
-			// Widget data is stored as an associative array. To get the right data we need to get the right key which is stored in $wp_registered_widgets.
-			$key = $wp_registered_widgets[ $id ]['params'][0]['number'];
-			$widget_data = get_option( $option_name );
-			$output[] = (object) $widget_data[ $key ];
-		}
-	}
-
-	return $output;
-}

--- a/includes/general.php
+++ b/includes/general.php
@@ -253,13 +253,20 @@ add_filter( 'generateblocks_do_content', 'generateblocks_do_widget_styling' );
  * @param string $content The existing content to process.
  */
 function generateblocks_do_widget_styling( $content ) {
-	$widget_data = generateblocks_get_widget_data();
+	$widget_blocks = get_option( 'widget_block' );
 
-	foreach ( (array) $widget_data as $widget_area => $widget ) {
-		if ( is_object( $widget ) && ! empty( $widget->content ) ) {
-			$content .= $widget->content;
-		}
-	}
+	return array_reduce(
+		(array) $widget_blocks,
+		function( $content, $block ) {
+			if (
+				isset( $block['content'] )
+				&& preg_match( '/(wp:generateblocks\/)/', $block['content'] )
+			) {
+				$content .= $block['content'];
+			}
 
-	return $content;
+			return $content;
+		},
+		$content
+	);
 }

--- a/includes/general.php
+++ b/includes/general.php
@@ -244,3 +244,22 @@ function generateblocks_do_shape_divider( $output, $attributes ) {
 
 	return $output;
 }
+
+add_filter( 'generateblocks_do_content', 'generateblocks_do_widget_styling' );
+/**
+ * Process all widget content for potential styling.
+ *
+ * @since 1.3.4
+ * @param string $content The existing content to process.
+ */
+function generateblocks_do_widget_styling( $content ) {
+	$widget_data = generateblocks_get_widget_data();
+
+	foreach ( (array) $widget_data as $widget_area => $widget ) {
+		if ( is_object( $widget ) && ! empty( $widget->content ) ) {
+			$content .= $widget->content;
+		}
+	}
+
+	return $content;
+}

--- a/includes/general.php
+++ b/includes/general.php
@@ -255,18 +255,11 @@ add_filter( 'generateblocks_do_content', 'generateblocks_do_widget_styling' );
 function generateblocks_do_widget_styling( $content ) {
 	$widget_blocks = get_option( 'widget_block' );
 
-	return array_reduce(
-		(array) $widget_blocks,
-		function( $content, $block ) {
-			if (
-				isset( $block['content'] )
-				&& preg_match( '/(wp:generateblocks\/)/', $block['content'] )
-			) {
-				$content .= $block['content'];
-			}
+	foreach ( (array) $widget_blocks as $block ) {
+		if ( isset( $block['content'] ) ) {
+			$content .= $block['content'];
+		}
+	}
 
-			return $content;
-		},
-		$content
-	);
+	return $content;
 }


### PR DESCRIPTION
Original pull here: https://github.com/tomusborne/generateblocks/pull/63

Now going to merge this into 1.3.4 as a patch release for WP 5.8.

One issue with this PR is that it uses wp_get_sidebars_widgets(), which is private: https://developer.wordpress.org/reference/functions/wp_get_sidebars_widgets/

I'm not sure why, exactly. I suppose we could extract the parts we need and ditch the function.