### PR TITLE
Fix: Missing legacy alpha color slider in gradient component

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Fix: "Sticky posts only" not displaying correctly in the frontend
 * Fix: Pass dynamic container link to settings variable
 * Fix: Color picker behavior when manually changing value
+* Fix: Missing legacy alpha color slider in gradient component if set to 0
 * Tweak: Enqueue inline embedding stylesheet using wp_enqueue_scripts
 * Tweak: Remove block-editor-block-list__block class from root wrapper
 * Tweak: Headline transform to core Heading keep the level

--- a/src/components/gradient/index.js
+++ b/src/components/gradient/index.js
@@ -127,7 +127,7 @@ class GradientControl extends Component {
 								<ColorPicker
 									value={ attributes[ attrGradientColorOne ] }
 									alpha={ true }
-									valueOpacity={ attributes[ attrGradientColorOneOpacity ] || 1 }
+									valueOpacity={ attributes[ attrGradientColorOneOpacity ] || 0 === attributes[ attrGradientColorOneOpacity ] ? attributes[ attrGradientColorOneOpacity ] : 1 }
 									attrOpacity={ 'gradientColorOneOpacity' }
 									onChange={ ( value ) =>
 										setAttributes( {
@@ -177,7 +177,7 @@ class GradientControl extends Component {
 								<ColorPicker
 									value={ attributes[ attrGradientColorTwo ] }
 									alpha={ true }
-									valueOpacity={ attributes[ attrGradientColorTwoOpacity ] || 1 }
+									valueOpacity={ attributes[ attrGradientColorTwoOpacity ] || 0 === attributes[ attrGradientColorTwoOpacity ] ? attributes[ attrGradientColorTwoOpacity ] : 1 }
 									attrOpacity={ 'gradientColorTwoOpacity' }
 									onChange={ ( value ) =>
 										setAttributes( {


### PR DESCRIPTION
This fixes a bug where if the old opacity slider was set to `0` in the gradient component it wouldn't show and changing the colors wouldn't work as the opacity was set to 0.

This should allow the gradient picker to display the old opacity slider if it's set to `0` so users can set it to `1` and use the newer rgba slider.