### PR TITLE
Feature: Add template selector system

### DIFF
--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -11,6 +11,7 @@ import ContainerContentRenderer from './components/ContainerContentRenderer';
 import GenerateBlocksInspectorControls from '../../extend/inspector-control';
 import { withBlockContext } from '../../block-context';
 import { useSelect } from '@wordpress/data';
+import { withTemplateContext } from '../../extend/template-selector/templateContext';
 
 const ContainerEdit = ( props ) => {
 	const {
@@ -139,6 +140,7 @@ const ContainerEdit = ( props ) => {
 };
 
 export default compose(
+	withTemplateContext,
 	withBlockContext,
 	withDynamicContent,
 	withUniqueId,

--- a/src/extend/template-selector/editor.scss
+++ b/src/extend/template-selector/editor.scss
@@ -1,0 +1,15 @@
+.editor-styles-wrapper {
+  .gb-templates-wrapper {
+	display: flex;
+	gap: 16px;
+
+	.gb-template-selector-button {
+	  font-size: 13px;
+	  display: inline-flex;
+	  flex-direction: column;
+	  height: 100%;
+	  padding: 0;
+	  gap: 8px;
+	}
+  }
+}

--- a/src/extend/template-selector/index.js
+++ b/src/extend/template-selector/index.js
@@ -1,0 +1,38 @@
+import './editor.scss';
+import { Button, Placeholder } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
+import TemplateContext from './templateContext';
+import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+
+export default function TemplateSelector( { clientId } ) {
+	const { label, instructions, templates } = useContext( TemplateContext );
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+
+	return (
+		<div className="wp-block">
+			<Placeholder
+				label={ label }
+				instructions={ instructions }
+				className="gb-select-layout"
+			>
+				<div className="gb-templates-wrapper">
+					{ templates && templates.map( ( template ) => (
+						<Button
+							key={ `template-${ template.id }` }
+							className="gb-template-selector-button"
+							onClick={ () => {
+								replaceInnerBlocks(
+									clientId,
+									createBlocksFromInnerBlocksTemplate( template.innerBlocks )
+								);
+							} }
+						>
+							{ template.icon }<span>{ template.label }</span>
+						</Button>
+					) ) }
+				</div>
+			</Placeholder>
+		</div>
+	);
+}

--- a/src/extend/template-selector/templateContext.js
+++ b/src/extend/template-selector/templateContext.js
@@ -1,0 +1,33 @@
+import { applyFilters } from '@wordpress/hooks';
+import { createContext } from '@wordpress/element';
+import { useInnerBlocksCount } from '../../hooks';
+import TemplateSelector from './index';
+
+const defaultContext = {
+	label: 'Label',
+	instructions: 'Instructions...',
+	templates: [],
+};
+
+const TemplateContext = createContext( defaultContext );
+
+export const withTemplateContext = ( WrappedComponent ) => ( ( props ) => {
+	const { clientId } = props;
+	const innerBlocksCount = useInnerBlocksCount( clientId );
+	const templateContext = applyFilters(
+		'generateblocks.editor.templateContext',
+		defaultContext,
+		props
+	);
+
+	return (
+		<TemplateContext.Provider value={ templateContext }>
+			{ 0 < templateContext.templates.length && 0 === innerBlocksCount
+				? <TemplateSelector { ...props } />
+				: <WrappedComponent { ...props } />
+			}
+		</TemplateContext.Provider>
+	);
+} );
+
+export default TemplateContext;


### PR DESCRIPTION
This adds a system for the template selector, currently enabled for the container block.

Usage:

```js
wp.hooks.addFilter(
	'generateblocks.editor.templateContext',
	'testing-template-context',
	function( context, props ) {
		return {
			label: 'Label',
			instructions: 'Instructions',
			templates: [
				{
					id: 'vertical-tabs',
					label: 'Vertical tabs',
					icon: getIcon( 'shapes' ),
					innerBlocks: [
						[ 'generateblocks/headline', {
							element: 'h3',
							content: 'My vertical template',
						} ],
					],
				},
			],
		};
	}
);
```
![image](https://user-images.githubusercontent.com/7506830/204319436-a2e8b01e-ea29-479e-a7df-c51231308594.png)

