### PR TITLE
Fix: Duplicate CSS when using external file

### DIFF
--- a/includes/blocks/class-button-container.php
+++ b/includes/blocks/class-button-container.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Button_Container {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -53,9 +60,20 @@ class GenerateBlocks_Block_Button_Container {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -70,17 +88,18 @@ class GenerateBlocks_Block_Button_Container {
 			$defaults['buttonContainer']
 		);
 
-		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-button-wrapper' );
 			$css->add_property( 'display', 'flex' );
 			$css->add_property( 'flex-wrap', 'wrap' );
 			$css->add_property( 'align-items', 'flex-start' );
 			$css->add_property( 'justify-content', 'flex-start' );
 			$css->add_property( 'clear', 'both' );
+
+			self::$singular_css_added = true;
 		}
 
 		$css->set_selector( '.gb-button-wrapper-' . $id );
@@ -149,9 +168,6 @@ class GenerateBlocks_Block_Button_Container {
 			$mobile_css->add_property( 'width', '100%' );
 			$mobile_css->add_property( 'box-sizing', 'border-box' );
 		}
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-button-container.php
+++ b/includes/blocks/class-button-container.php
@@ -58,22 +58,20 @@ class GenerateBlocks_Block_Button_Container {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -88,6 +86,7 @@ class GenerateBlocks_Block_Button_Container {
 			$defaults['buttonContainer']
 		);
 
+		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Only add this CSS once.
@@ -168,6 +167,9 @@ class GenerateBlocks_Block_Button_Container {
 			$mobile_css->add_property( 'width', '100%' );
 			$mobile_css->add_property( 'box-sizing', 'border-box' );
 		}
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -143,22 +143,20 @@ class GenerateBlocks_Block_Button {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -173,6 +171,7 @@ class GenerateBlocks_Block_Button {
 			$defaults['button']
 		);
 
+		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -312,6 +311,9 @@ class GenerateBlocks_Block_Button {
 				$mobile_css->add_property( 'padding', array( $settings['iconPaddingTopMobile'], $settings['iconPaddingRightMobile'], $settings['iconPaddingBottomMobile'], $settings['iconPaddingLeftMobile'] ), $settings['iconPaddingUnit'] );
 			}
 		}
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Button {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -138,9 +145,20 @@ class GenerateBlocks_Block_Button {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -155,7 +173,6 @@ class GenerateBlocks_Block_Button {
 			$defaults['button']
 		);
 
-		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -194,7 +211,7 @@ class GenerateBlocks_Block_Button {
 		}
 
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-button-wrapper .gb-button' );
 			$css->add_property( 'display', 'inline-flex' );
 			$css->add_property( 'align-items', 'center' );
@@ -214,6 +231,8 @@ class GenerateBlocks_Block_Button {
 			$css->add_property( 'height', '1em' );
 			$css->add_property( 'width', '1em' );
 			$css->add_property( 'fill', 'currentColor' );
+
+			self::$singular_css_added = true;
 		}
 
 		$css->set_selector( '.gb-button-wrapper ' . $selector . ',.gb-button-wrapper ' . $selector . ':visited' );
@@ -293,9 +312,6 @@ class GenerateBlocks_Block_Button {
 				$mobile_css->add_property( 'padding', array( $settings['iconPaddingTopMobile'], $settings['iconPaddingRightMobile'], $settings['iconPaddingBottomMobile'], $settings['iconPaddingLeftMobile'] ), $settings['iconPaddingUnit'] );
 			}
 		}
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Container {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -166,9 +173,20 @@ class GenerateBlocks_Block_Container {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -183,7 +201,6 @@ class GenerateBlocks_Block_Container {
 			$defaults['container']
 		);
 
-		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -214,7 +231,7 @@ class GenerateBlocks_Block_Container {
 		$hasBgImage = generateblocks_has_background_image( $settings );
 
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-container .wp-block-image img' );
 			$css->add_property( 'vertical-align', 'middle' );
 
@@ -226,6 +243,8 @@ class GenerateBlocks_Block_Container {
 
 			$css->set_selector( '.gb-container .gb-shape svg' );
 			$css->add_property( 'fill', 'currentColor' );
+
+			self::$singular_css_added = true;
 		}
 
 		$css->set_selector( '.gb-container-' . $id );
@@ -655,9 +674,6 @@ class GenerateBlocks_Block_Container {
 
 			$mobile_css->add_property( 'background-attachment', 'initial' );
 		}
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -171,22 +171,20 @@ class GenerateBlocks_Block_Container {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -201,6 +199,7 @@ class GenerateBlocks_Block_Container {
 			$defaults['container']
 		);
 
+		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -674,6 +673,9 @@ class GenerateBlocks_Block_Container {
 
 			$mobile_css->add_property( 'background-attachment', 'initial' );
 		}
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -48,22 +48,20 @@ class GenerateBlocks_Block_Grid {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -78,6 +76,7 @@ class GenerateBlocks_Block_Grid {
 			$defaults['gridContainer']
 		);
 
+		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -169,6 +168,9 @@ class GenerateBlocks_Block_Grid {
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$mobile_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapMobile'], 'px' );
 		$mobile_css->add_property( 'padding-bottom', $settings['verticalGapMobile'], 'px' );
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Grid {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -43,9 +50,20 @@ class GenerateBlocks_Block_Grid {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -60,7 +78,6 @@ class GenerateBlocks_Block_Grid {
 			$defaults['gridContainer']
 		);
 
-		$id = $attributes['uniqueId'];
 		$blockVersion = ! empty( $settings['blockVersion'] ) ? $settings['blockVersion'] : 1;
 
 		// Use legacy settings if needed.
@@ -82,7 +99,7 @@ class GenerateBlocks_Block_Grid {
 		}
 
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-grid-wrapper' );
 			$css->add_property( 'display', 'flex' );
 			$css->add_property( 'flex-wrap', 'wrap' );
@@ -97,6 +114,8 @@ class GenerateBlocks_Block_Grid {
 
 			$css->set_selector( '.gb-grid-wrapper .wp-block-image' );
 			$css->add_property( 'margin-bottom', '0' );
+
+			self::$singular_css_added = true;
 		}
 
 		$css->set_selector( '.gb-grid-wrapper-' . $id );
@@ -150,9 +169,6 @@ class GenerateBlocks_Block_Grid {
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$mobile_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapMobile'], 'px' );
 		$mobile_css->add_property( 'padding-bottom', $settings['verticalGapMobile'], 'px' );
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Headline {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -144,9 +151,20 @@ class GenerateBlocks_Block_Headline {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -160,8 +178,6 @@ class GenerateBlocks_Block_Headline {
 			$attributes,
 			$defaults['headline']
 		);
-
-		$id = $attributes['uniqueId'];
 
 		$selector = '.gb-headline-' . $id;
 
@@ -181,7 +197,7 @@ class GenerateBlocks_Block_Headline {
 		}
 
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-icon' );
 			$css->add_property( 'display', 'inline-flex' );
 			$css->add_property( 'line-height', '0' );
@@ -194,6 +210,8 @@ class GenerateBlocks_Block_Headline {
 			$css->set_selector( '.gb-highlight' );
 			$css->add_property( 'background', 'none' );
 			$css->add_property( 'color', 'unset' );
+
+			self::$singular_css_added = true;
 		}
 
 		if ( ! isset( $attributes['hasWrapper'] ) ) {
@@ -599,9 +617,6 @@ class GenerateBlocks_Block_Headline {
 				}
 			}
 		}
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 			* Do generateblocks_block_css_data hook

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -149,22 +149,20 @@ class GenerateBlocks_Block_Headline {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -178,6 +176,8 @@ class GenerateBlocks_Block_Headline {
 			$attributes,
 			$defaults['headline']
 		);
+
+		$id = $attributes['uniqueId'];
 
 		$selector = '.gb-headline-' . $id;
 
@@ -617,6 +617,9 @@ class GenerateBlocks_Block_Headline {
 				}
 			}
 		}
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 			* Do generateblocks_block_css_data hook

--- a/includes/blocks/class-image.php
+++ b/includes/blocks/class-image.php
@@ -103,22 +103,20 @@ class GenerateBlocks_Block_Image {
 	}
 
 	/**
+	 * Store our block ID in memory.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function store_block_id( $id ) {
+		self::$block_ids[] = $id;
+	}
+
+	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array  $attributes Our block attributes.
-	 * @param string $return Whether to build the CSS store the ID.
+	 * @param array $attributes Our block attributes.
 	 */
-	public static function get_css_data( $attributes, $return = 'full' ) {
-		$id = $attributes['uniqueId'];
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
-
-		// Bail if we only need to store our block ID.
-		if ( 'id' === $return ) {
-			return;
-		}
-
+	public static function get_css_data( $attributes ) {
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -132,6 +130,8 @@ class GenerateBlocks_Block_Image {
 			$attributes,
 			$defaults['image']
 		);
+
+		$id = $attributes['uniqueId'];
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
@@ -213,6 +213,9 @@ class GenerateBlocks_Block_Image {
 		$mobile_css->add_property( 'width', $settings['widthMobile'] );
 		$mobile_css->add_property( 'height', $settings['heightMobile'] );
 		$mobile_css->add_property( 'object-fit', $settings['objectFitMobile'] );
+
+		// Store this block ID in memory.
+		self::store_block_id( $id );
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/blocks/class-image.php
+++ b/includes/blocks/class-image.php
@@ -21,6 +21,13 @@ class GenerateBlocks_Block_Image {
 	private static $block_ids = [];
 
 	/**
+	 * Keep track of CSS we want to output once per block type.
+	 *
+	 * @var boolean
+	 */
+	private static $singular_css_added = false;
+
+	/**
 	 * Block defaults.
 	 */
 	public static function defaults() {
@@ -98,9 +105,20 @@ class GenerateBlocks_Block_Image {
 	/**
 	 * Compile our CSS data based on our block attributes.
 	 *
-	 * @param array $attributes Our block attributes.
+	 * @param array  $attributes Our block attributes.
+	 * @param string $return Whether to build the CSS store the ID.
 	 */
-	public static function get_css_data( $attributes ) {
+	public static function get_css_data( $attributes, $return = 'full' ) {
+		$id = $attributes['uniqueId'];
+
+		// Store this block ID in memory.
+		self::$block_ids[] = $id;
+
+		// Bail if we only need to store our block ID.
+		if ( 'id' === $return ) {
+			return;
+		}
+
 		$css = new GenerateBlocks_Dynamic_CSS();
 		$desktop_css = new GenerateBlocks_Dynamic_CSS();
 		$tablet_css = new GenerateBlocks_Dynamic_CSS();
@@ -115,12 +133,12 @@ class GenerateBlocks_Block_Image {
 			$defaults['image']
 		);
 
-		$id = $attributes['uniqueId'];
-
 		// Only add this CSS once.
-		if ( count( (array) self::$block_ids ) === 0 ) {
+		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-block-image img' );
 			$css->add_property( 'vertical-align', 'middle' );
+
+			self::$singular_css_added = true;
 		}
 
 		$css->set_selector( '.gb-block-image-' . $id );
@@ -195,9 +213,6 @@ class GenerateBlocks_Block_Image {
 		$mobile_css->add_property( 'width', $settings['widthMobile'] );
 		$mobile_css->add_property( 'height', $settings['heightMobile'] );
 		$mobile_css->add_property( 'object-fit', $settings['objectFitMobile'] );
-
-		// Store this block ID in memory.
-		self::$block_ids[] = $id;
 
 		/**
 		 * Do generateblocks_block_css_data hook

--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -139,7 +139,7 @@ class GenerateBlocks_Enqueue_CSS {
 
 		if ( 'file' === $this->mode() ) {
 			if ( ! self::$has_made_css ) {
-				// Build our CSS based on the content we find.
+				// Store our block IDs based on the content we find.
 				generateblocks_get_dynamic_css( '', 'id' );
 			}
 

--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -23,6 +23,15 @@ class GenerateBlocks_Enqueue_CSS {
 	private static $instance;
 
 	/**
+	 * Check to see if we've made this CSS in this instance.
+	 * This should only run on first load if needed.
+	 *
+	 * @access private
+	 * @var boolean
+	 */
+	private static $has_made_css = false;
+
+	/**
 	 * Initiator.
 	 *
 	 * @since 0.1
@@ -129,6 +138,11 @@ class GenerateBlocks_Enqueue_CSS {
 		}
 
 		if ( 'file' === $this->mode() ) {
+			if ( ! self::$has_made_css ) {
+				// Build our CSS based on the content we find.
+				generateblocks_get_dynamic_css( '', 'id' );
+			}
+
 			wp_enqueue_style( 'generateblocks', esc_url( $this->file( 'uri' ) ), array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		}
 	}
@@ -224,6 +238,9 @@ class GenerateBlocks_Enqueue_CSS {
 
 				// Update the 'generateblocks_dynamic_css_time' option.
 				$this->update_saved_time();
+
+				// Set flag.
+				self::$has_made_css = true;
 
 				// Success!
 				return true;

--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -140,7 +140,7 @@ class GenerateBlocks_Enqueue_CSS {
 		if ( 'file' === $this->mode() ) {
 			if ( ! self::$has_made_css ) {
 				// Store our block IDs based on the content we find.
-				generateblocks_get_dynamic_css( '', 'id' );
+				generateblocks_get_dynamic_css( '', true );
 			}
 
 			wp_enqueue_style( 'generateblocks', esc_url( $this->file( 'uri' ) ), array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1018,11 +1018,11 @@ function generateblocks_get_parsed_css( $data ) {
  *
  * @since 0.1
  * @param string $content The content we're looking through.
- * @param string $return Whether to return full CSS output or add to block IDs.
+ * @param string $store_block_id_only Store the found block IDs instead of adding CSS.
  *
  * @return string The dynamic CSS.
  */
-function generateblocks_get_dynamic_css( $content = '', $return = 'full' ) {
+function generateblocks_get_dynamic_css( $content = '', $store_block_id_only = false ) {
 	if ( ! $content ) {
 		$content = generateblocks_get_parsed_content();
 	}
@@ -1054,7 +1054,7 @@ function generateblocks_get_dynamic_css( $content = '', $return = 'full' ) {
 				}
 
 				if ( is_callable( [ $blocks[ $name ], 'get_css_data' ] ) ) {
-					if ( 'id' === $return ) {
+					if ( $store_block_id_only ) {
 						$blocks[ $name ]::store_block_id( $atts['uniqueId'] );
 					} else {
 						generateblocks_add_to_css_data(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1055,10 +1055,10 @@ function generateblocks_get_dynamic_css( $content = '', $return = 'full' ) {
 
 				if ( is_callable( [ $blocks[ $name ], 'get_css_data' ] ) ) {
 					if ( 'id' === $return ) {
-						$blocks[ $name ]::get_css_data( $atts, $return );
+						$blocks[ $name ]::store_block_id( $atts['uniqueId'] );
 					} else {
 						generateblocks_add_to_css_data(
-							$blocks[ $name ]::get_css_data( $atts, $return )
+							$blocks[ $name ]::get_css_data( $atts )
 						);
 					}
 				}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1018,10 +1018,11 @@ function generateblocks_get_parsed_css( $data ) {
  *
  * @since 0.1
  * @param string $content The content we're looking through.
+ * @param string $return Whether to return full CSS output or add to block IDs.
  *
  * @return string The dynamic CSS.
  */
-function generateblocks_get_dynamic_css( $content = '' ) {
+function generateblocks_get_dynamic_css( $content = '', $return = 'full' ) {
 	if ( ! $content ) {
 		$content = generateblocks_get_parsed_content();
 	}
@@ -1053,9 +1054,13 @@ function generateblocks_get_dynamic_css( $content = '' ) {
 				}
 
 				if ( is_callable( [ $blocks[ $name ], 'get_css_data' ] ) ) {
-					generateblocks_add_to_css_data(
-						$blocks[ $name ]::get_css_data( $atts )
-					);
+					if ( 'id' === $return ) {
+						$blocks[ $name ]::get_css_data( $atts, $return );
+					} else {
+						generateblocks_add_to_css_data(
+							$blocks[ $name ]::get_css_data( $atts, $return )
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a bug where block CSS was being duplicated when using the External File option in 1.6.