### PR TITLE
Fix: Button hasUrl attribute

### DIFF
--- a/src/blocks/button/components/BlockControls.js
+++ b/src/blocks/button/components/BlockControls.js
@@ -85,6 +85,7 @@ export default ( { clientId, attributes, setAttributes } ) => {
 											onChange={ ( value ) => {
 												setAttributes( {
 													url: value,
+													hasUrl: !! value,
 												} );
 											} }
 										/>


### PR DESCRIPTION
This fixes an issue where the Button `hasUrl` attribute wasn't being set.

Previously, we set this attribute inside the component: https://github.com/tomusborne/generateblocks/blob/1.4.4/src/blocks/button/edit.js#L1123
