### PR TITLE
Tweak: Migrate GPP Element inline option

### DIFF
--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -15,6 +15,10 @@ function getLayoutAttributes( attributes ) {
 		verticalAlignmentTablet,
 		verticalAlignmentMobile,
 		sizing,
+		gpInlinePostMeta,
+		gpInlinePostMetaJustify,
+		gpInlinePostMetaJustifyTablet,
+		gpInlinePostMetaJustifyMobile,
 	} = attributes;
 
 	const layoutAttributes = {};
@@ -63,6 +67,27 @@ function getLayoutAttributes( attributes ) {
 
 	if ( isGrid && verticalAlignmentMobile && 'inherit' !== verticalAlignmentMobile ) {
 		layoutAttributes.justifyContentMobile = verticalAlignmentMobile;
+	}
+
+	if ( gpInlinePostMeta ) {
+		layoutAttributes.display = 'flex';
+		layoutAttributes.alignItems = 'center';
+		layoutAttributes.gpInlinePostMeta = false;
+
+		if ( gpInlinePostMetaJustify ) {
+			layoutAttributes.justifyContent = gpInlinePostMetaJustify;
+			layoutAttributes.gpInlinePostMetaJustify = '';
+		}
+
+		if ( gpInlinePostMetaJustifyTablet ) {
+			layoutAttributes.justifyContentTablet = gpInlinePostMetaJustifyTablet;
+			layoutAttributes.gpInlinePostMetaJustifyTablet = '';
+		}
+
+		if ( gpInlinePostMetaJustifyMobile ) {
+			layoutAttributes.justifyContentMobile = gpInlinePostMetaJustifyMobile;
+			layoutAttributes.gpInlinePostMetaJustifyMobile = '';
+		}
 	}
 
 	return layoutAttributes;


### PR DESCRIPTION
This migrates the "Inline post meta items" option in GPP Elements to use our Layout options when we turn off the Inner Container.

Kind of sucks adding GPP stuff into GB. If we want to avoid that we would need to insert a filter here instead. Only issue with that is if the user runs the migration before updating GPP.