### PR TITLE
Change actions trigger from push to manual

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,8 +1,6 @@
 name: "Plugin asset/readme update"
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 jobs:
   master:
     name: Push to master


### PR DESCRIPTION
This PR changes the actions "Deploy to WordPress.org" and "Plugin asset/readme update" to have manual trigger instead of auto on pushing changes to master/tags.