### PR TITLE
Feature: Remove the "Remove Vertical Gap" option

### DIFF
--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -137,15 +137,26 @@ class GenerateBlocks_Block_Grid {
 		$css->add_property( 'align-items', $settings['verticalAlignment'] );
 		$css->add_property( 'justify-content', $settings['horizontalAlignment'] );
 
+		if ( $blockVersion > 2 ) {
+			$css->add_property( 'row-gap', $settings['verticalGap'], 'px' );
+		}
+
 		if ( $settings['horizontalGap'] ) {
 			$css->add_property( 'margin-' . $gap_direction, '-' . $settings['horizontalGap'] . 'px' );
 		}
 
 		$css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$css->add_property( 'padding-' . $gap_direction, $settings['horizontalGap'], 'px' );
-		$css->add_property( 'padding-bottom', $settings['verticalGap'], 'px' );
+
+		if ( $blockVersion < 3 ) {
+			$css->add_property( 'padding-bottom', $settings['verticalGap'], 'px' );
+		}
 
 		$tablet_css->set_selector( '.gb-grid-wrapper-' . $id );
+
+		if ( $blockVersion > 2 ) {
+			$tablet_css->add_property( 'row-gap', $settings['verticalGapTablet'], 'px' );
+		}
 
 		if ( 'inherit' !== $settings['verticalAlignmentTablet'] ) {
 			$tablet_css->add_property( 'align-items', $settings['verticalAlignmentTablet'] );
@@ -163,9 +174,16 @@ class GenerateBlocks_Block_Grid {
 
 		$tablet_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$tablet_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapTablet'], 'px' );
-		$tablet_css->add_property( 'padding-bottom', $settings['verticalGapTablet'], 'px' );
+
+		if ( $blockVersion < 3 ) {
+			$tablet_css->add_property( 'padding-bottom', $settings['verticalGapTablet'], 'px' );
+		}
 
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id );
+
+		if ( $blockVersion > 2 ) {
+			$mobile_css->add_property( 'row-gap', $settings['verticalGapMobile'], 'px' );
+		}
 
 		if ( 'inherit' !== $settings['verticalAlignmentMobile'] ) {
 			$mobile_css->add_property( 'align-items', $settings['verticalAlignmentMobile'] );
@@ -183,7 +201,10 @@ class GenerateBlocks_Block_Grid {
 
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$mobile_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapMobile'], 'px' );
-		$mobile_css->add_property( 'padding-bottom', $settings['verticalGapMobile'], 'px' );
+
+		if ( $blockVersion < 3 ) {
+			$mobile_css->add_property( 'padding-bottom', $settings['verticalGapMobile'], 'px' );
+		}
 
 		// Store this block ID in memory.
 		self::store_block_id( $id );

--- a/src/blocks/container/components/InspectorControls.js
+++ b/src/blocks/container/components/InspectorControls.js
@@ -3,7 +3,6 @@ import { Fragment, useEffect } from '@wordpress/element';
 import {
 	SelectControl,
 	TextControl,
-	ToggleControl,
 } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import hasNumericValue from '../../../utils/has-numeric-value';
@@ -31,9 +30,6 @@ export default ( props ) => {
 		verticalAlignment,
 		verticalAlignmentTablet,
 		verticalAlignmentMobile,
-		removeVerticalGap,
-		removeVerticalGapTablet,
-		removeVerticalGapMobile,
 		orderTablet,
 		orderMobile,
 		tagName,
@@ -145,18 +141,6 @@ export default ( props ) => {
 									} );
 								} }
 							/>
-
-							{ ! isQueryLoopItem &&
-								<ToggleControl
-									label={ __( 'Remove Vertical Gap', 'generateblocks' ) }
-									checked={ !! removeVerticalGap }
-									onChange={ ( value ) => {
-										setAttributes( {
-											removeVerticalGap: value,
-										} );
-									} }
-								/>
-							}
 						</>
 					}
 
@@ -195,18 +179,6 @@ export default ( props ) => {
 						} }
 					/>
 
-					{ ! isQueryLoopItem &&
-						<ToggleControl
-							label={ __( 'Remove Vertical Gap', 'generateblocks' ) }
-							checked={ !! removeVerticalGapTablet }
-							onChange={ ( value ) => {
-								setAttributes( {
-									removeVerticalGapTablet: value,
-								} );
-							} }
-						/>
-					}
-
 					<TextControl
 						type={ 'number' }
 						label={ __( 'Order', 'generateblocks' ) }
