### PR TITLE
Tweak: Remove ...props from UnitControl

### DIFF
--- a/src/blocks/image/components/inspector-controls/ImageSettingsControl.js
+++ b/src/blocks/image/components/inspector-controls/ImageSettingsControl.js
@@ -67,21 +67,21 @@ export default function ImageSettingsControls( props ) {
 			>
 				<div className="gblocks-image-dimensions__row">
 					<UnitControl
-						{ ...props }
 						label={ __( 'Width', 'generateblocks' ) }
 						id="gblocks-image-width"
+						attributes={ attributes }
+						setAttributes={ setAttributes }
 						attributeName="width"
-						device={ deviceType }
 						min="1"
 						units={ [ 'px', '%', 'vw', 'rem' ] }
 					/>
 
 					<UnitControl
-						{ ...props }
 						label={ __( 'Height', 'generateblocks' ) }
 						id="gblocks-image-height"
+						attributes={ attributes }
+						setAttributes={ setAttributes }
 						attributeName="height"
-						device={ deviceType }
 						min="1"
 						units={ [ 'px', '%', 'vw', 'rem' ] }
 					/>

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -9,6 +9,7 @@ import { TextControl, BaseControl } from '@wordpress/components';
  */
 
 import './editor.scss';
+import { useDeviceType } from '../../hooks';
 
 export default function UnitControl( props ) {
 	const {
@@ -17,7 +18,6 @@ export default function UnitControl( props ) {
 		attributes,
 		setAttributes,
 		units = [ 'px', 'em', '%', 'rem' ],
-		device,
 		min = 0,
 		max,
 		step,
@@ -26,6 +26,7 @@ export default function UnitControl( props ) {
 		overrideValue = null,
 	} = props;
 
+	const [ device ] = useDeviceType();
 	const [ unitValue, setUnitValue ] = useState( '' );
 	const [ numericValue, setNumericValue ] = useState( '' );
 	const [ placeholderValue, setPlaceholderValue ] = useState( '' );


### PR DESCRIPTION
This makes it so we don't have to pass all `props` to the `UnitControl` component.