### PR TITLE
Fix undefined option when saving settings

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -131,7 +131,7 @@ class GenerateBlocks_Rest extends WP_REST_Controller {
 
 		foreach ( $new_settings as $name => $value ) {
 			// Skip if the option hasn't changed.
-			if ( $current_settings[ $name ] === $new_settings[ $name ] ) {
+			if ( isset( $current_settings[ $name ] ) && $current_settings[ $name ] === $new_settings[ $name ] ) {
 				unset( $new_settings[ $name ] );
 				continue;
 			}


### PR DESCRIPTION
Closes #181

This fixes an undefined index error when saving our options for the first time.

To test, delete the `generateblocks` option from `wp_options` and then click the Save button in the GB settings area.