### PR TITLE
Fix: Inline Headline not inlining in the root

### DIFF
--- a/src/blocks/headline/css/main.js
+++ b/src/blocks/headline/css/main.js
@@ -154,7 +154,7 @@ export default class MainCSS extends Component {
 			'color': highlightTextColor, // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '#block-' + clientId ] = [ {
+		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidth ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/blocks/headline/css/main.js
+++ b/src/blocks/headline/css/main.js
@@ -154,7 +154,7 @@ export default class MainCSS extends Component {
 			'color': highlightTextColor, // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
+		cssObj[ '.gb-is-root-block[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidth ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/blocks/headline/css/mobile.js
+++ b/src/blocks/headline/css/mobile.js
@@ -119,7 +119,7 @@ export default class MobileCSS extends Component {
 			'height': valueWithUnit( iconSizeMobile, iconSizeUnit ), // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
+		cssObj[ '.gb-is-root-block[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidthMobile ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/blocks/headline/css/mobile.js
+++ b/src/blocks/headline/css/mobile.js
@@ -119,7 +119,7 @@ export default class MobileCSS extends Component {
 			'height': valueWithUnit( iconSizeMobile, iconSizeUnit ), // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '#block-' + clientId ] = [ {
+		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidthMobile ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/blocks/headline/css/tablet.js
+++ b/src/blocks/headline/css/tablet.js
@@ -119,7 +119,7 @@ export default class TabletCSS extends Component {
 			'height': valueWithUnit( iconSizeTablet, iconSizeUnit ), // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '#block-' + clientId ] = [ {
+		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidthTablet ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/blocks/headline/css/tablet.js
+++ b/src/blocks/headline/css/tablet.js
@@ -119,7 +119,7 @@ export default class TabletCSS extends Component {
 			'height': valueWithUnit( iconSizeTablet, iconSizeUnit ), // eslint-disable-line quote-props
 		} ];
 
-		cssObj[ '[data-block="' + clientId + '"]' ] = [ {
+		cssObj[ '.gb-is-root-block[data-block="' + clientId + '"]' ] = [ {
 			'display': inlineWidthTablet ? 'inline-flex' : false, // eslint-disable-line quote-props
 		} ];
 

--- a/src/components/root-element/index.js
+++ b/src/components/root-element/index.js
@@ -17,6 +17,7 @@ export default function RootElement( { name, clientId, align, children } ) {
 			[ `gb-root-block-${ blockName }` ]: true,
 		} ),
 		'data-align': align ? align : null,
+		'data-block': clientId,
 	};
 
 	const parentBlock = getBlockRootClientId( clientId );


### PR DESCRIPTION
close #570 

This fixes our Headline blocks when set to inline width and in the root.

However, adding Inline Width to the Headline block when it's in the root will prevent it from being centered on the page.

<img width="1906" alt="inline-width" src="https://user-images.githubusercontent.com/20714883/173624527-7d5966d2-2148-48a3-ab78-12853d23ced5.png">

This is also a current bug in the stable version:

<img width="1920" alt="inline-width-2" src="https://user-images.githubusercontent.com/20714883/173624733-bf604cbf-84f7-4478-9262-d62a66586d65.png">

It would be nice if we could figure out an actual solution to this bug.