### PR TITLE
Regenerate CSS files after customizer save

### DIFF
--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -46,6 +46,7 @@ class GenerateBlocks_Enqueue_CSS {
 		add_action( 'save_post_wp_block', array( $this, 'wp_block_update' ), 10, 2 );
 		add_action( 'init', array( $this, 'enqueue_assets' ) );
 		add_filter( 'widget_update_callback', array( $this, 'force_file_regen_on_widget_save' ) );
+		add_action( 'customize_save_after', array( $this, 'force_file_regen_on_customizer_save' ) );
 	}
 
 	/**
@@ -448,6 +449,18 @@ class GenerateBlocks_Enqueue_CSS {
 		}
 
 		return $instance;
+	}
+
+	/**
+	 * Force CSS files to regenerate after the Customizer has been saved.
+	 * This is necessary because force_file_regen_on_widget_save() doesn't fire in the Customizer for some reason.
+	 *
+	 * @todo Make this only happen when the widgets have been changed.
+	 */
+	public function force_file_regen_on_customizer_save() {
+		if ( function_exists( 'wp_use_widgets_block_editor' ) && wp_use_widgets_block_editor() ) {
+			update_option( 'generateblocks_dynamic_css_posts', array() );
+		}
 	}
 }
 


### PR DESCRIPTION
For some reason #83 doesn't work when saving widgets from the Customizer.

This PR forces the CSS files to regenerate once the Customizer is saved so users can see their changes.

It would be nice if we could make this happen only if the widgets have changed down the road.

To test this:

1. Build a page using GB and make sure the CSS method is set to file in "Settings > GenerateBlocks".
2. Make sure the file is being served in the source of this page.
3. Go to the Customizer and add a GB widget, then save.

The CSS file should regenerate once you load the page again with the necessary widget CSS.