### PR TITLE
Fix: Keep the order in which query loop parameter was included

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,8 +87,9 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 
 = 1.5.3 =
 * Fix: Dynamic image placeholder border radius
-* Fix: Dulicated block options in Query Loop when selecting links
+* Fix: Duplicated block options in Query Loop when selecting links
 * Fix: Inherit query option in Query Loop
+* Fix: Keep the order in which query loop parameter was included
 
 = 1.5.2 =
 * Feature: Add option to exclude or ignore sticky posts

--- a/src/blocks/query-loop/components/inspector-controls/parameter-list/index.js
+++ b/src/blocks/query-loop/components/inspector-controls/parameter-list/index.js
@@ -2,7 +2,11 @@ import queryParameterOptions from '../../../query-parameters';
 import ParameterControl from './ParameterControl';
 
 const getParametersList = ( query ) => {
-	return queryParameterOptions.filter( ( parameter ) => Object.keys( query ).includes( parameter.id ) );
+	const options = queryParameterOptions.filter( ( param ) => param.isSticky );
+
+	return options.concat( Object.keys( query ).map( ( id ) => (
+		queryParameterOptions.find( ( param ) => ( id === param.id && ! param.isSticky ) )
+	) ).filter( Boolean ) );
 };
 
 export default ( { query, setParameter, removeParameter } ) => {


### PR DESCRIPTION
This PR fixes the behavior where query loop parameters were being displayed in the order they were registered in the configuration files. Now we keep the order in which they were added, excluded sticky parameters that still must be displayed at the top of the list.