### PR TITLE
Add filter to control query loop posts cap in the editor

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -79,6 +79,7 @@ function generateblocks_do_block_editor_assets() {
 				'square' => GENERATEBLOCKS_DIR_URL . 'assets/images/square-image-placeholder.png',
 			),
 			'globalContainerWidth' => generateblocks_get_global_container_width(),
+			'queryLoopEditorPostsCap' => apply_filters( 'generateblocks_query_loop_editor_posts_cap', 50 ), // phpcs:ignore -- Core filter.
 		)
 	);
 

--- a/src/blocks/query-loop/components/inspector-controls/parameter-list/ControlBuilder.js
+++ b/src/blocks/query-loop/components/inspector-controls/parameter-list/ControlBuilder.js
@@ -1,5 +1,5 @@
 import { ToggleControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import SelectPostType from '../../../../../extend/dynamic-content/components/SelectPostType';
 import SimpleSelect from '../../../../../components/simple-select';
 import AuthorsSelect from '../../../../../components/authors-select';
@@ -59,8 +59,11 @@ export default function ControlBuilder( props ) {
 	const Control = getParameterControl( type );
 	let controlDescription = description;
 
-	if ( 'per_page' === id && ( '-1' === value || value > 50 ) ) {
-		controlDescription += ' ' + __( 'Editor only: A maximum of 50 posts can be previewed in the editor.', 'generateblocks' );
+	if ( 'per_page' === id && ( '-1' === value || parseInt( value ) > parseInt( generateBlocksInfo.queryLoopEditorPostsCap ) ) ) {
+		controlDescription += ' ' + sprintf(
+			'Editor only: A maximum of %s posts can be previewed in the editor.',
+			generateBlocksInfo.queryLoopEditorPostsCap
+		);
 	}
 
 	const defaultValuePlaceholder = !! defaultValue && ( ! isArray( defaultValue ) || ! isObject( defaultValue ) )

--- a/src/blocks/query-loop/components/utils.js
+++ b/src/blocks/query-loop/components/utils.js
@@ -56,9 +56,9 @@ export function normalizeRepeatableArgs( query ) {
 export function normalizeArgs( query ) {
 	const defaultPerPage = !! query.per_page ? query.per_page : 10;
 
-	// In the editor we capped to 50 posts.
-	const perPage = '-1' === query.per_page || query.per_page > 50
-		? 50
+	// In the editor we capped the posts.
+	const perPage = '-1' === query.per_page || parseInt( query.per_page ) > parseInt( generateBlocksInfo.queryLoopEditorPostsCap )
+		? generateBlocksInfo.queryLoopEditorPostsCap
 		: defaultPerPage;
 
 	let sticky;


### PR DESCRIPTION
This PR adds a filter to control the cap of posts in the editor for the Query Loop block.

Reference: https://community.generateblocks.com/t/query-loop-spiking-cpu/816/6