### PR TITLE
Feature: Allow Buttons outside of the Button Container block

### DIFF
--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -139,6 +139,7 @@ class GenerateBlocks_Block_Button {
 			'iconSizeTablet' => '',
 			'iconSizeMobile' => '',
 			'iconSizeUnit' => 'em',
+			'hasButtonContainer' => false,
 		];
 	}
 
@@ -188,11 +189,14 @@ class GenerateBlocks_Block_Button {
 			$settings = GenerateBlocks_Legacy_Attributes::get_settings( '1.4.0', 'button', $settings, $attributes );
 		}
 
+		$containerSelector = $settings['hasButtonContainer'] || $blockVersion < 3 ? '.gb-button-wrapper ' : '';
 		$selector = 'a.gb-button-' . $id;
 
 		if ( isset( $attributes['hasUrl'] ) && ! $attributes['hasUrl'] ) {
 			$selector = '.gb-button-' . $id;
 		}
+
+		$selector = $containerSelector . $selector;
 
 		// Back-compatibility for when icon held a value.
 		if ( $settings['icon'] ) {
@@ -220,7 +224,7 @@ class GenerateBlocks_Block_Button {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-button-wrapper .gb-button' );
+			$css->set_selector( '.gb-button' );
 			$css->add_property( 'display', 'inline-flex' );
 			$css->add_property( 'align-items', 'center' );
 			$css->add_property( 'justify-content', 'center' );
@@ -228,7 +232,7 @@ class GenerateBlocks_Block_Button {
 			$css->add_property( 'text-decoration', 'none' );
 			$css->add_property( 'transition', '.2s background-color ease-in-out, .2s color ease-in-out, .2s border-color ease-in-out, .2s opacity ease-in-out, .2s box-shadow ease-in-out' );
 
-			$css->set_selector( '.gb-button-wrapper .gb-button .gb-icon' );
+			$css->set_selector( '.gb-button .gb-icon' );
 			$css->add_property( 'align-items', 'center' );
 
 			$css->set_selector( '.gb-icon' );
@@ -250,7 +254,7 @@ class GenerateBlocks_Block_Button {
 			self::$singular_css_added = true;
 		}
 
-		$css->set_selector( '.gb-button-wrapper ' . $selector . ',.gb-button-wrapper ' . $selector . ':visited' );
+		$css->set_selector( $selector . ', ' . $selector . ':visited' );
 		$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
 		$css->add_property( 'color', $settings['textColor'] );
 
@@ -275,12 +279,12 @@ class GenerateBlocks_Block_Button {
 			$css->add_property( 'align-items', 'center' );
 		}
 
-		$css->set_selector( '.gb-button-wrapper ' . $selector . ':hover,.gb-button-wrapper ' . $selector . ':active,.gb-button-wrapper ' . $selector . ':focus' );
+		$css->set_selector( $selector . ':hover, ' . $selector . ':active, ' . $selector . ':focus' );
 		$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColorHover'], $settings['backgroundColorHoverOpacity'] ) );
 		$css->add_property( 'color', $settings['textColorHover'] );
 		$css->add_property( 'border-color', generateblocks_hex2rgba( $settings['borderColorHover'], $settings['borderColorHoverOpacity'] ) );
 
-		$css->set_selector( '.gb-button-wrapper ' . $selector . '.gb-button__current, .gb-button-wrapper ' . $selector . '.gb-button__current:visited' );
+		$css->set_selector( $selector . '.gb-button__current, ' . $selector . '.gb-button__current:visited' );
 		$css->add_property( 'background-color', $settings['backgroundColorCurrent'] );
 		$css->add_property( 'color', $settings['textColorCurrent'] );
 		$css->add_property( 'border-color', $settings['borderColorCurrent'] );
@@ -294,7 +298,7 @@ class GenerateBlocks_Block_Button {
 			}
 		}
 
-		$tablet_css->set_selector( '.gb-button-wrapper ' . $selector );
+		$tablet_css->set_selector( $selector );
 		$tablet_css->add_property( 'font-size', $settings['fontSizeTablet'], $settings['fontSizeUnit'] );
 		$tablet_css->add_property( 'letter-spacing', $settings['letterSpacingTablet'], 'em' );
 		$tablet_css->add_property( 'padding', array( $settings['paddingTopTablet'], $settings['paddingRightTablet'], $settings['paddingBottomTablet'], $settings['paddingLeftTablet'] ), $settings['paddingUnit'] );
@@ -311,7 +315,7 @@ class GenerateBlocks_Block_Button {
 			}
 		}
 
-		$mobile_css->set_selector( '.gb-button-wrapper ' . $selector );
+		$mobile_css->set_selector( $selector );
 		$mobile_css->add_property( 'font-size', $settings['fontSizeMobile'], $settings['fontSizeUnit'] );
 		$mobile_css->add_property( 'letter-spacing', $settings['letterSpacingMobile'], 'em' );
 		$mobile_css->add_property( 'padding', array( $settings['paddingTopMobile'], $settings['paddingRightMobile'], $settings['paddingBottomMobile'], $settings['paddingLeftMobile'] ), $settings['paddingUnit'] );

--- a/src/blocks/button-container/block.js
+++ b/src/blocks/button-container/block.js
@@ -22,8 +22,8 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 registerBlockType( 'generateblocks/button-container', {
 	apiVersion: 2,
-	title: __( 'Buttons', 'generateblocks' ),
-	description: __( 'Drive conversions with beautiful buttons.', 'generateblocks' ),
+	title: __( 'Button Group', 'generateblocks' ),
+	description: __( 'Group your buttons in a row.', 'generateblocks' ),
 	icon: getIcon( 'button-container' ),
 	category: 'generateblocks',
 	keywords: [

--- a/src/blocks/button/attributes.js
+++ b/src/blocks/button/attributes.js
@@ -472,6 +472,10 @@ export default {
 	blockVersion: {
 		type: 'number',
 	},
+	hasButtonContainer: {
+		type: 'boolean',
+		default: false,
+	},
 	// deprecated since 1.2.0
 	elementId: {
 		type: 'string',

--- a/src/blocks/button/block.js
+++ b/src/blocks/button/block.js
@@ -38,7 +38,6 @@ registerBlockType( 'generateblocks/button', {
 	apiVersion: 2,
 	title: __( 'Button', 'generateblocks' ),
 	description: __( 'Drive conversions with beautiful buttons.', 'generateblocks' ),
-	parent: [ 'generateblocks/button-container' ],
 	icon: getIcon( 'button' ),
 	category: 'generateblocks',
 	keywords: [
@@ -49,8 +48,6 @@ registerBlockType( 'generateblocks/button', {
 	attributes,
 	supports: {
 		className: false,
-		inserter: false,
-		reusable: false,
 	},
 	edit: editButton,
 	save: saveButton,

--- a/src/blocks/button/components/BlockControls.js
+++ b/src/blocks/button/components/BlockControls.js
@@ -16,7 +16,6 @@ export default ( props ) => {
 	const { insertBlocks } = useDispatch( 'core/block-editor' );
 	const {
 		getBlockParentsByBlockName,
-		getBlockRootClientId,
 		getBlocksByClientId,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 
@@ -37,25 +36,18 @@ export default ( props ) => {
 	const hasDynamicLink = useDynamicData && dynamicLinkType;
 	const showAppender = applyFilters( 'generateblocks.editor.showButtonAppender', true, props );
 	const showButtonLinkControl = applyFilters( 'generateblocks.editor.showButtonLinkControl', true, props );
+	const parentBlockId = getBlockParentsByBlockName( clientId, 'generateblocks/button-container', true )[ 0 ];
 
 	return (
 		<>
 			<BlockControls>
 				<ToolbarGroup>
-					{ showAppender &&
+					{ showAppender && parentBlockId &&
 						<ToolbarButton
 							className="gblocks-add-new-button"
 							icon={ plus }
 							label={ __( 'Add Button', 'generateblocks' ) }
 							onClick={ () => {
-								let parentBlockId = false;
-
-								if ( typeof getBlockParentsByBlockName === 'function' ) {
-									parentBlockId = getBlockParentsByBlockName( clientId, 'generateblocks/button-container', true )[ 0 ];
-								} else {
-									parentBlockId = getBlockRootClientId( clientId );
-								}
-
 								const thisBlock = getBlocksByClientId( clientId )[ 0 ];
 
 								const clonedBlock = cloneBlock(

--- a/src/blocks/button/components/ButtonContentRenderer.js
+++ b/src/blocks/button/components/ButtonContentRenderer.js
@@ -2,6 +2,7 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import IconWrapper from '../../../components/icon-wrapper';
 import { __ } from '@wordpress/i18n';
 import Element from '../../../components/element';
+import RootElement from '../../../components/root-element';
 import classnames from 'classnames';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -14,6 +15,7 @@ export default function ButtonContentRenderer( props ) {
 		context,
 		name,
 		buttonRef,
+		clientId,
 	} = props;
 
 	const {
@@ -74,27 +76,29 @@ export default function ButtonContentRenderer( props ) {
 	const buttonTagName = applyFilters( 'generateblocks.frontend.buttonTagName', url ? 'a' : 'span', props );
 
 	return (
-		<Element tagName={ buttonTagName } htmlAttrs={ blockProps }>
-			<IconWrapper
-				hasIcon={ !! icon }
-				icon={ icon }
-				direction={ iconLocation }
-				hideChildren={ removeText }
-				showWrapper={ ! removeText && !! icon }
-				wrapperClassname={ 'gb-button-text' }
-			>
-				<InnerContent
-					name={ name }
-					placeholder={ __( 'Add text…', 'generateblocks' ) }
-					value={ text }
-					onChange={ ( value ) => setAttributes( { text: value } ) }
-					allowedFormats={ richTextFormats }
-					isSelected={ isSelected }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					context={ context }
-				/>
-			</IconWrapper>
-		</Element>
+		<RootElement name={ name } clientId={ clientId }>
+			<Element tagName={ buttonTagName } htmlAttrs={ blockProps }>
+				<IconWrapper
+					hasIcon={ !! icon }
+					icon={ icon }
+					direction={ iconLocation }
+					hideChildren={ removeText }
+					showWrapper={ ! removeText && !! icon }
+					wrapperClassname={ 'gb-button-text' }
+				>
+					<InnerContent
+						name={ name }
+						placeholder={ __( 'Add text…', 'generateblocks' ) }
+						value={ text }
+						onChange={ ( value ) => setAttributes( { text: value } ) }
+						allowedFormats={ richTextFormats }
+						isSelected={ isSelected }
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						context={ context }
+					/>
+				</IconWrapper>
+			</Element>
+		</RootElement>
 	);
 }

--- a/src/blocks/button/css/main.js
+++ b/src/blocks/button/css/main.js
@@ -71,6 +71,7 @@ export default class MainCSS extends Component {
 			iconPaddingUnit,
 			iconSize,
 			iconSizeUnit,
+			hasButtonContainer,
 		} = attributes;
 
 		let fontFamilyFallbackValue = '',
@@ -96,11 +97,9 @@ export default class MainCSS extends Component {
 			fontFamilyFallbackValue = ', ' + fontFamilyFallback;
 		}
 
-		let selector = '.editor-styles-wrapper .gb-button-wrapper a.gb-button-' + uniqueId;
-
-		if ( ! url ) {
-			selector = '.editor-styles-wrapper .gb-button-wrapper .gb-button-' + uniqueId;
-		}
+		const containerSelector = !! hasButtonContainer ? '.gb-button-wrapper ' : '';
+		let selector = !! url ? 'a.gb-button-' + uniqueId : '.gb-button-' + uniqueId;
+		selector = '.editor-styles-wrapper ' + containerSelector + selector;
 
 		let cssObj = [];
 

--- a/src/blocks/button/css/mobile.js
+++ b/src/blocks/button/css/mobile.js
@@ -47,13 +47,12 @@ export default class MobileCSS extends Component {
 			iconPaddingUnit,
 			iconSizeMobile,
 			iconSizeUnit,
+			hasButtonContainer,
 		} = attributes;
 
-		let selector = '.editor-styles-wrapper .gb-button-wrapper a.gb-button-' + uniqueId;
-
-		if ( ! url ) {
-			selector = '.editor-styles-wrapper .gb-button-wrapper .gb-button-' + uniqueId;
-		}
+		const containerSelector = !! hasButtonContainer ? '.gb-button-wrapper ' : '';
+		let selector = !! url ? 'a.gb-button-' + uniqueId : '.gb-button-' + uniqueId;
+		selector = '.editor-styles-wrapper ' + containerSelector + selector;
 
 		let cssObj = [];
 

--- a/src/blocks/button/css/tablet.js
+++ b/src/blocks/button/css/tablet.js
@@ -47,13 +47,12 @@ export default class TabletCSS extends Component {
 			iconPaddingUnit,
 			iconSizeTablet,
 			iconSizeUnit,
+			hasButtonContainer,
 		} = attributes;
 
-		let selector = '.editor-styles-wrapper .gb-button-wrapper a.gb-button-' + uniqueId;
-
-		if ( ! url ) {
-			selector = '.editor-styles-wrapper .gb-button-wrapper .gb-button-' + uniqueId;
-		}
+		const containerSelector = !! hasButtonContainer ? '.gb-button-wrapper ' : '';
+		let selector = !! url ? 'a.gb-button-' + uniqueId : '.gb-button-' + uniqueId;
+		selector = '.editor-styles-wrapper ' + containerSelector + selector;
 
 		let cssObj = [];
 

--- a/src/blocks/button/editor.scss
+++ b/src/blocks/button/editor.scss
@@ -2,34 +2,30 @@
  * Editor Styles
  */
 .editor-styles-wrapper {
-	.gb-button-wrapper {
-		position: relative;
+	.gb-button {
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
+		padding: unset;
+		line-height: unset;
+		text-decoration: none !important;
+		border: none;
+		transition: .2s background-color ease-in-out, .2s color ease-in-out, .2s border-color ease-in-out, .2s opacity ease-in-out, .2s box-shadow ease-in-out;
+		margin: 0;
 
-		.gb-button {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			text-align: center;
-			padding: unset;
-			line-height: unset;
-			text-decoration: none !important;
-			border: none;
-			transition: .2s background-color ease-in-out, .2s color ease-in-out, .2s border-color ease-in-out, .2s opacity ease-in-out, .2s box-shadow ease-in-out;
-			margin: 0;
+		.editor-rich-text__tinymce {
+			line-height: 1em;
+		}
 
-			.editor-rich-text__tinymce {
-				line-height: 1em;
-			}
+		.gb-icon {
+			align-self: center;
+		}
 
-			.gb-icon {
-				align-self: center;
-			}
-
-			&.button {
-				font-size: inherit;
-				min-height: auto;
-				border-radius: unset;
-			}
+		&.button {
+			font-size: inherit;
+			min-height: auto;
+			border-radius: unset;
 		}
 	}
 }

--- a/src/hoc/withButtonLegacyMigration.js
+++ b/src/hoc/withButtonLegacyMigration.js
@@ -58,8 +58,8 @@ export default ( WrappedComponent ) => {
 			}
 
 			// Update block version flag if it's out of date.
-			if ( isBlockVersionLessThan( blockVersion, 2 ) ) {
-				setAttributes( { blockVersion: 2 } );
+			if ( isBlockVersionLessThan( blockVersion, 3 ) ) {
+				setAttributes( { blockVersion: 3 } );
 			}
 		}, [] );
 


### PR DESCRIPTION
This allows the Button block to be added outside of the Button Container block.

Buttons within the Button Container will continue to use the `.gb-button-wrapper` selector to maintain backward-compatibility.

Buttons outside of the Button Container only use the `.gb-button` selector.

The only possible "breaking change" here is that the one-time CSS no longer has the wrapper selector.