### PR TITLE
Update class-dynamic-content.php

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -651,7 +651,7 @@ class GenerateBlocks_Dynamic_Content {
 			}
 		}
 
-		return $id;
+		return apply_filters( 'generate_dynamic_content_source_id', $id, $attributes );
 	}
 
 	/**


### PR DESCRIPTION
The `get_source_id()` function in class-block-elements.php of GPP has a filter that is indispensable for some applications.  This provides one for GB.