### PR TITLE
Tweak: Remove block-editor-block-list__block class from root

### DIFF
--- a/src/components/root-element/index.js
+++ b/src/components/root-element/index.js
@@ -12,7 +12,6 @@ export default function RootElement( { name, clientId, align, children } ) {
 	const blockProps = {
 		className: classnames( {
 			'wp-block': true,
-			'block-editor-block-list__block': true,
 			'gb-is-root-block': true,
 			[ `gb-root-block-${ blockName }` ]: true,
 		} ),


### PR DESCRIPTION
close #656 

This removes the `block-editor-block-list__block` class from our root-element component.

This class is causing conflicts as seen in the linked issue. I believe it likely caused this issue as well: https://secure.helpscout.net/conversation/1981700690/346527?folderId=3610634

This class was added (https://github.com/tomusborne/generateblocks/pull/271) to fix an image floating issue, but it seems removing it doesn't make the bug re-appear.