### PR TITLE
Tweak: Improve editor per page cap

### DIFF
--- a/src/blocks/query-loop/components/inspector-controls/parameter-list/ControlBuilder.js
+++ b/src/blocks/query-loop/components/inspector-controls/parameter-list/ControlBuilder.js
@@ -1,4 +1,5 @@
 import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import SelectPostType from '../../../../../extend/dynamic-content/components/SelectPostType';
 import SimpleSelect from '../../../../../components/simple-select';
 import AuthorsSelect from '../../../../../components/authors-select';
@@ -54,13 +55,18 @@ export default function ControlBuilder( props ) {
 	} = props;
 
 	const Control = getParameterControl( type );
+	let controlDescription = description;
+
+	if ( 'per_page' === id && ( '-1' === value || value > 50 ) ) {
+		controlDescription += ' ' + __( 'Editor only: A maximum of 50 posts can be previewed in the editor.', 'generateblocks' );
+	}
 
 	return (
 		<div className={ 'gblocks-parameter-component' }>
 			<Control
 				type={ type }
 				label={ label }
-				help={ description }
+				help={ controlDescription }
 				options={ selectOptions }
 				value={ value }
 				placeholder={ defaultValue }

--- a/src/blocks/query-loop/components/utils.js
+++ b/src/blocks/query-loop/components/utils.js
@@ -22,7 +22,9 @@ function normalizeTaxQuery( taxQueryValue, isExclude = false ) {
 
 export function normalizeRepeatableArgs( query ) {
 	// In the editor we capped to 50 posts.
-	const perPage = ! query.per_page || 50 > query.per_page ? query.per_page : 50;
+	const perPage = '-1' === query.per_page || query.per_page > 50
+		? 50
+		: query.per_page;
 
 	let normalizedQuery = Object.assign( {}, query, { per_page: perPage } );
 

--- a/src/blocks/query-loop/query-parameters.js
+++ b/src/blocks/query-loop/query-parameters.js
@@ -15,7 +15,7 @@ export default [
 		type: 'number',
 		default: 10,
 		label: __( 'Posts per page', 'generateblocks' ),
-		description: __( 'Number of post to show per page. Editor only: displays a maximum of 50 posts', 'generateblocks' ),
+		description: __( 'Number of post to show per page.', 'generateblocks' ),
 		group: __( 'Pagination', 'generateblocks' ),
 		isSticky: true,
 	},


### PR DESCRIPTION
This PR does two things:

1. Checks for `-1` as a per_page value to set the `50` cap on posts.
2. Conditionally shows the "Editor only" message if the value is higher than `50`.