### PR TITLE
Add protocol to Google fonts request

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -348,7 +348,7 @@ function generateblocks_get_google_fonts_uri() {
 		)
 	);
 
-	return add_query_arg( $font_args, '//fonts.googleapis.com/css' );
+	return add_query_arg( $font_args, 'https://fonts.googleapis.com/css' );
 }
 
 /**


### PR DESCRIPTION
This removes the relative protocol from the Google fonts API request: https://webhint.io/docs/user-guide/hints/hint-no-protocol-relative-urls/