### PR TITLE
Tweak: Remove :visited pseudo selectors

### DIFF
--- a/includes/generate-css.php
+++ b/includes/generate-css.php
@@ -409,7 +409,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 					$css->add_property( 'position', 'relative' );
 				}
 
-				$css->set_selector( '.gb-container-' . $id . ' a, .gb-container-' . $id . ' a:visited' );
+				$css->set_selector( '.gb-container-' . $id . ' a' );
 				$css->add_property( 'color', $settings['linkColor'] );
 
 				$css->set_selector( '.gb-container-' . $id . ' a:hover' );
@@ -1394,7 +1394,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 						}
 					}
 
-					$css->set_selector( '.gb-headline-' . $id . ' a, .gb-headline-' . $id . ' a:visited' );
+					$css->set_selector( '.gb-headline-' . $id . ' a' );
 					$css->add_property( 'color', $settings['linkColor'] );
 
 					$css->set_selector( '.gb-headline-' . $id . ' a:hover' );

--- a/src/blocks/container/css/main.js
+++ b/src/blocks/container/css/main.js
@@ -210,7 +210,7 @@ export default function MainCSS( props ) {
 		} ];
 	}
 
-	cssObj[ '.gb-container-' + uniqueId + ' a, .gb-container-' + uniqueId + ' a:visited' ] = [ {
+	cssObj[ '.gb-container-' + uniqueId + ' a' ] = [ {
 		'color': linkColor, // eslint-disable-line quote-props
 	} ];
 


### PR DESCRIPTION
This removes the `:visited` pseudo selector from links in the Container and Headline blocks.

It fixes a bug in 1.5 where the Container link color will overwrite the Button text color because our Button doesn't define `:visited` where the Container does.