### PR TITLE
Tweak: Change image description option value name

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -124,7 +124,7 @@ class GenerateBlocks_Dynamic_Content {
 				$content = self::get_image_alt_text( $attributes, $block );
 				break;
 
-			case 'description':
+			case 'image-description':
 				$content = self::get_image_description( $attributes, $block );
 				break;
 		}
@@ -619,7 +619,7 @@ class GenerateBlocks_Dynamic_Content {
 			$id = absint( $attributes['postId'] );
 		}
 
-		$image_content_types = array( 'caption', 'post-title', 'alt-text', 'description' );
+		$image_content_types = array( 'caption', 'post-title', 'alt-text', 'image-description' );
 
 		if ( isset( $attributes['dynamicContentType'] ) ) {
 			if ( in_array( $attributes['dynamicContentType'], $image_content_types ) ) {

--- a/src/extend/dynamic-content/inspector-controls/ContentTypeControl.js
+++ b/src/extend/dynamic-content/inspector-controls/ContentTypeControl.js
@@ -80,7 +80,7 @@ const getOptions = ( name, isCaption ) => {
 					{ value: 'caption', label: __( 'Caption', 'generateblocks' ) },
 					{ value: 'post-title', label: __( 'Title', 'generateblocks' ) },
 					{ value: 'alt-text', label: __( 'Alt text', 'generateblocks' ) },
-					{ value: 'description', label: __( 'Description', 'generateblocks' ) },
+					{ value: 'image-description', label: __( 'Description', 'generateblocks' ) },
 				],
 			},
 		];

--- a/src/extend/dynamic-content/utils/getContent.js
+++ b/src/extend/dynamic-content/utils/getContent.js
@@ -25,7 +25,7 @@ const contentTypeSelectors = {
 	'author-avatar': getAuthorAvatar,
 	caption: getCaption,
 	'alt-text': getAltText,
-	description: getDescription,
+	'image-description': getDescription,
 };
 
 /**


### PR DESCRIPTION
`description` seemed like a very vague option value name. This will break existing Image block captions using the `description` value, but I figure it's best to do this now before things are live.

Not sure it's necessary - open to discussion.