### PR TITLE
Fix: Duplicated block toolbars when selecting links

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 
 == Changelog ==
 
+= 1.5.3 =
+* Fix: Dulicated block options in Query Loop when selecting links
+
 = 1.5.2 =
 * Feature: Add option to exclude or ignore sticky posts
 * Fix: Container gridId attribute not updating correctly

--- a/src/blocks/query-loop/components/LoopRenderer.js
+++ b/src/blocks/query-loop/components/LoopRenderer.js
@@ -29,7 +29,7 @@ function BlockPreview( {
 	return (
 		<div
 			{ ...blockPreviewProps }
-			className={ 'block-editor-inner-blocks' }
+			className={ 'block-editor-inner-blocks gb-query-loop-block-preview' }
 			tabIndex={ 0 }
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 			role={ 'button' }

--- a/src/blocks/query-loop/editor.scss
+++ b/src/blocks/query-loop/editor.scss
@@ -90,3 +90,7 @@
 		}
 	}
 }
+
+.gb-query-loop-block-preview a {
+	pointer-events: none;
+}


### PR DESCRIPTION
This fixes a bug where our block toolbars and inspector controls are duplicated (or more) when selecting `a` elements inside the block previews.