### PR TITLE
Tweak: Change panel icon color

### DIFF
--- a/src/shared/editor.scss
+++ b/src/shared/editor.scss
@@ -21,6 +21,10 @@
 			padding: 10px;
 		}
 	}
+
+	.components-panel__icon {
+		color: currentColor;
+	}
 }
 
 .gblocks-panel-label svg.components-panel__icon {


### PR DESCRIPTION
This makes the panel icons the same color as the text.

![panel-icon](https://user-images.githubusercontent.com/20714883/197899144-4f72a374-38cf-4c46-9f21-f0045c6c9b5d.jpg)
