### PR TITLE
Use block.json in dist folder to register

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -116,7 +116,7 @@ class GenerateBlocks_Render_Block {
 		);
 
 		register_block_type(
-			GENERATEBLOCKS_DIR . 'src/blocks/image',
+			GENERATEBLOCKS_DIR . 'dist/blocks/image',
 			array(
 				'title' => esc_html__( 'Image', 'generateblocks' ),
 				'render_callback' => array( $this, 'do_image_block' ),


### PR DESCRIPTION
This uses the `block.json` file in the `dist` folder to register the image block. This will allow us to exclude the `src` folder from builds in the future if we want to.