### PR TITLE
Tweak: Remove block description from inspector controls

### DIFF
--- a/src/extend/inspector-control/controls/responsive-tabs/editor.scss
+++ b/src/extend/inspector-control/controls/responsive-tabs/editor.scss
@@ -6,6 +6,17 @@
     z-index: 10;
     display: flex;
 
+	& + .block-editor-block-card {
+		.block-editor-block-card__description {
+			display: none;
+		}
+
+		.block-editor-block-card__title,
+		.block-editor-block-card__content {
+			margin-bottom: 0;
+		}
+	}
+
 	button {
 	    flex-grow: 1;
 	    justify-content: center;


### PR DESCRIPTION
This removes the block description from the inspector controls to free up a little vertical space.

![block-descriptions](https://user-images.githubusercontent.com/20714883/201168694-7a094d14-fa7b-4da3-aceb-65d34e4a2285.jpg)
