### PR TITLE
Fix: Inherit query feature

### DIFF
--- a/includes/class-render-blocks.php
+++ b/includes/class-render-blocks.php
@@ -73,6 +73,7 @@ class GenerateBlocks_Render_Block {
 				'uses_context' => array(
 					'generateblocks/query',
 					'generateblocks/queryId',
+					'generateblocks/inheritQuery',
 				),
 			)
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 = 1.5.3 =
 * Fix: Dynamic image placeholder border radius
 * Fix: Dulicated block options in Query Loop when selecting links
+* Fix: Inherit query option in Query Loop
 
 = 1.5.2 =
 * Feature: Add option to exclude or ignore sticky posts


### PR DESCRIPTION
This fixes the "inherit query" feature so it actually inherits the query.

Previously `$block->context['generateblocks/inheritQuery']` always returned false even if it was toggled.