### PR TITLE
Fix: Align classes when using theme.json

### DIFF
--- a/src/blocks/container/components/ContainerContentRenderer.js
+++ b/src/blocks/container/components/ContainerContentRenderer.js
@@ -2,14 +2,14 @@ import RootElement from '../../../components/root-element';
 import GridItem from './GridItem';
 import Element from '../../../components/element';
 import { applyFilters } from '@wordpress/hooks';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import getIcon from '../../../utils/get-icon';
 import ShapeDividers from './ShapeDividers';
 import classnames from 'classnames';
 import { useInnerBlocksCount } from '../../../hooks';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import ComponentCSS from './ComponentCSS';
 import getBackgroundImageUrl from '../../../utils/get-background-image-url';
 
@@ -39,6 +39,13 @@ export default function ContainerContentRenderer( props ) {
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const innerBlocksCount = useInnerBlocksCount( clientId );
 	const hasChildBlocks = 0 < innerBlocksCount;
+	const supportsLayout = useSelect( ( select ) => {
+		const {
+			getSettings,
+		} = select( blockEditorStore );
+
+		return getSettings().supportsLayout || false;
+	}, [] );
 
 	let hasStyling = (
 		!! backgroundColor ||
@@ -57,9 +64,10 @@ export default function ContainerContentRenderer( props ) {
 			[ `${ className }` ]: undefined !== className,
 			'gb-container-empty': ! hasChildBlocks && ! isBlockPreview,
 			'gb-container-visual-guides': ! hasChildBlocks && ! hasStyling && ! props.isSelected && ! isBlockPreview,
+			[ `align${ align }` ]: supportsLayout,
 		} ),
 		id: anchor ? anchor : null,
-		'data-align': align ? align : null,
+		'data-align': align && ! supportsLayout ? align : null,
 	};
 
 	const backgroundUrl = getBackgroundImageUrl( props );

--- a/src/blocks/image/components/ImageContentRenderer.js
+++ b/src/blocks/image/components/ImageContentRenderer.js
@@ -1,5 +1,5 @@
 import ImagePlaceholder from './ImagePlaceholder';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import RootElement from '../../../components/root-element';
 import Element from '../../../components/element';
@@ -79,14 +79,22 @@ export default function ImageContentRenderer( props ) {
 	const imageUrl = useDynamicData && dynamicContentType ? dynamicImageFallback : attributes.mediaUrl;
 	const altText = useDynamicData && dynamicContentType ? currentImage?.alt_text : attributes.alt;
 	const titleText = useDynamicData && dynamicContentType ? currentImage?.title?.rendered : attributes.title;
+	const supportsLayout = useSelect( ( select ) => {
+		const {
+			getSettings,
+		} = select( blockEditorStore );
+
+		return getSettings().supportsLayout || false;
+	}, [] );
 
 	const figureAttributes = useBlockProps( {
 		className: classnames( {
 			'gb-block-image': true,
 			[ `gb-block-image-${ uniqueId }` ]: true,
 			'is-applying': !! temporaryURL,
+			[ `align${ align }` ]: !! parentBlock && supportsLayout,
 		} ),
-		'data-align': !! parentBlock ? align : null,
+		'data-align': !! parentBlock && ! supportsLayout ? align : null,
 		ref: figureRef,
 	} );
 

--- a/src/components/root-element/index.js
+++ b/src/components/root-element/index.js
@@ -1,11 +1,20 @@
 import { createElement } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 export default function RootElement( { name, clientId, align, children } ) {
 	const {
 		getBlockRootClientId,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
+
+	const supportsLayout = useSelect( ( select ) => {
+		const {
+			getSettings,
+		} = select( blockEditorStore );
+
+		return getSettings().supportsLayout || false;
+	}, [] );
 
 	const blockName = name.toString().replace( '/', '-' );
 
@@ -14,8 +23,9 @@ export default function RootElement( { name, clientId, align, children } ) {
 			'wp-block': true,
 			'gb-is-root-block': true,
 			[ `gb-root-block-${ blockName }` ]: true,
+			[ `align${ align }` ]: supportsLayout,
 		} ),
-		'data-align': align ? align : null,
+		'data-align': align && ! supportsLayout ? align : null,
 		'data-block': clientId,
 	};
 


### PR DESCRIPTION
close #522 

This should fix an issue in block themes and classic themes using a `theme.json` where the alignwide and alignfull options cause the blocks to lose alignment (and go off screen) in the editor.

It needs to be tested in WP 5.9 and 6.0 with block themes, classic themes and classic themes with theme.json.