### PR TITLE
Feature: Make sizing units consistent

### DIFF
--- a/src/extend/inspector-control/controls/sizing/components/Height.js
+++ b/src/extend/inspector-control/controls/sizing/components/Height.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function Height( { value, desktopValue, tabletValue, onChange } ) {
+export default function Height( { value, desktopValue, tabletValue, onChange, units } ) {
 	return (
 		<UnitControl
 			label={ __( 'Height', 'generateblocks' ) }
 			id="gblocks-height"
-			units={ [ 'px', '%', 'vw', 'rem' ] }
+			units={ units }
 			value={ value }
 			desktopValue={ desktopValue }
 			tabletValue={ tabletValue }

--- a/src/extend/inspector-control/controls/sizing/components/MaxHeight.js
+++ b/src/extend/inspector-control/controls/sizing/components/MaxHeight.js
@@ -1,13 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function MaxHeight( { value, desktopValue, tabletValue, onChange } ) {
+export default function MaxHeight( { value, desktopValue, tabletValue, onChange, units } ) {
 	return (
 		<>
 			<UnitControl
 				label={ __( 'Max Height', 'generateblocks' ) }
 				id="gblocks-max-height"
-				units={ [ 'px', '%', 'vw', 'rem' ] }
+				units={ units }
 				value={ value }
 				desktopValue={ desktopValue }
 				tabletValue={ tabletValue }

--- a/src/extend/inspector-control/controls/sizing/components/MaxWidth.js
+++ b/src/extend/inspector-control/controls/sizing/components/MaxWidth.js
@@ -1,13 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function MaxWidth( { value, desktopValue, tabletValue, onChange, disabled, overrideValue } ) {
+export default function MaxWidth( { value, desktopValue, tabletValue, onChange, disabled, overrideValue, units } ) {
 	return (
 		<>
 			<UnitControl
 				label={ __( 'Max Width', 'generateblocks' ) }
 				id="gblocks-max-width"
-				units={ [ 'px', '%', 'vw', 'rem' ] }
+				units={ units }
 				overrideValue={ overrideValue }
 				disabled={ disabled }
 				value={ value }

--- a/src/extend/inspector-control/controls/sizing/components/MinHeight.js
+++ b/src/extend/inspector-control/controls/sizing/components/MinHeight.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function MinHeight( { value, desktopValue, tabletValue, onChange } ) {
+export default function MinHeight( { value, desktopValue, tabletValue, onChange, units } ) {
 	return (
 		<UnitControl
 			label={ __( 'Min Height', 'generateblocks' ) }
 			id="gblocks-min-height"
-			units={ [ 'px', 'vh', 'vw' ] }
+			units={ units }
 			value={ value }
 			desktopValue={ desktopValue }
 			tabletValue={ tabletValue }

--- a/src/extend/inspector-control/controls/sizing/components/MinWidth.js
+++ b/src/extend/inspector-control/controls/sizing/components/MinWidth.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function MinWidth( { value, desktopValue, tabletValue, onChange, disabled } ) {
+export default function MinWidth( { value, desktopValue, tabletValue, onChange, disabled, units } ) {
 	return (
 		<UnitControl
 			label={ __( 'Min Width', 'generateblocks' ) }
 			id="gblocks-min-width"
-			units={ [ 'px', 'vh', 'vw' ] }
+			units={ units }
 			value={ value }
 			desktopValue={ desktopValue }
 			tabletValue={ tabletValue }

--- a/src/extend/inspector-control/controls/sizing/components/Width.js
+++ b/src/extend/inspector-control/controls/sizing/components/Width.js
@@ -7,13 +7,14 @@ export default function Width( props ) {
 		desktopValue,
 		tabletValue,
 		onChange,
+		units,
 	} = props;
 
 	return (
 		<UnitControl
 			label={ __( 'Width', 'generateblocks' ) }
 			id="gblocks-width"
-			units={ [ 'px', '%', 'vw', 'rem' ] }
+			units={ units }
 			value={ value }
 			desktopValue={ desktopValue }
 			tabletValue={ tabletValue }

--- a/src/extend/inspector-control/controls/sizing/index.js
+++ b/src/extend/inspector-control/controls/sizing/index.js
@@ -4,6 +4,7 @@ import getIcon from '../../../../utils/get-icon';
 import { useContext } from '@wordpress/element';
 import ControlsContext from '../../../../block-context';
 import { ToggleControl } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 import MinHeight from './components/MinHeight';
 import getAttribute from '../../../../utils/get-attribute';
 import { useDeviceType } from '../../../../hooks';
@@ -35,6 +36,14 @@ export default function Sizing( props ) {
 			: '';
 	}
 
+	function getUnits( context ) {
+		return applyFilters(
+			'generateblocks.editor.sizingUnits',
+			[ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ],
+			context
+		);
+	}
+
 	return (
 		<PanelArea
 			title={ __( 'Sizing', 'generateblocks' ) }
@@ -49,6 +58,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'width' ) }
 						desktopValue={ sizing?.width }
 						tabletValue={ sizing?.widthTablet }
+						units={ getUnits( 'width' ) }
 						onChange={ ( value ) => {
 							setAttributes( {
 								sizing: {
@@ -65,6 +75,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'height' ) }
 						desktopValue={ sizing?.height }
 						tabletValue={ sizing?.heightTablet }
+						units={ getUnits( 'height' ) }
 						onChange={ ( value ) => {
 							setAttributes( {
 								sizing: {
@@ -81,6 +92,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'minWidth' ) }
 						desktopValue={ sizing?.minWidth }
 						tabletValue={ sizing?.minWidthTablet }
+						units={ getUnits( 'minWidth' ) }
 						disabled={ isGrid }
 						onChange={ ( value ) => {
 							setAttributes( {
@@ -98,6 +110,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'minHeight' ) }
 						desktopValue={ sizing?.minHeight }
 						tabletValue={ sizing?.minHeightTablet }
+						units={ getUnits( 'minHeight' ) }
 						onChange={ ( value ) => {
 							setAttributes( {
 								sizing: {
@@ -114,6 +127,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'maxWidth' ) }
 						desktopValue={ sizing?.maxWidth }
 						tabletValue={ sizing?.maxWidthTablet }
+						units={ getUnits( 'maxWidth' ) }
 						overrideValue={ !! useGlobalContainerWidth ? generateBlocksInfo.globalContainerWidth : null }
 						disabled={ useInnerContainer || useGlobalContainerWidth || isGrid }
 						onChange={ ( value ) => {
@@ -132,6 +146,7 @@ export default function Sizing( props ) {
 						value={ getValue( 'maxHeight' ) }
 						desktopValue={ sizing?.maxHeight }
 						tabletValue={ sizing?.maxHeightTablet }
+						units={ getUnits( 'maxHeight' ) }
 						onChange={ ( value ) => {
 							setAttributes( {
 								sizing: {


### PR DESCRIPTION
This makes it so all our Sizing controls use the same set of units.

They can also be filtered per-control with the `generateblocks.editor.sizingUnits` filter.