### PR TITLE
Fix: get_the_excerpt notice with no source ID

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -651,7 +651,11 @@ class GenerateBlocks_Dynamic_Content {
 			}
 		}
 
-		return $id;
+		return apply_filters(
+			'generateblocks_dynamic_source_id',
+			$id,
+			$attributes
+		);
 	}
 
 	/**

--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -158,7 +158,7 @@ class GenerateBlocks_Dynamic_Content {
 		$unique_id = $attributes['uniqueId'];
 
 		// This prevents endless loops by not rendering excerpts within themselves.
-		if ( isset( self::$source_ids[ $unique_id ] ) && $source_id === self::$source_ids[ $unique_id ] ) {
+		if ( ! $source_id || ( isset( self::$source_ids[ $unique_id ] ) && $source_id === self::$source_ids[ $unique_id ] ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
close #765 

This prevents a PHP notice when using a dynamic excerpt on a page with no ID.

It also adds a new filter so we can filter the source ID.