### PR TITLE
Release 1.4.2

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -56,6 +56,8 @@ class GenerateBlocks_Render_Block {
 			array(
 				'title' => esc_html__( 'Container', 'generateblocks' ),
 				'render_callback' => array( $this, 'do_container_block' ),
+				'editor_script' => 'generateblocks',
+				'editor_style' => 'generateblocks',
 			)
 		);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generateblocks",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"private": true,
 	"description": "A small collection of lightweight WordPress blocks that can accomplish nearly anything.",
 	"author": "Tom Usborne",

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: A small collection of lightweight WordPress blocks that can accomplish nearly anything.
  * Author: Tom Usborne
  * Author URI: https://tomusborne.com
- * Version: 1.4.1
+ * Version: 1.4.2
  * Requires at least: 5.4
  * Requires PHP: 5.6
  * License: GPL2+
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'GENERATEBLOCKS_VERSION', '1.4.1' );
+define( 'GENERATEBLOCKS_VERSION', '1.4.2' );
 define( 'GENERATEBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENERATEBLOCKS_DIR_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,8 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 
 == Changelog ==
 
+= 1.4.2 =
+
 = 1.4.1 =
 * Fix: Color picker UI in WP 5.9
 * Fix: PHP notice when first saving Dashboard settings

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: blocks, gutenberg, container, headline, grid, columns, page builder, wysiw
 Requires at least: 5.4
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 == Changelog ==
 
 = 1.4.2 =
+* Fix: Missing responsive editor styles in Firefox
 
 = 1.4.1 =
 * Fix: Color picker UI in WP 5.9


### PR DESCRIPTION
This update fixes an issue in the editor where the GB styles are missing in tablet/mobile modes when using Firefox.

It's scheduled to be released on February 8.

- [ ] Run builds
- [x] Update version: package.json
- [x] Update version: plugin/style.css header
- [x] Update version: PHP constant
- [x] Update version: readme.txt stable tag
- [x] Update changelog
- [x] Test for PHP parse errors
- [x] Test PHP 5.6+