@@ -239,18 +211,6 @@ export default ( props ) => {
 							} );
 						} }
 					/>
-
-					{ ! isQueryLoopItem &&
-						<ToggleControl
-							label={ __( 'Remove Vertical Gap', 'generateblocks' ) }
-							checked={ !! removeVerticalGapMobile }
-							onChange={ ( value ) => {
-								setAttributes( {
-									removeVerticalGapMobile: value,
-								} );
-							} }
-						/>
-					}
 
 					<TextControl
 						type={ 'number' }

--- a/src/blocks/grid/css/main.js
+++ b/src/blocks/grid/css/main.js
@@ -36,11 +36,11 @@ export default class MainCSS extends Component {
 			'align-items': verticalAlignment,
 			'justify-content': horizontalAlignment,
 			'margin-left': horizontalGap || 0 === horizontalGap ? '-' + horizontalGap + 'px' : null,
+			'row-gap': valueWithUnit( verticalGap, 'px' ),
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGap, 'px' ),
-			'margin-bottom': valueWithUnit( verticalGap, 'px' ),
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.mainCSS', cssObj, this.props, 'grid' );

--- a/src/blocks/grid/css/mobile.js
+++ b/src/blocks/grid/css/mobile.js
@@ -36,11 +36,11 @@ export default class MobileCSS extends Component {
 			'align-items': 'inherit' !== verticalAlignmentMobile ? verticalAlignmentMobile : null,
 			'justify-content': 'inherit' !== horizontalAlignmentMobile ? horizontalAlignmentMobile : null,
 			'margin-left': horizontalGapMobile || 0 === horizontalGapMobile ? '-' + horizontalGapMobile + 'px' : null,
+			'row-gap': verticalGapMobile || 0 === verticalGapMobile ? valueWithUnit( verticalGapMobile, 'px' ) : null,
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGapMobile, 'px' ),
-			'margin-bottom': verticalGapMobile || 0 === verticalGapMobile ? valueWithUnit( verticalGapMobile, 'px' ) : null,
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.mobileCSS', cssObj, this.props, 'grid' );

--- a/src/blocks/grid/css/tablet.js
+++ b/src/blocks/grid/css/tablet.js
@@ -36,11 +36,11 @@ export default class TabletCSS extends Component {
 			'align-items': 'inherit' !== verticalAlignmentTablet ? verticalAlignmentTablet : null,
 			'justify-content': 'inherit' !== horizontalAlignmentTablet ? horizontalAlignmentTablet : null,
 			'margin-left': horizontalGapTablet || 0 === horizontalGapTablet ? '-' + horizontalGapTablet + 'px' : null,
+			'row-gap': verticalGapTablet || 0 === verticalGapTablet ? valueWithUnit( verticalGapTablet, 'px' ) : null,
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGapTablet, 'px' ),
-			'margin-bottom': verticalGapTablet || 0 === verticalGapTablet ? valueWithUnit( verticalGapTablet, 'px' ) : null,
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.tabletCSS', cssObj, this.props, 'grid' );

--- a/src/blocks/query-loop/components/BlockControls.js
+++ b/src/blocks/query-loop/components/BlockControls.js
@@ -24,6 +24,7 @@ export default ( { clientId } ) => {
 	const PAGINATION_TEMPLATE = [
 		'generateblocks/button-container', {
 			isPagination: true,
+			marginTop: '20',
 		},
 		[
 			[

--- a/src/hoc/withGridLegacyMigration.js
+++ b/src/hoc/withGridLegacyMigration.js
@@ -33,8 +33,8 @@ export default ( WrappedComponent ) => {
 				}
 			}
 
-			if ( isBlockVersionLessThan( attributes.blockVersion, 2 ) ) {
-				setAttributes( { blockVersion: 2 } );
+			if ( isBlockVersionLessThan( attributes.blockVersion, 3 ) ) {
+				setAttributes( { blockVersion: 3 } );
 			}
 		}, [] );
 


### PR DESCRIPTION
This PR uses `row-gap` to implement the Vertical Gap option in the Grid block and removes the "Remove Vertical Gap" option from the Container block.