### PR TITLE
Feature: Add toggle to remove block if no dynamic link

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -43,6 +43,7 @@ class GenerateBlocks_Render_Block {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_filter( 'render_block', array( $this, 'filter_rendered_blocks' ), 10, 3 );
 	}
 
 	/**
@@ -655,18 +656,6 @@ class GenerateBlocks_Render_Block {
 
 			$dynamic_link = GenerateBlocks_Dynamic_Content::get_dynamic_url( $attributes, $block );
 
-			// Don't output pagination buttons with no link.
-			if (
-				! $dynamic_link &&
-				! empty( $attributes['dynamicLinkType'] ) &&
-				(
-					'pagination-prev' === $attributes['dynamicLinkType'] ||
-					'pagination-next' === $attributes['dynamicLinkType']
-				)
-			) {
-				return '';
-			}
-
 			if ( isset( $content['attributes']['href'] ) || $dynamic_link ) {
 				$tagName = 'a';
 			}
@@ -838,6 +827,29 @@ class GenerateBlocks_Render_Block {
 		$output .= '</figure>';
 
 		return $output;
+	}
+
+	/**
+	 * Filter existing rendered blocks.
+	 *
+	 * @since 1.5.0
+	 * @param string   $block_content The block content.
+	 * @param array    $block The block data.
+	 * @param WP_Block $instance Block instance.
+	 */
+	public function filter_rendered_blocks( $block_content, $block, $instance ) {
+		$attributes = isset( $block['attrs'] ) ? $block['attrs'] : null;
+
+		// Don't output if no dynamic link exists.
+		if ( isset( $attributes ) && ! empty( $attributes['dynamicLinkType'] ) && ! empty( $attributes['dynamicLinkRemoveIfEmpty'] ) ) {
+			$dynamic_link = GenerateBlocks_Dynamic_Content::get_dynamic_url( $attributes, $instance );
+
+			if ( ! $dynamic_link ) {
+				return '';
+			}
+		}
+
+		return $block_content;
 	}
 }
 

--- a/src/extend/dynamic-content/InspectorControls.js
+++ b/src/extend/dynamic-content/InspectorControls.js
@@ -38,6 +38,7 @@ export default ( { context, attributes, setAttributes, name } ) => {
 		excerptLength,
 		useDefaultMoreLink,
 		customMoreLinkText,
+		dynamicLinkRemoveIfEmpty,
 	} = attributes;
 
 	const currentPostType = dynamicSource === 'current-post' ? context.postType : postType;
@@ -181,6 +182,7 @@ export default ( { context, attributes, setAttributes, name } ) => {
 								)
 							}
 							linkType={ dynamicLinkType }
+							dynamicLinkRemoveIfEmpty={ dynamicLinkRemoveIfEmpty }
 							dynamicContentType={ dynamicContentType }
 							linkMetaFieldName={ linkMetaFieldName }
 							linkMetaFieldType={ linkMetaFieldType }

--- a/src/extend/dynamic-content/attributes.js
+++ b/src/extend/dynamic-content/attributes.js
@@ -24,6 +24,11 @@ export default {
 		default: '',
 	},
 
+	dynamicLinkRemoveIfEmpty: {
+		type: 'boolean',
+		default: false,
+	},
+
 	dynamicSource: {
 		type: 'string',
 		default: 'current-post',

--- a/src/extend/dynamic-content/inspector-controls/LinkTypeControl.js
+++ b/src/extend/dynamic-content/inspector-controls/LinkTypeControl.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import AdvancedSelect from '../../../components/advanced-select';
 import { applyFilters } from '@wordpress/hooks';
-import { SelectControl, TextControl } from '@wordpress/components';
+import { SelectControl, TextControl, ToggleControl } from '@wordpress/components';
 
 const getOptions = ( dynamicContentType, isPagination = false, name ) => {
 	let defaultOptions = [
@@ -108,6 +108,7 @@ export default ( {
 	isPagination,
 	isActive,
 	name,
+	dynamicLinkRemoveIfEmpty,
 } ) => {
 	const options = getOptions( dynamicContentType, isPagination, name );
 
@@ -151,6 +152,14 @@ export default ( {
 							value={ linkMetaFieldType }
 							onChange={ ( newValue ) => setAttributes( { linkMetaFieldType: newValue } ) }
 							options={ getMetaLinkTypes }
+						/>
+					}
+
+					{ !! linkType &&
+						<ToggleControl
+							label={ __( 'Remove block if link is empty', 'generateblocks' ) }
+							checked={ !! dynamicLinkRemoveIfEmpty }
+							onChange={ ( newValue ) => setAttributes( { dynamicLinkRemoveIfEmpty: newValue } ) }
 						/>
 					}
 				</>


### PR DESCRIPTION
This PR adds a new toggle when using dynamic links.

<img width="265" alt="remove-if-empty-link" src="https://user-images.githubusercontent.com/20714883/173424246-8d6531b8-4570-47f5-88ea-789ad4d8d4cc.png">

It allows you to remove the entire block on the frontend if no dynamic link is found. This is particularly useful for things like next/previous pagination or post meta.