### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,40 @@
+name: Build package
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Package name'
+        default: 'generateblocks'
+        required: true
+
+jobs:
+
+  build-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'npm'
+
+      - name: NPM install
+        run: npm install
+
+      - name: NPM build
+        run: npm run build
+
+      - name: Build zip file
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: ${{ github.event.inputs.name }}
+          path: |
+            assets/
+            dist/
+            includes/
+            src/
+            plugin.php
+            readme.txt
+          retention-days: 1

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -37,4 +37,20 @@ jobs:
             src/
             plugin.php
             readme.txt
+            !/.wordpress-org
+            !/.git
+            !/.github
+            !.distignore
+            !.DS_Store
+            !.editorconfig
+            !.eslintignore
+            !.eslintrc.json
+            !.gitattributes
+            !.gitignore
+            !package-lock.json
+            !package.json
+            !composer.json
+            !composer.lock
+            !phpcs.xml.dist
+            !Gruntfile.js
           retention-days: 1

--- a/.github/workflows/commit-dist-files.yml
+++ b/.github/workflows/commit-dist-files.yml
@@ -1,0 +1,31 @@
+name: Commit dist files
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release/*
+
+jobs:
+
+  commit-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'npm'
+
+      - name: NPM install
+        run: npm install
+
+      - name: NPM build
+        run: npm run build
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: 'Update dist files'
+          add: 'dist/'

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -1,14 +1,10 @@
-name: GenerateBlocks JS CI
+name: JS CI
 
 on:
-  push:
+  pull_request:
     branches:
-      - test
-#      - 'release/**'
-#  pull_request:
-#    branches:
-#      - master
-#      - 'release/**'
+      - master
+      - 'release/**'
 
 jobs:
   build:
@@ -16,9 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+          cache: 'npm'
 
-      - name: Check node_modules cache
+      - name: NPM Cache
         id: npm-cache
         uses: actions/cache@v2
         with:
@@ -26,6 +26,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-modules-
+
       - name: NPM install
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm install


### PR DESCRIPTION
- Fix the JS CI to use cache of node_modules instead of installing dependencies on every action
- Adds manual action to build the GenerateBlocks package
- Adds the action to build dist files on release branches