### PR TITLE
Add generateblocks_query_loop_args filter

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -412,6 +412,13 @@ class GenerateBlocks_Render_Block {
 			}
 		}
 
+		$query_args = apply_filters(
+			'generateblocks_query_loop_args',
+			$query_args,
+			$attributes,
+			$block
+		);
+
 		$the_query = new WP_Query( $query_args );
 
 		$content = '';


### PR DESCRIPTION
Closes #463 

This adds a `generateblocks_query_loop_args` so we can filter the frontend query args.