### PR TITLE
Fix: Query Loop template key warning

### DIFF
--- a/src/blocks/query-loop/components/LayoutSelector.js
+++ b/src/blocks/query-loop/components/LayoutSelector.js
@@ -23,7 +23,7 @@ export default ( { clientId, isDisabled } ) => {
 				{ templates.map( ( template ) => {
 					return (
 						<Button
-							key={ `template-${ template }` }
+							key={ `template-${ template.name }` }
 							onClick={ () => {
 								replaceInnerBlocks(
 									clientId,


### PR DESCRIPTION
This fixes a warning when adding the Query Loop block to the editor.

![key-warning](https://user-images.githubusercontent.com/20714883/186754667-3de2a43d-3448-4bc4-acc7-bf4ab7e91621.jpg)
