### PR TITLE
Tweak: Disable empty next/prev pagination buttons

### DIFF
--- a/src/blocks/query-loop/components/BlockControls.js
+++ b/src/blocks/query-loop/components/BlockControls.js
@@ -31,6 +31,7 @@ export default ( { clientId } ) => {
 				Object.assign( {}, DEFAULT_BUTTON_ATTRIBUTES, generateBlocksStyling.button, {
 					text: __( 'Previous', 'generateblocks' ),
 					dynamicLinkType: 'pagination-prev',
+					dynamicLinkRemoveIfEmpty: true,
 				} ),
 			],
 			[
@@ -45,6 +46,7 @@ export default ( { clientId } ) => {
 				Object.assign( {}, DEFAULT_BUTTON_ATTRIBUTES, generateBlocksStyling.button, {
 					text: __( 'Next', 'generateblocks' ),
 					dynamicLinkType: 'pagination-next',
+					dynamicLinkRemoveIfEmpty: true,
 				} ),
 			],
 		],


### PR DESCRIPTION
This disables the next/previous pagination buttons by default if no link exists.