### PR TITLE
Feature: Add filter for query loop enabled post types

### DIFF
--- a/src/extend/dynamic-content/components/SelectPostType.js
+++ b/src/extend/dynamic-content/components/SelectPostType.js
@@ -2,18 +2,24 @@ import { __ } from '@wordpress/i18n';
 import AdvancedSelect from '../../../components/advanced-select';
 import usePostTypes from '../hooks/usePostTypes';
 import { useMemo } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 export default ( { postType, onChange, value, help } ) => {
 	const postTypes = usePostTypes();
 
+	const enabledPostTypes = useMemo( () => {
+		const enabled = postTypes.filter( ( type ) => ( type.viewable && 'attachment' !== type.slug ) );
+
+		return applyFilters( 'generateBlocks.editor.query-loop.enabled-post-types', enabled, postTypes );
+	}, [ postTypes ] );
+
 	const postTypeOptions = useMemo( () => {
-		return postTypes
-			.filter( ( type ) => ( type.viewable && 'attachment' !== type.slug ) )
+		return enabledPostTypes
 			.reduce( ( result, type ) => {
 				result.push( { value: type.slug, label: type.name } );
 				return result;
 			}, [] );
-	}, [ postTypes ] );
+	}, [ enabledPostTypes ] );
 
 	const selectValue = postTypeOptions.filter( ( option ) => ( option.value === postType || option.value === value ) );
 

--- a/src/extend/dynamic-content/components/SelectPostType.js
+++ b/src/extend/dynamic-content/components/SelectPostType.js
@@ -10,7 +10,7 @@ export default ( { postType, onChange, value, help } ) => {
 	const enabledPostTypes = useMemo( () => {
 		const enabled = postTypes.filter( ( type ) => ( type.viewable && 'attachment' !== type.slug ) );
 
-		return applyFilters( 'generateBlocks.editor.query-loop.enabled-post-types', enabled, postTypes );
+		return applyFilters( 'generateblocks.editor.query-loop.enabled-post-types', enabled, postTypes );
 	}, [ postTypes ] );
 
 	const postTypeOptions = useMemo( () => {


### PR DESCRIPTION
closes #631 

By default we only display post types that have `viewable` set to true, with this filter users can enable any other post type.

Filter usage: 

```js
wp.hooks.addFilter(
	'generateblocks.editor.query-loop.enabled-post-types',
	'testing-not-viewable-post-types',
	function( enabledPostTypes, postTypes ) {
		const customPostTypes = postTypes.filter( ( postType ) => ( 'custom-slug' === postType.slug ) );

		return enabledPostTypes.concat( customPostTypes );
	}
);
```