### PR TITLE
Fix: Block error in editor mobile preview using fixed backgrounds

### DIFF
--- a/src/blocks/container/css/mobile.js
+++ b/src/blocks/container/css/mobile.js
@@ -153,7 +153,7 @@ export default class MobileCSS extends Component {
 
 		if ( !! bgImage && 'fixed' === bgOptions.attachment ) {
 			if ( 'element' === bgOptions.selector ) {
-				cssObj[ '.gb-container-' + uniqueId ].push( {
+				cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
 					'background-attachment': 'initial',
 				} );
 			}


### PR DESCRIPTION
close #564 

This fixes a block error in the mobile editor when the Container block has a fixed background.