### PR TITLE
Bump WP version to 5.9

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -44,9 +44,9 @@ class GenerateBlocks_Render_Block {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
 
-        if ( version_compare( $GLOBALS['wp_version'], '5.9', '>' ) ) {
-            add_filter( 'render_block', array( $this, 'filter_rendered_blocks' ), 10, 3 );
-        }
+		if ( version_compare( $GLOBALS['wp_version'], '5.9', '>' ) ) {
+			add_filter( 'render_block', array( $this, 'filter_rendered_blocks' ), 10, 3 );
+		}
 	}
 
 	/**

--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -43,7 +43,10 @@ class GenerateBlocks_Render_Block {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
-		add_filter( 'render_block', array( $this, 'filter_rendered_blocks' ), 10, 3 );
+
+        if ( version_compare( $GLOBALS['wp_version'], '5.9', '>' ) ) {
+            add_filter( 'render_block', array( $this, 'filter_rendered_blocks' ), 10, 3 );
+        }
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generateblocks",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"private": true,
 	"description": "A small collection of lightweight WordPress blocks that can accomplish nearly anything.",
 	"author": "Tom Usborne",

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: A small collection of lightweight WordPress blocks that can accomplish nearly anything.
  * Author: Tom Usborne
  * Author URI: https://tomusborne.com
- * Version: 1.5.0
+ * Version: 1.5.1
  * Requires at least: 5.9
  * Requires PHP: 5.6
  * License: GPL2+
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'GENERATEBLOCKS_VERSION', '1.5.0' );
+define( 'GENERATEBLOCKS_VERSION', '1.5.1' );
 define( 'GENERATEBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENERATEBLOCKS_DIR_URL', plugin_dir_url( __FILE__ ) );
 

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: Tom Usborne
  * Author URI: https://tomusborne.com
  * Version: 1.5.0
- * Requires at least: 5.6
+ * Requires at least: 5.9
  * Requires PHP: 5.6
  * License: GPL2+
  * License URI: https://www.gnu.org/licenses/gpl-2.0.txt

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: edge22
 Donate link: https://generateblocks.com
 Tags: blocks, gutenberg, container, headline, grid, columns, page builder, wysiwyg, block editor
-Requires at least: 5.6
+Requires at least: 5.9
 Tested up to: 6.0
 Requires PHP: 5.6
 Stable tag: 1.5.0

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: blocks, gutenberg, container, headline, grid, columns, page builder, wysiw
 Requires at least: 5.9
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,6 +84,9 @@ In most cases, #1 will work fine and is way easier.
 GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://generatepress.com). However, it will work with any theme you choose.
 
 == Changelog ==
+
+= 1.5.1 =
+* Fix: Require WordPress version 5.9 or higher
 
 = 1.5.0 =
 * New: Dynamic data


### PR DESCRIPTION
Reference https://generatepress.com/forums/topic/site-crashed-after-update-to-generateblocks-pro-12-0/#post-2260533