### PR TITLE
Filter the font list of the typography component.

### DIFF
--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -26,6 +26,10 @@ import {
 	Button,
 } from '@wordpress/components';
 
+import {
+	applyFilters,
+} from '@wordpress/hooks';
+
 /**
  * Typography Component
  */
@@ -53,13 +57,13 @@ class TypographyControls extends Component {
 			fontSizePlaceholder = '17',
 		} = this.props;
 
-		const fonts = [
+		const fonts = applyFilters( 'generateblocks.editor.fonts', [
 			{ value: '', label: __( 'Select font', 'generateblocks' ) },
 			{ value: 'Arial', label: 'Arial' },
 			{ value: 'Helvetica', label: 'Helvetica' },
 			{ value: 'Times New Roman', label: 'Times New Roman' },
 			{ value: 'Georgia', label: 'Georgia' },
-		];
+		] );
 
 		Object.keys( googleFonts ).slice( 0, 20 ).forEach( ( k ) => {
 			fonts.push(


### PR DESCRIPTION
Add a filter, allowing to filter the font picker's fonts. This allows theme developers to add their own local fonts.

See: https://generatepress.com/forums/topic/add-local-font-to-generateblock-dropdown