### PR TITLE
Fix: Allow -1 posts_per_page on frontend

### DIFF
--- a/includes/class-query-loop.php
+++ b/includes/class-query-loop.php
@@ -101,7 +101,7 @@ class GenerateBlocks_Query_Loop {
 			isset( $query_args['posts_per_page'] ) &&
 			is_numeric( $query_args['posts_per_page'] )
 		) {
-			$per_page = absint( $query_args['posts_per_page'] );
+			$per_page = intval( $query_args['posts_per_page'] );
 			$offset   = 0;
 
 			if (


### PR DESCRIPTION
Fixes https://community.generateblocks.com/t/problem-with-query-loop/714

This fixes a bug where using `-1` as your posts per page option only shows one post on the frontend.