### PR TITLE
Tweak: Only show image alt/title controls for Desktop

### DIFF
--- a/src/blocks/image/components/inspector-controls/ImageSettingsControl.js
+++ b/src/blocks/image/components/inspector-controls/ImageSettingsControl.js
@@ -135,7 +135,7 @@ export default function ImageSettingsControls( props ) {
 				} }
 			/>
 
-			{ ! useDynamicData &&
+			{ ! useDynamicData && 'Desktop' === deviceType &&
 				<>
 					<TextareaControl
 						label={ __( 'Alt text (alternative text)', 'generateblocks' ) }


### PR DESCRIPTION
This makes it so the Image block alt/title controls only show when in Desktop mode.