### PR TITLE
Fix broken dynamic image when loading

### DIFF
--- a/src/extend/dynamic-content/DynamicRenderer.js
+++ b/src/extend/dynamic-content/DynamicRenderer.js
@@ -19,6 +19,15 @@ function getContentRenderer( name ) {
 	return contentRenders[ name ];
 }
 
+function isValidUrl( string ) {
+	try {
+		new URL( string );
+		return true;
+	} catch ( err ) {
+		return false;
+	}
+}
+
 export default function DynamicRenderer( props ) {
 	const {
 		name,
@@ -56,8 +65,8 @@ export default function DynamicRenderer( props ) {
 
 	const dynamicImage = (
 		!! content &&
-		! content.includes( 'Loading' ) &&
-		( 'generateblocks/container' === name || 'generateblocks/image' === name )
+		( 'generateblocks/container' === name || 'generateblocks/image' === name ) &&
+		( isValidUrl( content ) || ! isNaN( parseInt( content ) ) )
 	) ? content : undefined;
 
 	const newAttributes = Object.assign( {}, attributes, {


### PR DESCRIPTION
@JeanPaiva This fixes the block error I mentioned earlier.

I also made it check for a valid URL which does two things:

1. Prevents a broken image if the URL isn't an image (wrong URL, Loading text etc...)
2. Prevent the check for the "Loading" string from failing in other languages where the `.includes( 'Loading' )` would no longer work.

Not sure if the valid URL check is a good idea - open to changes there.