### PR TITLE
Fix: Query loop taxonomy query include/exclude children

### DIFF
--- a/includes/class-query-loop.php
+++ b/includes/class-query-loop.php
@@ -172,7 +172,7 @@ class GenerateBlocks_Query_Loop {
 					'field'    => 'term_id',
 					'terms'    => $tax['terms'],
 					'operator' => $operator,
-					'include_children' => false,
+					'include_children' => isset( $tax['includeChildren'] ) ? $tax['includeChildren'] : true,
 				);
 			},
 			$raw_tax_query

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Fix: Inherit query option in Query Loop
 * Fix: Keep the order in which query loop parameter was included
 * Tweak: Move Post Template list view label to Container
+* Fix: Query loop taxonomy query include/exclude children
 
 = 1.5.2 =
 * Feature: Add option to exclude or ignore sticky posts

--- a/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
+++ b/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
@@ -2,23 +2,15 @@ import SimpleSelect from '../../../../../components/simple-select';
 import TaxonomiesSelect from '../../../../../components/taxonomies-select';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useTaxonomies } from '../../../../../hooks';
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-export default function TaxonomyParameterControl( props ) {
-	const { label, value, onChange } = props;
-	const [ taxonomy, setTaxonomy ] = useState();
-	const [ terms, setTerms ] = useState( [] );
+export default function TaxonomyParameterControl( { label, value, onChange } ) {
+	const [ taxonomy, setTaxonomy ] = useState( value.taxonomy );
+	const [ terms, setTerms ] = useState( value.terms );
+	const [ includeChildren, setIncludeChildren ] = useState( false !== value.includeChildren );
 
 	const taxonomies = useTaxonomies();
-
-	useEffect( () => {
-		if ( !! value.taxonomy ) {
-			setTaxonomy( value.taxonomy );
-		}
-
-		if ( !! value.terms ) {
-			setTerms( value.terms );
-		}
-	}, [] );
 
 	useEffect( () => {
 		if ( value.taxonomy !== taxonomy ) {
@@ -35,9 +27,9 @@ export default function TaxonomyParameterControl( props ) {
 			const tax = taxonomies.filter( ( record ) => ( record.slug === taxonomy ) );
 			const rest = !! tax[ 0 ] ? tax[ 0 ].rest_base : undefined;
 
-			onChange( { taxonomy, terms, rest } );
+			onChange( { taxonomy, terms, rest, includeChildren } );
 		}
-	}, [ taxonomy, JSON.stringify( terms ) ] );
+	}, [ taxonomy, JSON.stringify( terms ), includeChildren ] );
 
 	const taxonomiesOptions = useMemo( () => (
 		taxonomies
@@ -74,6 +66,13 @@ export default function TaxonomyParameterControl( props ) {
 
 					setTerms( newTerms );
 				} }
+			/>
+
+			<ToggleControl
+				checked={ includeChildren }
+				label={ __( 'Include children', 'generateblocks' ) }
+				help={ __( 'Whether to include children taxonomies', 'generateblocks' ) }
+				onChange={ setIncludeChildren }
 			/>
 		</>
 	);

--- a/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
+++ b/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
@@ -5,7 +5,8 @@ import { useTaxonomies } from '../../../../../hooks';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function TaxonomyParameterControl( { label, value, onChange } ) {
+export default function TaxonomyParameterControl( props ) {
+	const { label, value, onChange } = props;
 	const [ taxonomy, setTaxonomy ] = useState( value.taxonomy );
 	const [ terms, setTerms ] = useState( value.terms );
 	const [ includeChildren, setIncludeChildren ] = useState( false !== value.includeChildren );
@@ -53,27 +54,32 @@ export default function TaxonomyParameterControl( { label, value, onChange } ) {
 				} }
 			/>
 
-			<TaxonomiesSelect
-				taxonomy={ taxonomy }
-				value={ terms }
-				filterName={ 'generateblocks.editor.taxonomy-parameter-control.' + props.id }
-				onChange={ ( newValue ) => {
-					const newTerms = newValue.reduce( ( result, option ) => {
-						result.push( option.value );
+			{ taxonomy &&
+				<>
+					<TaxonomiesSelect
+						taxonomy={ taxonomy }
+						value={ terms }
+						filterName={ 'generateblocks.editor.taxonomy-parameter-control.' + props.id }
+						onChange={ ( newValue ) => {
+							const newTerms = newValue.reduce( ( result, option ) => {
+								result.push( option.value );
 
-						return result;
-					}, [] );
+								return result;
+							}, [] );
 
-					setTerms( newTerms );
-				} }
-			/>
+							setTerms( newTerms );
+						} }
+						help={ terms.length === 0 ? __( 'You must select at least one term.', 'generateblocks' ) : '' }
+					/>
 
-			<ToggleControl
-				checked={ includeChildren }
-				label={ __( 'Include children', 'generateblocks' ) }
-				help={ __( 'Whether to include children taxonomies', 'generateblocks' ) }
-				onChange={ setIncludeChildren }
-			/>
+					<ToggleControl
+						checked={ includeChildren }
+						label={ __( 'Include children', 'generateblocks' ) }
+						help={ __( 'Whether to include children taxonomies', 'generateblocks' ) }
+						onChange={ setIncludeChildren }
+					/>
+				</>
+			}
 		</>
 	);
 }

