### PR TITLE
Fix: No spaces in RichText using button tag name

### DIFF
--- a/src/blocks/button/components/ButtonContentRenderer.js
+++ b/src/blocks/button/components/ButtonContentRenderer.js
@@ -73,7 +73,13 @@ export default function ButtonContentRenderer( props ) {
 		props
 	) ? [] : [ 'core/bold', 'core/italic', 'core/strikethrough' ];
 
-	const buttonTagName = applyFilters( 'generateblocks.frontend.buttonTagName', url ? 'a' : 'span', props );
+	let buttonTagName = applyFilters( 'generateblocks.frontend.buttonTagName', url ? 'a' : 'span', props );
+
+	// The `button` element prevents RichText from allowing spaces.
+	// To fix that we'll return a `span` element in the editor only.
+	if ( 'button' === buttonTagName ) {
+		buttonTagName = 'span';
+	}
 
 	return (
 		<RootElement name={ name } clientId={ clientId }>


### PR DESCRIPTION
The `button` tag name makes it so the `RichText` component doesn't accept spaces.

This returns a `span` if `button` is set as the tag name to prevent this.