### PR TITLE
Tweak: Add current button colors

### DIFF
--- a/src/blocks/button/css/main.js
+++ b/src/blocks/button/css/main.js
@@ -71,6 +71,9 @@ export default class MainCSS extends Component {
 			iconSizeUnit,
 			hasButtonContainer,
 			alignment,
+			backgroundColorCurrent,
+			textColorCurrent,
+			borderColorCurrent,
 		} = attributes;
 
 		let fontFamilyFallbackValue = '',
@@ -128,6 +131,12 @@ export default class MainCSS extends Component {
 				'border-style': 'solid',
 			} );
 		}
+
+		cssObj[ selector + '[data-button-is-current]' ] = [ {
+			'background-color': backgroundColorCurrent,
+			color: textColorCurrent,
+			'border-color': borderColorCurrent,
+		} ];
 
 		cssObj[ selector + ':hover, ' + selector + ':focus, ' + selector + ':active' ] = [ {
 			'background-color': hexToRGBA( backgroundColorHover, backgroundColorHoverOpacity ),


### PR DESCRIPTION
This adds the current button color CSS to the editor if the button has the `[data-button-is-current]` attribute. This can be used by accordions and tabs to style the current button.