### PR TITLE
Tweak: Simplify button layout when inserted

### DIFF
--- a/includes/defaults.php
+++ b/includes/defaults.php
@@ -64,9 +64,6 @@ function generateblocks_get_default_styles() {
 			'paddingRight' => $defaults['button']['paddingRight'] ? $defaults['button']['paddingRight'] : '20',
 			'paddingBottom' => $defaults['button']['paddingBottom'] ? $defaults['button']['paddingBottom'] : '15',
 			'paddingLeft' => $defaults['button']['paddingLeft'] ? $defaults['button']['paddingLeft'] : '20',
-			'display' => 'inline-flex',
-			'alignItems' => 'center',
-			'justifyContent' => 'center',
 		),
 		'container' => array(
 			'gridItemPaddingTop' => '',

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -30,6 +30,7 @@ const ButtonEdit = ( props ) => {
 		isBlockPreview = false,
 		hasButtonContainer,
 		blockVersion,
+		display,
 	} = attributes;
 
 	const ref = useRef( null );
@@ -67,7 +68,10 @@ const ButtonEdit = ( props ) => {
 	useEffect( () => {
 		// Add our default Button styles when inserted.
 		if ( wasBlockJustInserted( attributes ) && ! blockVersion ) {
-			setAttributes( generateBlocksStyling.button );
+			setAttributes( {
+				...generateBlocksStyling.button,
+				display: ! display ? 'inline-block' : display,
+			} );
 		}
 	}, [] );
 


### PR DESCRIPTION
There's no need to set `inline-flex` and other flexbox attributes on newly inserted buttons.

Instead, let's just set `inline-block` unless another `display` exists (from a template, for example).

`inline-flex` and `align-items: center` should still be set automatically when a user adds an icon.