### PR TITLE
Tweak: Re-add :visited selectors

### DIFF
--- a/includes/generate-css.php
+++ b/includes/generate-css.php
@@ -409,7 +409,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 					$css->add_property( 'position', 'relative' );
 				}
 
-				$css->set_selector( '.gb-container-' . $id . ' a' );
+				$css->set_selector( '.gb-container-' . $id . ' a, .gb-container-' . $id . ' a:visited' );
 				$css->add_property( 'color', $settings['linkColor'] );
 
 				$css->set_selector( '.gb-container-' . $id . ' a:hover' );
@@ -992,7 +992,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 					}
 				}
 
-				$css->set_selector( '.gb-button-wrapper ' . $selector );
+				$css->set_selector( '.gb-button-wrapper ' . $selector . ',.gb-button-wrapper ' . $selector . ':visited' );
 				$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
 				$css->add_property( 'color', $settings['textColor'] );
 
@@ -1022,7 +1022,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 				$css->add_property( 'color', $settings['textColorHover'] );
 				$css->add_property( 'border-color', generateblocks_hex2rgba( $settings['borderColorHover'], $settings['borderColorHoverOpacity'] ) );
 
-				$css->set_selector( '.gb-button-wrapper ' . $selector . '.gb-button__current' );
+				$css->set_selector( '.gb-button-wrapper ' . $selector . '.gb-button__current, .gb-button-wrapper ' . $selector . '.gb-button__current:visited' );
 				$css->add_property( 'background-color', $settings['backgroundColorCurrent'] );
 				$css->add_property( 'color', $settings['textColorCurrent'] );
 				$css->add_property( 'border-color', $settings['borderColorCurrent'] );
@@ -1394,7 +1394,7 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 						}
 					}
 
-					$css->set_selector( '.gb-headline-' . $id . ' a' );
+					$css->set_selector( '.gb-headline-' . $id . ' a, .gb-headline-' . $id . ' a:visited' );
 					$css->add_property( 'color', $settings['linkColor'] );
 
 					$css->set_selector( '.gb-headline-' . $id . ' a:hover' );

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,6 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Tweak: Add memory to open editor panels
 * Tweak: Make device buttons sticky
 * Tweak: Improve container width label
-* Tweak: Remove :visited selector from button, headline and container links
 * Tweak: Use compiled assets in script registration
 * Tweak: Improve button CSS selectors in the editor
 * Tweak: Allow more decimal places in background image opacity

--- a/src/blocks/container/css/main.js
+++ b/src/blocks/container/css/main.js
@@ -210,7 +210,7 @@ export default function MainCSS( props ) {
 		} ];
 	}
 
-	cssObj[ '.gb-container-' + uniqueId + ' a' ] = [ {
+	cssObj[ '.gb-container-' + uniqueId + ' a, .gb-container-' + uniqueId + ' a:visited' ] = [ {
 		'color': linkColor, // eslint-disable-line quote-props
 	} ];
 


### PR DESCRIPTION
This reverts a change we made where we removed `:visited` selectors from our blocks.

We'll re-visit this in the future with more testing.