### PR TITLE
Fix: Missing CSS when do_blocks is ran early

### DIFF
--- a/includes/blocks/class-button-container.php
+++ b/includes/blocks/class-button-container.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Button_Container {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -64,6 +64,15 @@ class GenerateBlocks_Block_Button_Container {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/blocks/class-button-container.php
+++ b/includes/blocks/class-button-container.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Button_Container {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Button {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Button {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -149,6 +149,15 @@ class GenerateBlocks_Block_Button {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Container {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Container {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -177,6 +177,15 @@ class GenerateBlocks_Block_Container {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Grid {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -54,6 +54,15 @@ class GenerateBlocks_Block_Grid {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Grid {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Headline {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -155,6 +155,15 @@ class GenerateBlocks_Block_Headline {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Headline {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-image.php
+++ b/includes/blocks/class-image.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Image {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	private static $block_ids = [];
+	public static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.

--- a/includes/blocks/class-image.php
+++ b/includes/blocks/class-image.php
@@ -18,7 +18,7 @@ class GenerateBlocks_Block_Image {
 	 *
 	 * @var array $block_ids The current block id.
 	 */
-	public static $block_ids = [];
+	private static $block_ids = [];
 
 	/**
 	 * Keep track of CSS we want to output once per block type.
@@ -109,6 +109,15 @@ class GenerateBlocks_Block_Image {
 	 */
 	public static function store_block_id( $id ) {
 		self::$block_ids[] = $id;
+	}
+
+	/**
+	 * Check if our block ID exists.
+	 *
+	 * @param string $id The block ID to store.
+	 */
+	public static function block_id_exists( $id ) {
+		return in_array( $id, (array) self::$block_ids );
 	}
 
 	/**

--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -65,7 +65,7 @@ class GenerateBlocks_Enqueue_CSS {
 		$dynamic_css_priority = apply_filters( 'generateblocks_dynamic_css_priority', 10 );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_dynamic_css' ), $dynamic_css_priority );
-		add_action( 'wp_head', array( $this, 'print_inline_css' ), $dynamic_css_priority );
+		add_action( 'wp_enqueue_scripts', array( $this, 'print_inline_css' ), $dynamic_css_priority );
 	}
 
 	/**
@@ -161,8 +161,12 @@ class GenerateBlocks_Enqueue_CSS {
 				return;
 			}
 
-			printf(
-				'<style id="generateblocks-css">%s</style>',
+			// Add a "dummy" handle we can add inline styles to.
+			wp_register_style( 'generateblocks', false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_enqueue_style( 'generateblocks' );
+
+			wp_add_inline_style(
+				'generateblocks',
 				wp_strip_all_tags( $css ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			);
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1056,7 +1056,7 @@ function generateblocks_get_dynamic_css( $content = '', $store_block_id_only = f
 				if ( is_callable( [ $blocks[ $name ], 'get_css_data' ] ) ) {
 					if ( $store_block_id_only ) {
 						$blocks[ $name ]::store_block_id( $atts['uniqueId'] );
-					} elseif ( ! in_array( $atts['uniqueId'], $blocks[ $name ]::$block_ids ) ) {
+					} elseif ( ! $blocks[ $name ]::block_id_exists( $atts['uniqueId'] ) ) {
 						generateblocks_add_to_css_data(
 							$blocks[ $name ]::get_css_data( $atts )
 						);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1056,7 +1056,7 @@ function generateblocks_get_dynamic_css( $content = '', $store_block_id_only = f
 				if ( is_callable( [ $blocks[ $name ], 'get_css_data' ] ) ) {
 					if ( $store_block_id_only ) {
 						$blocks[ $name ]::store_block_id( $atts['uniqueId'] );
-					} else {
+					} elseif ( ! in_array( $atts['uniqueId'], $blocks[ $name ]::$block_ids ) ) {
 						generateblocks_add_to_css_data(
 							$blocks[ $name ]::get_css_data( $atts )
 						);


### PR DESCRIPTION
alternative to #682 

#682 works but has an issue where CSS (singular and block-specific) is duplicated when using block themes.

This method works by using `wp_enqueue_scripts` and `wp_add_inline_style` for our inline style. This works because `wp_enqueue_scripts` fires before `wp_head` which is where Slim SEO (in this case) is calling `do_blocks`.

We also have to check `$block_ids` within the `generateblocks_get_dynamic_css` function to prevent duplicate CSS in block themes.

Not sure if this is the best solution.