### PR TITLE
Feature: Add generateblocks.editor.renderBlock hook

### DIFF
--- a/src/blocks/button/components/ButtonContentRenderer.js
+++ b/src/blocks/button/components/ButtonContentRenderer.js
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import Element from '../../../components/element';
 import RootElement from '../../../components/root-element';
 import classnames from 'classnames';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 
 export default function ButtonContentRenderer( props ) {
 	const {
@@ -81,6 +81,8 @@ export default function ButtonContentRenderer( props ) {
 	if ( 'button' === buttonType ) {
 		buttonTagName = 'span';
 	}
+
+	doAction( 'generateblocks.editor.renderBlock', { ...props, ref: buttonRef } );
 
 	return (
 		<RootElement name={ name } clientId={ clientId }>

--- a/src/blocks/container/components/ContainerContentRenderer.js
+++ b/src/blocks/container/components/ContainerContentRenderer.js
@@ -1,6 +1,6 @@
 import RootElement from '../../../components/root-element';
 import GridItem from './GridItem';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 import { useBlockProps, store as blockEditorStore, useInnerBlocksProps } from '@wordpress/block-editor';
 import ShapeDividers from './ShapeDividers';
 import classnames from 'classnames';
@@ -18,6 +18,7 @@ export default function ContainerContentRenderer( props ) {
 		filterTagName,
 		allShapes,
 		deviceType,
+		containerRef,
 	} = props;
 
 	const {
@@ -66,6 +67,7 @@ export default function ContainerContentRenderer( props ) {
 		} ),
 		id: anchor ? anchor : null,
 		'data-align': align && ! supportsLayout ? align : null,
+		ref: containerRef,
 	};
 
 	const backgroundUrl = getBackgroundImageUrl( props );
@@ -101,6 +103,7 @@ export default function ContainerContentRenderer( props ) {
 		}
 	);
 
+	doAction( 'generateblocks.editor.renderBlock', { ...props, ref: containerRef } );
 	const containerBlockProps = useInnerContainer ? blockProps : innerBlocksProps;
 
 	return (

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -2,7 +2,7 @@ import BlockControls from './components/BlockControls';
 import InspectorAdvancedControls from './components/InspectorAdvancedControls';
 import GoogleFontLink from '../../components/google-font-link';
 import { applyFilters } from '@wordpress/hooks';
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment, useEffect, useRef } from '@wordpress/element';
 import { useDeviceType } from '../../hooks';
 import { compose } from '@wordpress/compose';
 import { withUniqueId, withContainerLegacyMigration } from '../../hoc';
@@ -31,6 +31,7 @@ const ContainerEdit = ( props ) => {
 		isQueryLoopItem,
 	} = attributes;
 
+	const ref = useRef( null );
 	const [ deviceType ] = useDeviceType();
 
 	const allowedTagNames = applyFilters(
@@ -133,6 +134,7 @@ const ContainerEdit = ( props ) => {
 				filterTagName={ filterTagName }
 				allShapes={ allShapes }
 				deviceType={ deviceType }
+				containerRef={ ref }
 			/>
 		</Fragment>
 	);

--- a/src/blocks/headline/components/HeadlineContentRenderer.js
+++ b/src/blocks/headline/components/HeadlineContentRenderer.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import RootElement from '../../../components/root-element';
@@ -71,6 +71,8 @@ export default function HeadlineContentRenderer( props ) {
 
 		return richTextFormats;
 	}, [ linkAllowedFormats, richTextFormats, dynamicLinkType ] );
+
+	doAction( 'generateblocks.editor.renderBlock', { ...props, ref: headlineRef } );
 
 	return (
 		<RootElement name={ name } clientId={ clientId }>

--- a/src/blocks/image/components/ImageContentRenderer.js
+++ b/src/blocks/image/components/ImageContentRenderer.js
@@ -9,7 +9,7 @@ import { useRef, useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import getDynamicImage from '../../../utils/get-dynamic-image';
 import getMediaUrl from '../../../utils/get-media-url';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction } from '@wordpress/hooks';
 
 export default function ImageContentRenderer( props ) {
 	const {
@@ -131,6 +131,8 @@ export default function ImageContentRenderer( props ) {
 		attributes,
 		temporaryURL,
 	};
+
+	doAction( 'generateblocks.editor.renderBlock', { ...props, ref: imageRef } );
 
 	return (
 		<>


### PR DESCRIPTION
This adds a `generateblocks.editor.renderBlock` hook to the Container, Button, Headline and Image blocks.

It allows us to hook into the rendering of these blocks with the available props and ref.