--- a/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
+++ b/src/blocks/query-loop/components/inspector-controls/controls/TaxonomyParameterControl.js
@@ -74,8 +74,7 @@ export default function TaxonomyParameterControl( props ) {
 
 					<ToggleControl
 						checked={ includeChildren }
-						label={ __( 'Include children', 'generateblocks' ) }
-						help={ __( 'Whether to include children taxonomies', 'generateblocks' ) }
+						label={ __( 'Include child terms', 'generateblocks' ) }
 						onChange={ setIncludeChildren }
 					/>
 				</>

--- a/src/blocks/query-loop/components/utils.js
+++ b/src/blocks/query-loop/components/utils.js
@@ -13,7 +13,10 @@ export function removeEmpty( obj ) {
 
 function getTaxQueryParam( taxQuery, isExclude = false ) {
 	const paramKey = isExclude ? `${ taxQuery.rest }_exclude` : taxQuery.rest;
-	return { [ paramKey ]: taxQuery.terms };
+	return { [ paramKey ]: {
+		terms: taxQuery.terms,
+		include_children: taxQuery.includeChildren,
+	} };
 }
 
 function normalizeTaxQuery( taxQueryValue, isExclude = false ) {

--- a/src/blocks/query-loop/query-parameters.js
+++ b/src/blocks/query-loop/query-parameters.js
@@ -104,7 +104,7 @@ export default applyFilters( 'generateblocks.editor.query-loop.query-parameters'
 		description: __( 'Show posts from taxonomies.', 'generateblocks' ),
 		group: __( 'Taxonomy', 'generateblocks' ),
 		isRepeatable: true,
-		repeatableDefaultValue: { taxonomy: '', terms: [], rest: '' },
+		repeatableDefaultValue: { taxonomy: '', terms: [], rest: '', includeChildren: true },
 	},
 	{
 		id: 'tax_query_exclude',
@@ -114,7 +114,7 @@ export default applyFilters( 'generateblocks.editor.query-loop.query-parameters'
 		description: __( 'Exclude posts from taxonomies.', 'generateblocks' ),
 		group: __( 'Taxonomy', 'generateblocks' ),
 		isRepeatable: true,
-		repeatableDefaultValue: { taxonomy: '', terms: [], rest: '' },
+		repeatableDefaultValue: { taxonomy: '', terms: [], rest: '', includeChildren: true },
 	},
 	{
 		id: 'status',


### PR DESCRIPTION
Fix taxonomies/exclude taxonomies parameter to include children terms by default. Also adds a toggle for users to choose what they want.