### PR TITLE
Fix dynamic button icon location

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -686,7 +686,10 @@ class GenerateBlocks_Render_Block {
 			);
 
 			if ( $icon_html ) {
-				$output .= $icon_html;
+				if ( 'left' === $settings['iconLocation'] ) {
+					$output .= $icon_html;
+				}
+
 				$output .= '<span class="gb-button-text">';
 			}
 
@@ -698,6 +701,10 @@ class GenerateBlocks_Render_Block {
 
 			if ( $icon_html ) {
 				$output .= '</span>';
+
+				if ( 'right' === $settings['iconLocation'] ) {
+					$output .= $icon_html;
+				}
 			}
 
 			$output .= sprintf(


### PR DESCRIPTION
Closes #303 

This fixes a bug where icons added to the right of the button text remained on the left on the frontend when using dynamic buttons.