### PR TITLE
Fix block categories in WP 5.8

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -120,7 +120,11 @@ function generateblocks_do_block_editor_assets() {
 	);
 }
 
-add_filter( 'block_categories', 'generateblocks_do_category' );
+if ( version_compare( $GLOBALS['wp_version'], '5.8-alpha-1', '<' ) ) {
+	add_filter( 'block_categories', 'generateblocks_do_category' );
+} else {
+	add_filter( 'block_categories_all', 'generateblocks_do_category' );
+}
 /**
  * Add GeneratePress category to Gutenberg.
  *


### PR DESCRIPTION
In the WP 5.8 widget area, GB blocks are uncategorized as WP introduced a new filter and didn't add backwards-compatibility in the widget area (guessing): https://www.screencast.com/t/fiy3Ugzln

This should fix that issue while maintaining compatibility with versions prior to 5.8.