### PR TITLE
Run commit dist files only on src/ files changes

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -26,31 +26,13 @@ jobs:
       - name: NPM build
         run: npm run build
 
+      - name: Grunt action-package
+        run: npm run action-package
+
       - name: Build zip file
         uses: actions/upload-artifact@v3.1.0
         with:
           name: ${{ github.event.inputs.name }}
           path: |
-            assets/
-            dist/
-            includes/
-            src/
-            plugin.php
-            readme.txt
-            !/.wordpress-org
-            !/.git
-            !/.github
-            !.distignore
-            !.DS_Store
-            !.editorconfig
-            !.eslintignore
-            !.eslintrc.json
-            !.gitattributes
-            !.gitignore
-            !package-lock.json
-            !package.json
-            !composer.json
-            !composer.lock
-            !phpcs.xml.dist
-            !Gruntfile.js
+            generateblocks/
           retention-days: 1

--- a/.github/workflows/commit-dist-files.yml
+++ b/.github/workflows/commit-dist-files.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - release/*
+    paths:
+      - src/**
 
 jobs:
 

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - 'release/**'
+    paths:
+      - src/**
 
 jobs:
   build:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,7 @@ module.exports = function( grunt ) {
 
 	// Grunt release - Create installable package of the local files
 	grunt.registerTask( 'package', [ 'clean:zip', 'copy:main', 'compress:main', 'clean:main' ] );
+	grunt.registerTask( 'action-package', [ 'copy:main' ] );
 
 	grunt.registerTask( 'download-google-fonts', function() {
 		const done = this.async();

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"lint:js": "wp-scripts lint-js",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"package": "grunt package",
+		"action-package": "grunt action-package",
 		"googleFonts": "grunt download-google-fonts",
 		"test:unit": "wp-scripts test-unit-js"
 	}


### PR DESCRIPTION
This PR adds a check to run the action to build dist files only when files inside `src/` directory were changed.
The same was applied to JS CI.