### PR TITLE
Remove pagination buttons with no link

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -648,6 +648,18 @@ class GenerateBlocks_Render_Block {
 
 			$dynamic_link = GenerateBlocks_Dynamic_Content::get_dynamic_url( $attributes, $block );
 
+			// Don't output pagination buttons with no link.
+			if (
+				! $dynamic_link &&
+				! empty( $attributes['dynamicLinkType'] ) &&
+				(
+					'pagination-prev' === $attributes['dynamicLinkType'] ||
+					'pagination-next' === $attributes['dynamicLinkType']
+				)
+			) {
+				return '';
+			}
+
 			if ( isset( $content['attributes']['href'] ) || $dynamic_link ) {
 				$tagName = 'a';
 			}


### PR DESCRIPTION
Closes #449 

This doesn't output the pagination next/prev buttons if no next/prev page exists.