### PR TITLE
Use compiled script assets

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -28,11 +28,19 @@ function generateblocks_do_block_editor_assets() {
 		unset( $generateblocks_deps[2] );
 	}
 
+	$assets_file = GENERATEBLOCKS_DIR . 'dist/blocks.asset.php';
+	$assets = file_exists( $assets_file )
+		? require $assets_file
+		: [
+			'dependencies' => $generateblocks_deps,
+			'version' => filemtime( GENERATEBLOCKS_DIR . 'dist/blocks.js' ),
+		];
+
 	wp_enqueue_script(
 		'generateblocks',
 		GENERATEBLOCKS_DIR_URL . 'dist/blocks.js',
-		$generateblocks_deps,
-		filemtime( GENERATEBLOCKS_DIR . 'dist/blocks.js' ),
+		$assets['dependencies'],
+		$assets['version'],
 		true
 	);
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -29,8 +29,14 @@ function generateblocks_do_block_editor_assets() {
 	}
 
 	$assets_file = GENERATEBLOCKS_DIR . 'dist/blocks.asset.php';
-	$assets = file_exists( $assets_file )
+	$compiled_assets = file_exists( $assets_file )
 		? require $assets_file
+		: false;
+
+	$assets =
+		isset( $compiled_assets['dependencies'] ) &&
+		isset( $compiled_assets['version'] )
+		? $compiled_assets
 		: [
 			'dependencies' => $generateblocks_deps,
 			'version' => filemtime( GENERATEBLOCKS_DIR . 'dist/blocks.js' ),


### PR DESCRIPTION
This uses the compiled script assets and version instead of defining our own.

I left the old method as a backup just in case.