### PR TITLE
Fix missing editor styles in Firefox

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -56,6 +56,8 @@ class GenerateBlocks_Render_Block {
 			array(
 				'title' => esc_html__( 'Container', 'generateblocks' ),
 				'render_callback' => array( $this, 'do_container_block' ),
+				'editor_script' => 'generateblocks',
+				'editor_style' => 'generateblocks',
 			)
 		);
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -28,7 +28,7 @@ function generateblocks_do_block_editor_assets() {
 		unset( $generateblocks_deps[2] );
 	}
 
-	wp_register_script(
+	wp_enqueue_script(
 		'generateblocks',
 		GENERATEBLOCKS_DIR_URL . 'dist/blocks.js',
 		$generateblocks_deps,
@@ -40,7 +40,7 @@ function generateblocks_do_block_editor_assets() {
 		wp_set_script_translations( 'generateblocks', 'generateblocks' );
 	}
 
-	wp_register_style(
+	wp_enqueue_style(
 		'generateblocks',
 		GENERATEBLOCKS_DIR_URL . 'dist/blocks.css',
 		array( 'wp-edit-blocks' ),

--- a/includes/general.php
+++ b/includes/general.php
@@ -28,7 +28,7 @@ function generateblocks_do_block_editor_assets() {
 		unset( $generateblocks_deps[2] );
 	}
 
-	wp_enqueue_script(
+	wp_register_script(
 		'generateblocks',
 		GENERATEBLOCKS_DIR_URL . 'dist/blocks.js',
 		$generateblocks_deps,
@@ -40,7 +40,7 @@ function generateblocks_do_block_editor_assets() {
 		wp_set_script_translations( 'generateblocks', 'generateblocks' );
 	}
 
-	wp_enqueue_style(
+	wp_register_style(
 		'generateblocks',
 		GENERATEBLOCKS_DIR_URL . 'dist/blocks.css',
 		array( 'wp-edit-blocks' ),

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 == Changelog ==
 
 = 1.4.2 =
+* Fix: Missing responsive editor styles in Firefox
 
 = 1.4.1 =
 * Fix: Color picker UI in WP 5.9


### PR DESCRIPTION
This PR fixes an issue where we lose all block styling in the editor using Firefox when in Tablet or Mobile modes.