### PR TITLE
Fix: Reset the query with wp_reset_postdata

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -444,7 +444,7 @@ class GenerateBlocks_Render_Block {
 			}
 		}
 
-		$the_query->reset_postdata();
+		wp_reset_postdata();
 
 		return $content;
 	}


### PR DESCRIPTION
close #609 

This resets the postdata by using `wp_reset_postdata()` instead of the method:
https://developer.wordpress.org/reference/functions/wp_reset_postdata/
https://developer.wordpress.org/reference/classes/wp_query/reset_postdata/

I've done some reading and I'm not entirely sure why this is necessary, but core does it here: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-template/index.php#L110

Other references:
https://wordpress.stackexchange.com/a/216154
https://developer.wordpress.org/reference/classes/wp_query/#more-information