### PR TITLE
Fix missing dynamic image link

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -521,6 +521,9 @@ class GenerateBlocks_Dynamic_Content {
 			return '';
 		}
 
+		// Add our saved dimensions to the image.
+		$dynamic_image = self::get_image_with_dimensions( $dynamic_image, $attributes );
+
 		return $dynamic_image;
 	}
 
@@ -861,9 +864,9 @@ class GenerateBlocks_Dynamic_Content {
 	 * The width and height attributes aren't available via filter.
 	 *
 	 * @param string $content The image HTML.
-	 * @param array  $settings The block settings.
+	 * @param array  $attributes The block settings.
 	 */
-	public static function get_image_with_dimensions( $content, $settings ) {
+	public static function get_image_with_dimensions( $content, $attributes ) {
 		$doc = self::load_html( $content );
 
 		if ( ! $doc ) {
@@ -881,13 +884,13 @@ class GenerateBlocks_Dynamic_Content {
 
 		$update_image = false;
 
-		if ( $settings['width'] ) {
-			$image->setAttribute( 'width', $settings['width'] );
+		if ( ! empty( $attributes['width'] ) ) {
+			$image->setAttribute( 'width', $attributes['width'] );
 			$update_image = true;
 		}
 
-		if ( $settings['height'] ) {
-			$image->setAttribute( 'height', $settings['height'] );
+		if ( ! empty( $attributes['height'] ) ) {
+			$image->setAttribute( 'height', $attributes['height'] );
 			$update_image = true;
 		}
 

--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -803,8 +803,6 @@ class GenerateBlocks_Render_Block {
 			return '';
 		}
 
-		$image = GenerateBlocks_Dynamic_Content::get_image_with_dimensions( $image, $settings );
-
 		$output .= $image;
 
 		if ( isset( $block->parsed_block['innerBlocks'][0]['attrs'] ) ) {


### PR DESCRIPTION
This PR fixes a bug where the dynamic image link was being removed before output.

This moves the function that adds the saved dimensions to the image before we add the link, which prevents it from being stripped.