### PR TITLE
Tweak: Improve dynamic link control

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -766,20 +766,20 @@ class GenerateBlocks_Dynamic_Content {
 				}
 			}
 
-			if ( 'user-meta' === $link_type ) {
+			if ( 'author-meta' === $link_type ) {
 				$url = self::get_user_data( $author_id, $attributes['linkMetaFieldName'] );
 
 				if ( isset( $attributes['linkMetaFieldType'] ) ) {
 					$url = $attributes['linkMetaFieldType'] . $url;
 				}
 			}
+		}
 
-			if ( 'term-meta' === $link_type ) {
-				$url = get_term_meta( get_queried_object_id(), $attributes['linkMetaFieldName'], true );
+		if ( 'author-email' === $link_type ) {
+			$url = self::get_user_data( $author_id, 'user_email' );
 
-				if ( isset( $attributes['linkMetaFieldType'] ) ) {
-					$url = $attributes['linkMetaFieldType'] . $url;
-				}
+			if ( isset( $attributes['linkMetaFieldType'] ) ) {
+				$url = $attributes['linkMetaFieldType'] . $url;
 			}
 		}
 

--- a/src/extend/dynamic-content/inspector-controls/ContentTypeControl.js
+++ b/src/extend/dynamic-content/inspector-controls/ContentTypeControl.js
@@ -99,9 +99,15 @@ export default ( { dynamicContentType, setAttributes, name, isCaption } ) => {
 		.reduce( ( result, group ) => result.concat( group.options ), [] )
 		.filter( ( option ) => ( option.value === dynamicContentType ) );
 
-	const label = 'generateblocks/container' === name
-		? __( 'Background image type', 'generateblocks' )
-		: __( 'Data type', 'generateblocks' );
+	let label = __( 'Content source', 'generateblocks' );
+
+	if ( 'generateblocks/container' === name ) {
+		label = __( 'Background image source', 'generateblocks' );
+	}
+
+	if ( 'generateblocks/image' === name ) {
+		label = __( 'Image source', 'generateblocks' );
+	}
 
 	return (
 		<AdvancedSelect

--- a/src/extend/dynamic-content/inspector-controls/LinkTypeControl.js
+++ b/src/extend/dynamic-content/inspector-controls/LinkTypeControl.js
@@ -5,11 +5,27 @@ import { SelectControl, TextControl } from '@wordpress/components';
 
 const getOptions = ( dynamicContentType, isPagination = false, name ) => {
 	let defaultOptions = [
-		{ value: '', label: __( 'Select…', 'generateblocks' ) },
-		{ value: 'single-post', label: __( 'Single post', 'generateblocks' ) },
-		{ value: 'author-archives', label: __( 'Author archives', 'generateblocks' ) },
-		{ value: 'comments-area', label: __( 'Comments area', 'generateblocks' ) },
-		{ value: 'post-meta', label: __( 'Post meta', 'generateblocks' ) },
+		{
+			options: [
+				{ value: '', label: __( 'Select…', 'generateblocks' ) },
+			],
+		},
+		{
+			label: __( 'Post', 'generateblocks' ),
+			options: [
+				{ value: 'single-post', label: __( 'Single post', 'generateblocks' ) },
+				{ value: 'comments-area', label: __( 'Comments area', 'generateblocks' ) },
+				{ value: 'post-meta', label: __( 'Post meta', 'generateblocks' ) },
+			],
+		},
+		{
+			label: __( 'Author', 'generateblocks' ),
+			options: [
+				{ value: 'author-archives', label: __( 'Author archives', 'generateblocks' ) },
+				{ value: 'author-meta', label: __( 'Author meta', 'generateblocks' ) },
+				{ value: 'author-email', label: __( 'Author email', 'generateblocks' ) },
+			],
+		},
 	];
 
 	if ( 'terms' === dynamicContentType ) {
@@ -31,8 +47,11 @@ const getOptions = ( dynamicContentType, isPagination = false, name ) => {
 	}
 
 	if ( 'generateblocks/image' === name ) {
-		defaultOptions.splice( 2, 0, {
-			value: 'single-image', label: __( 'Single image', 'generateblocks' ),
+		defaultOptions.splice( 1, 0, {
+			label: __( 'Image', 'generateblocks' ),
+			options: [
+				{ value: 'single-image', label: __( 'Single image', 'generateblocks' ) },
+			],
 		} );
 	}
 
@@ -77,7 +96,11 @@ export default ( {
 		return null;
 	}
 
-	const value = options.filter( ( option ) => ( option.value === linkType ) );
+	const value = options
+		.reduce( ( result, group ) => result.concat( group.options ), [] )
+		.filter( ( option ) => ( option.value === linkType ) );
+
+	const isMeta = 'post-meta' === linkType || 'author-meta' === linkType;
 
 	return (
 		<>
@@ -85,30 +108,31 @@ export default ( {
 				<>
 					<AdvancedSelect
 						id={ 'gblocks-select-link-type-control' }
-						label={ __( 'Link type', 'generateblocks' ) }
-						placeholder={ __( 'Link type', 'generateblocks' ) }
+						label={ __( 'Link source', 'generateblocks' ) }
+						placeholder={ __( 'Link source', 'generateblocks' ) }
 						options={ options }
 						value={ value }
 						onChange={ ( option ) => setAttributes( { dynamicLinkType: option.value } ) }
 					/>
 
-					{ 'post-meta' === linkType &&
-						<>
-							<TextControl
-								label={ __( 'Meta field name', 'generateblocks' ) }
-								value={ linkMetaFieldName }
-								onChange={ ( newValue ) => setAttributes( { linkMetaFieldName: newValue } ) }
-							/>
+					{ isMeta &&
+						<TextControl
+							label={ __( 'Meta field name', 'generateblocks' ) }
+							value={ linkMetaFieldName }
+							onChange={ ( newValue ) => setAttributes( { linkMetaFieldName: newValue } ) }
+						/>
+					}
 
-							{ !! linkMetaFieldName &&
-								<SelectControl
-									label={ __( 'Meta field link type', 'generateblocks' ) }
-									value={ linkMetaFieldType }
-									onChange={ ( newValue ) => setAttributes( { linkMetaFieldType: newValue } ) }
-									options={ getMetaLinkTypes }
-								/>
-							}
-						</>
+					{ (
+						'author-email' === linkType ||
+						( isMeta && !! linkMetaFieldName )
+					) &&
+						<SelectControl
+							label={ __( 'Link type', 'generateblocks' ) }
+							value={ linkMetaFieldType }
+							onChange={ ( newValue ) => setAttributes( { linkMetaFieldType: newValue } ) }
+							options={ getMetaLinkTypes }
+						/>
 					}
 				</>
 			}


### PR DESCRIPTION
Blocked by #556 

This PR does the following to improve the dynamic link option.

1. Rename "Data type" to "Content source".
2. Rename "Background image type" to "Background image source".
3. When in the Image block, rename "Content source" to "Image source".
4. Rename "Link type" to "Link source".
5. Format "Link source" dropdown to match "Content source" with labels.
6. Remove `term-meta` dynamic content type from the frontend as it's not an option in the backend.
7. Add `author-meta` option to "Link source".
8. Add `author-email` option to "Link source".