### PR TITLE
Tweak: Fix container widths in editor

### DIFF
--- a/src/blocks/container/css/main.js
+++ b/src/blocks/container/css/main.js
@@ -107,9 +107,6 @@ export default function MainCSS( props ) {
 		'font-size': valueWithUnit( fontSize, fontSizeUnit ),
 		'min-height': valueWithUnit( minHeight, minHeightUnit ),
 		'border-color': hexToRGBA( borderColor, borderColorOpacity ),
-		'max-width': 'contained' === outerContainer && ! isGrid ? valueWithUnit( containerWidthPreview, 'px' ) : false,
-		'margin-left': 'contained' === outerContainer && ! isGrid ? 'auto' : false,
-		'margin-right': 'contained' === outerContainer && ! isGrid ? 'auto' : false,
 	} ];
 
 	if ( hasBgImage && 'element' === bgOptions.selector && backgroundImageValue ) {
@@ -237,6 +234,14 @@ export default function MainCSS( props ) {
 			'margin-right': 'auto',
 		} );
 	}
+
+	// We need use an ID for the contained block width so it overrides other
+	// .wp-block max-width selectors.
+	cssObj[ '#block-' + clientId ] = [ {
+		'max-width': 'contained' === outerContainer && ! isGrid ? valueWithUnit( containerWidthPreview, 'px' ) : false,
+		'margin-left': 'contained' === outerContainer && ! isGrid ? 'auto' : false,
+		'margin-right': 'contained' === outerContainer && ! isGrid ? 'auto' : false,
+	} ];
 
 	if ( isGrid ) {
 		const gridColumnSelectors = [

--- a/src/blocks/container/editor.scss
+++ b/src/blocks/container/editor.scss
@@ -278,13 +278,13 @@ body.gutenberg-editor-page [data-type="generateblocks/container"] .editor-block-
 	}
 }
 
+body .gb-container .wp-block {
+	max-width: none;
+}
+
 .gb-container {
 	margin-top: 0;
 	margin-bottom: 0;
-
-	.wp-block {
-		max-width: none;
-	}
 
 	.block-editor-block-list__layout {
 		.block-list-appender {


### PR DESCRIPTION
close #578 

This PR reverts a couple of changes we made in 1.5.0.
- #272 
- #513

#578 can be observed if you:

1. Create a Layout Element and apply to all Pages
2. In the Layout Element, set the Content Area to "Full Width"
3. Add the code from the issue into your editor
4. Instead of 3., you can also just do something simple like this to see the issue:

```
<!-- wp:generateblocks/container {"uniqueId":"f05ce777","minHeight":20,"backgroundColor":"var(\u002d\u002daccent)","isDynamic":true,"blockVersion":2} -->
<!-- wp:generateblocks/container {"uniqueId":"83d6555d","outerContainer":"contained","containerWidth":600,"minHeight":20,"marginLeft":"10","backgroundColor":"#c31b1b","isDynamic":true,"blockVersion":2} /-->
<!-- /wp:generateblocks/container -->

<!-- wp:generateblocks/container {"uniqueId":"54ee641e","outerContainer":"contained","containerWidth":600,"minHeight":20,"backgroundColor":"var(\u002d\u002daccent)","isDynamic":true,"blockVersion":2} /-->
```

The above should result in this:

<img width="1920" alt="good-widths" src="https://user-images.githubusercontent.com/20714883/174143586-e5f6e1b6-478e-4c94-9610-4daf4497cd25.png">

But it currently results in this:

<img width="1920" alt="bad-widths" src="https://user-images.githubusercontent.com/20714883/174143700-0c51c2b2-a56d-40c1-aabb-06b847a37c72.png">

We need to make sure that:

1. The initial issues we "fixed" and are reverting in this PR are still fixed
2. This doesn't break anything else (Query Loop layouts etc...)