### PR TITLE
Tweak: Move tagName option to Advanced

### DIFF
--- a/src/blocks/container/components/InspectorAdvancedControls.js
+++ b/src/blocks/container/components/InspectorAdvancedControls.js
@@ -1,11 +1,25 @@
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import HTMLAnchor from '../../../components/html-anchor';
 import MigrateInnerContainer from './MigrateInnerContainer';
+import TagName from './TagName';
 
 export default ( props ) => {
+	const {
+		attributes,
+		setAttributes,
+		filterTagName,
+	} = props;
+
 	return (
 		<InspectorAdvancedControls>
 			<HTMLAnchor { ...props } />
+
+			<TagName
+				filterTagName={ filterTagName }
+				tagName={ attributes.tagName }
+				onChange={ ( value ) => setAttributes( { tagName: filterTagName( value ) } ) }
+			/>
+
 			<MigrateInnerContainer { ...props } />
 		</InspectorAdvancedControls>
 	);

--- a/src/blocks/container/components/InspectorControls.js
+++ b/src/blocks/container/components/InspectorControls.js
@@ -17,7 +17,6 @@ export default ( props ) => {
 		clientId,
 		attributes,
 		setAttributes,
-		filterTagName,
 	} = props;
 	const [ deviceType ] = useDeviceType();
 
@@ -36,27 +35,12 @@ export default ( props ) => {
 		removeVerticalGapMobile,
 		orderTablet,
 		orderMobile,
-		tagName,
 	} = attributes;
 
 	const {
 		getBlockParents,
 		getBlocksByClientId,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
-
-	const tagNames = applyFilters(
-		'generateblocks.editor.containerTagNames',
-		[
-			{ label: 'div', value: 'div' },
-			{ label: 'article', value: 'article' },
-			{ label: 'section', value: 'section' },
-			{ label: 'header', value: 'header' },
-			{ label: 'footer', value: 'footer' },
-			{ label: 'aside', value: 'aside' },
-		],
-		props,
-		{ deviceType }
-	);
 
 	useEffect( () => {
 		const parentBlockId = getBlockParents( clientId, true );
@@ -159,19 +143,6 @@ export default ( props ) => {
 							}
 						</>
 					}
-
-					<SelectControl
-						label={ __( 'Tag Name', 'generateblocks' ) }
-						value={ tagName }
-						options={ tagNames }
-						onChange={ ( value ) => {
-							setAttributes( {
-								tagName: filterTagName( value ),
-							} );
-						} }
-					/>
-
-					{ applyFilters( 'generateblocks.editor.controls', '', 'containerAfterElementTag', props ) }
 				</>
 			}
 

--- a/src/blocks/container/components/TagName.js
+++ b/src/blocks/container/components/TagName.js
@@ -1,0 +1,38 @@
+import { SelectControl } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { useDeviceType } from '../../../hooks';
+
+export default function TagName( props ) {
+	const {
+		onChange,
+		tagName,
+	} = props;
+
+	const [ device ] = useDeviceType();
+
+	const tagNames = applyFilters(
+		'generateblocks.editor.containerTagNames',
+		[
+			{ label: 'div', value: 'div' },
+			{ label: 'article', value: 'article' },
+			{ label: 'section', value: 'section' },
+			{ label: 'header', value: 'header' },
+			{ label: 'footer', value: 'footer' },
+			{ label: 'aside', value: 'aside' },
+		],
+		props,
+		{ deviceType: device }
+	);
+
+	return (
+		<>
+			<SelectControl
+				label={ __( 'Tag Name', 'generateblocks' ) }
+				value={ tagName }
+				options={ tagNames }
+				onChange={ onChange }
+			/>
+		</>
+	);
+}

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -77,7 +77,10 @@ const ContainerEdit = ( props ) => {
 				/>
 			</GenerateBlocksInspectorControls>
 
-			<InspectorAdvancedControls { ...props } />
+			<InspectorAdvancedControls
+				{ ...props }
+				filterTagName={ filterTagName }
+			/>
 
 			<GoogleFontLink
 				fontFamily={ fontFamily }


### PR DESCRIPTION
This moves the Container tagName option to the Advanced panel.

It also removes the `containerAfterElementTag` filter as we're not using it.