### PR TITLE
Feature: Add position and overflow options

### DIFF
--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -243,19 +243,21 @@ class GenerateBlocks_Block_Container {
 			$css->add_property( 'background-image', $gradientValue );
 		}
 
-		if (
-			( $hasBgImage && 'pseudo-element' === $settings['bgOptions']['selector'] ) ||
-			$settings['zindex'] ||
-			( $settings['gradient'] && 'pseudo-element' === $settings['gradientSelector'] )
-		) {
-			$css->add_property( 'position', 'relative' );
-		}
+		if ( $useInnerContainer ) {
+			if (
+				( $hasBgImage && 'pseudo-element' === $settings['bgOptions']['selector'] ) ||
+				$settings['zindex'] ||
+				( $settings['gradient'] && 'pseudo-element' === $settings['gradientSelector'] )
+			) {
+				$css->add_property( 'position', 'relative' );
+			}
 
-		if (
-			( $hasBgImage && 'pseudo-element' === $settings['bgOptions']['selector'] ) ||
-			( $settings['gradient'] && 'pseudo-element' === $settings['gradientSelector'] )
-		) {
-			$css->add_property( 'overflow', 'hidden' );
+			if (
+				( $hasBgImage && 'pseudo-element' === $settings['bgOptions']['selector'] ) ||
+				( $settings['gradient'] && 'pseudo-element' === $settings['gradientSelector'] )
+			) {
+				$css->add_property( 'overflow', 'hidden' );
+			}
 		}
 
 		if ( $blockVersion < 3 ) {
@@ -442,7 +444,10 @@ class GenerateBlocks_Block_Container {
 		 */
 		if ( ! empty( $settings['shapeDividers'] ) ) {
 			$css->set_selector( '.gb-container-' . $id );
-			$css->add_property( 'position', 'relative' );
+
+			if ( $useInnerContainer ) {
+				$css->add_property( 'position', 'relative' );
+			}
 
 			$default_styles = generateblocks_get_default_styles();
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1177,6 +1177,9 @@ function generateblocks_add_layout_css( $css, $settings, $device = '' ) {
 		'column-gap' => 'columnGap',
 		'row-gap' => 'rowGap',
 		'z-index' => 'zindex',
+		'position' => 'position',
+		'overflow-x' => 'overflowX',
+		'overflow-y' => 'overflowY',
 	];
 
 	foreach ( $options as $property => $option ) {

--- a/includes/general.php
+++ b/includes/general.php
@@ -345,6 +345,9 @@ function generateblocks_set_layout_component_defaults( $defaults ) {
 		'justifyContent',
 		'columnGap',
 		'rowGap',
+		'position',
+		'overflowX',
+		'overflowY',
 	];
 
 	foreach ( $defaults as $block => $values ) {

--- a/src/block-context/button.js
+++ b/src/block-context/button.js
@@ -19,6 +19,7 @@ const buttonContext = defaultsDeep( {
 			justifyContent: true,
 			columnGap: true,
 			rowGap: true,
+			position: true,
 		},
 		flexChildPanel: {
 			enabled: true,

--- a/src/block-context/container.js
+++ b/src/block-context/container.js
@@ -20,6 +20,8 @@ const containerContext = defaultsDeep( {
 			columnGap: true,
 			rowGap: true,
 			zIndex: true,
+			position: true,
+			overflow: true,
 		},
 		flexChildPanel: {
 			enabled: true,

--- a/src/block-context/default.js
+++ b/src/block-context/default.js
@@ -21,6 +21,8 @@ const defaultContext = {
 			columnGap: false,
 			rowGap: false,
 			zIndex: false,
+			position: false,
+			overflow: false,
 		},
 		flexChildPanel: {
 			enabled: false,

--- a/src/block-context/headline.js
+++ b/src/block-context/headline.js
@@ -15,6 +15,7 @@ const headlineContext = defaultsDeep( {
 			justifyContent: true,
 			columnGap: true,
 			rowGap: true,
+			position: true,
 		},
 		flexChildPanel: {
 			enabled: true,

--- a/src/blocks/container/css/main.js
+++ b/src/blocks/container/css/main.js
@@ -133,24 +133,35 @@ export default function MainCSS( props ) {
 		} );
 	}
 
-	if (
-		( hasBgImage && 'pseudo-element' === bgOptions.selector ) ||
-		zindex ||
-		( gradient && 'pseudo-element' === gradientSelector )
-	) {
-		cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
-			'position': 'relative', // eslint-disable-line quote-props
-		} );
+	if ( useInnerContainer ) {
+		if (
+			( hasBgImage && 'pseudo-element' === bgOptions.selector ) ||
+			zindex ||
+			( gradient && 'pseudo-element' === gradientSelector )
+		) {
+			cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
+				'position': 'relative', // eslint-disable-line quote-props
+			} );
+		}
+
+		if (
+			( hasBgImage && 'pseudo-element' === bgOptions.selector ) ||
+			( gradient && 'pseudo-element' === gradientSelector )
+		) {
+			cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
+				'overflow': 'hidden', // eslint-disable-line quote-props
+			} );
+
+			cssObj[ '.gb-container-' + uniqueId + ' .block-list-appender' ] = [ {
+				'z-index': 10,
+			} ];
+		}
 	}
 
 	if (
 		( hasBgImage && 'pseudo-element' === bgOptions.selector ) ||
 		( gradient && 'pseudo-element' === gradientSelector )
 	) {
-		cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
-			'overflow': 'hidden', // eslint-disable-line quote-props
-		} );
-
 		cssObj[ '.gb-container-' + uniqueId + ' .block-list-appender' ] = [ {
 			'z-index': 10,
 		} ];
@@ -280,9 +291,11 @@ export default function MainCSS( props ) {
 	}
 
 	if ( shapeDividers.length ) {
-		cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
-			position: 'relative',
-		} );
+		if ( useInnerContainer ) {
+			cssObj[ '.editor-styles-wrapper .gb-container-' + uniqueId ].push( {
+				position: 'relative',
+			} );
+		}
 
 		cssObj[ '.gb-container-' + uniqueId + ' .block-list-appender' ] = [ {
 			position: 'relative',

--- a/src/components/gradient/index.js
+++ b/src/components/gradient/index.js
@@ -48,6 +48,8 @@ class GradientControl extends Component {
 		const {
 			gradientSelector,
 			innerZindex,
+			useInnerContainer,
+			position,
 		} = attributes;
 
 		const selectorHelp = 'element' === gradientSelector ? __( 'Displays behind the background image.', 'generateblocks' ) : __( 'Displays in front of the background image.', 'generateblocks' );
@@ -94,10 +96,14 @@ class GradientControl extends Component {
 										gradientSelector: value,
 									} );
 
-									if ( ! hasNumericValue( innerZindex ) && 'pseudo-element' === value ) {
+									if ( useInnerContainer && ! hasNumericValue( innerZindex ) && 'pseudo-element' === value ) {
 										setAttributes( {
 											innerZindex: 1,
 										} );
+									}
+
+									if ( ! useInnerContainer && 'pseudo-element' === value && ! position ) {
+										setAttributes( { position: 'relative' } );
 									}
 								} }
 							/>

--- a/src/components/migrate-inner-container/index.js
+++ b/src/components/migrate-inner-container/index.js
@@ -22,7 +22,6 @@ export default function MigrateInnerContainer( props ) {
 
 	const {
 		getBlocksByClientId,
-		getBlockRootClientId,
 		getBlockParentsByBlockName,
 		getBlock,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
@@ -77,7 +76,6 @@ export default function MigrateInnerContainer( props ) {
 								attributes,
 								setAttributes,
 								parentBlock: getBlocksByClientId( clientId )[ 0 ],
-								hasParentBlock: getBlockRootClientId( clientId ),
 								insertBlocks,
 								removeBlocks,
 							} );

--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -15,6 +15,18 @@ function getLayoutAttributes( attributes ) {
 		verticalAlignmentTablet,
 		verticalAlignmentMobile,
 		sizing,
+		bgImage,
+		bgOptions,
+		useDynamicData,
+		dynamicContentType,
+		zindex,
+		gradient,
+		gradientSelector,
+		shapeDividers,
+		linkType,
+		url,
+		dynamicLinkType,
+		advBackgrounds,
 		gpInlinePostMeta,
 		gpInlinePostMetaJustify,
 		gpInlinePostMetaJustifyTablet,
@@ -69,6 +81,28 @@ function getLayoutAttributes( attributes ) {
 		layoutAttributes.justifyContentMobile = verticalAlignmentMobile;
 	}
 
+	const hasBgImage = !! bgImage || ( useDynamicData && '' !== dynamicContentType );
+
+	if ( zindex || shapeDividers.length ) {
+		layoutAttributes.position = 'relative';
+	}
+
+	if (
+		( hasBgImage && 'pseudo-element' === bgOptions.selector ) ||
+		( gradient && 'pseudo-element' === gradientSelector ) ||
+		advBackgrounds.length
+	) {
+		layoutAttributes.position = 'relative';
+		layoutAttributes.overflowX = 'hidden';
+		layoutAttributes.overflowY = 'hidden';
+	}
+
+	// GB Pro features.
+	if ( 'hidden-link' === linkType && ( url || ( useDynamicData && dynamicLinkType ) ) ) {
+		layoutAttributes.position = 'relative';
+	}
+
+	// GP Premium feature.
 	if ( gpInlinePostMeta ) {
 		layoutAttributes.display = 'flex';
 		layoutAttributes.alignItems = 'center';
@@ -205,6 +239,7 @@ function doInnerContainerMigration( props ) {
 			marginLeft: 'auto',
 			marginRight: 'auto',
 			zindex: innerZindex,
+			position: innerZindex || 0 === innerZindex ? 'relative' : '',
 		},
 		childBlocks
 	);

--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -167,6 +167,19 @@ function shouldMigrateInnerContainer( props ) {
 		recommend = true;
 	}
 
+	// Some effects target the inner container.
+	const effects = [ 'opacities', 'transitions', 'boxShadows', 'transforms', 'textShadows', 'filters' ];
+
+	effects.forEach( ( effect ) => {
+		const hasInnerContainerEffect =
+			attributes[ effect ] &&
+			attributes[ effect ].some( ( type ) => 'innerContainer' === type.target );
+
+		if ( hasInnerContainerEffect ) {
+			recommend = true;
+		}
+	} );
+
 	return recommend;
 }
 
@@ -181,7 +194,6 @@ function doInnerContainerMigration( props ) {
 		attributes,
 		setAttributes,
 		parentBlock,
-		hasParentBlock,
 		removeBlocks,
 		insertBlocks,
 	} = props;
@@ -264,7 +276,6 @@ function doInnerContainerMigration( props ) {
 		paddingBottomMobile: '',
 		paddingLeftMobile: '',
 		paddingUnit: generateBlocksDefaults.container.paddingUnit,
-		variantRole: ! hasParentBlock ? 'section' : '',
 		useGlobalContainerWidth: ! isGrid && 'contained' === outerContainer && !! hasDefaultContainerWidth,
 		marginLeft: ! isGrid && 'contained' === outerContainer ? 'auto' : marginLeft,
 		marginRight: ! isGrid && 'contained' === outerContainer ? 'auto' : marginRight,

--- a/src/extend/inspector-control/controls/background-panel/components/background-options.js
+++ b/src/extend/inspector-control/controls/background-panel/components/background-options.js
@@ -11,6 +11,10 @@ export default function BackgroundOptions( { attributes, setAttributes } ) {
 		useDynamicData,
 		dynamicContentType,
 		innerZindex,
+		useInnerContainer,
+		position,
+		overflowX,
+		overflowY,
 	} = attributes;
 
 	return (
@@ -40,8 +44,17 @@ export default function BackgroundOptions( { attributes, setAttributes } ) {
 						value={ bgOptions.selector }
 						onChange={ ( value ) => {
 							setAttributes( { bgOptions: { ...bgOptions, selector: value } } );
-							if ( 'pseudo-element' === value && ! innerZindex && 0 !== innerZindex ) {
+
+							if ( useInnerContainer && 'pseudo-element' === value && ! innerZindex && 0 !== innerZindex ) {
 								setAttributes( { innerZindex: 1 } );
+							}
+
+							if ( ! useInnerContainer && 'pseudo-element' === value ) {
+								setAttributes( {
+									position: ! position ? 'relative' : position,
+									overflowX: ! overflowX ? 'hidden' : overflowX,
+									overflowY: ! overflowY ? 'hidden' : overflowY,
+								} );
 							}
 						} }
 					/>
@@ -53,8 +66,17 @@ export default function BackgroundOptions( { attributes, setAttributes } ) {
 							setAttributes( {
 								bgOptions: { ...bgOptions, opacity: value, selector: 'pseudo-element' },
 							} );
-							if ( ! innerZindex && 0 !== innerZindex ) {
+
+							if ( useInnerContainer && ! innerZindex && 0 !== innerZindex ) {
 								setAttributes( { innerZindex: 1 } );
+							}
+
+							if ( ! useInnerContainer ) {
+								setAttributes( {
+									position: ! position ? 'relative' : position,
+									overflowX: ! overflowX ? 'hidden' : overflowX,
+									overflowY: ! overflowY ? 'hidden' : overflowY,
+								} );
 							}
 						} }
 					/>

--- a/src/extend/inspector-control/controls/layout/attributes.js
+++ b/src/extend/inspector-control/controls/layout/attributes.js
@@ -8,6 +8,9 @@ export default function getLayoutAttributes( defaults ) {
 		'justifyContent',
 		'columnGap',
 		'rowGap',
+		'position',
+		'overflowX',
+		'overflowY',
 	];
 
 	const attributes = {};

--- a/src/extend/inspector-control/controls/layout/components/FlexDirection.js
+++ b/src/extend/inspector-control/controls/layout/components/FlexDirection.js
@@ -1,7 +1,7 @@
 import { BaseControl, ButtonGroup, Button, Tooltip } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import flexOptions from '../options';
+import { flexOptions } from '../options';
 import './editor.scss';
 import classnames from 'classnames';
 

--- a/src/extend/inspector-control/controls/layout/components/LayoutCSS.js
+++ b/src/extend/inspector-control/controls/layout/components/LayoutCSS.js
@@ -14,6 +14,9 @@ export default function LayoutCSS( css, selector, attributes, device = '' ) {
 		styles[ 'column-gap' ] = attributes[ 'columnGap' + device ];
 		styles[ 'row-gap' ] = attributes[ 'rowGap' + device ];
 		styles.order = attributes[ 'order' + device ];
+		styles.position = attributes[ 'position' + device ];
+		styles[ 'overflow-x' ] = attributes[ 'overflowX' + device ];
+		styles[ 'overflow-y' ] = attributes[ 'overflowY' + device ];
 	}
 
 	return (

--- a/src/extend/inspector-control/controls/layout/components/LayoutControl.js
+++ b/src/extend/inspector-control/controls/layout/components/LayoutControl.js
@@ -1,6 +1,6 @@
 import { BaseControl, ButtonGroup, Button, Tooltip } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import flexOptions from '../options';
+import { flexOptions } from '../options';
 import './editor.scss';
 import classnames from 'classnames';
 

--- a/src/extend/inspector-control/controls/layout/index.js
+++ b/src/extend/inspector-control/controls/layout/index.js
@@ -15,6 +15,9 @@ import ZIndex from './components/ZIndex';
 import FlexChild from '../flex-child-panel';
 import MigrateInnerContainer from '../../../../components/migrate-inner-container';
 import UnitControl from '../../../../components/unit-control';
+import { SelectControl } from '@wordpress/components';
+import { positionOptions, overflowOptions } from './options';
+import FlexControl from '../../../../components/flex-control';
 
 export default function Layout( { attributes, setAttributes } ) {
 	const [ device ] = useDeviceType();
@@ -36,6 +39,7 @@ export default function Layout( { attributes, setAttributes } ) {
 		columnGapTablet,
 		rowGap,
 		rowGapTablet,
+		position,
 	} = attributes;
 
 	const directionValue = getResponsivePlaceholder( 'flexDirection', attributes, device, 'row' );
@@ -170,7 +174,12 @@ export default function Layout( { attributes, setAttributes } ) {
 					<ZIndex
 						label={ useInnerContainer && __( 'Outer z-index', 'generateblocks' ) }
 						value={ zindex }
-						onChange={ ( value ) => setAttributes( { zindex: value } ) }
+						onChange={ ( value ) => {
+							setAttributes( {
+								zindex: value,
+								position: ! position && ! useInnerContainer ? 'relative' : position,
+							} );
+						} }
 					/>
 
 					{ useInnerContainer &&
@@ -179,6 +188,43 @@ export default function Layout( { attributes, setAttributes } ) {
 							value={ innerZindex }
 							onChange={ ( value ) => setAttributes( { innerZindex: value } ) }
 						/>
+					}
+				</>
+			}
+
+			{ ! useInnerContainer &&
+				<>
+					{ layout.position &&
+						<SelectControl
+							label={ __( 'Position', 'generateblocks' ) }
+							value={ getAttribute( 'position', componentProps ) }
+							options={ positionOptions }
+							onChange={ ( value ) => setAttributes( {
+								[ getAttribute( 'position', componentProps, true ) ]: value,
+							} ) }
+						/>
+					}
+
+					{ layout.overflow &&
+						<FlexControl>
+							<SelectControl
+								label={ __( 'Overflow-x', 'generateblocks' ) }
+								value={ getAttribute( 'overflowX', componentProps ) }
+								options={ overflowOptions }
+								onChange={ ( value ) => setAttributes( {
+									[ getAttribute( 'overflowX', componentProps, true ) ]: value,
+								} ) }
+							/>
+
+							<SelectControl
+								label={ __( 'Overflow-y', 'generateblocks' ) }
+								value={ getAttribute( 'overflowY', componentProps ) }
+								options={ overflowOptions }
+								onChange={ ( value ) => setAttributes( {
+									[ getAttribute( 'overflowY', componentProps, true ) ]: value,
+								} ) }
+							/>
+						</FlexControl>
 					}
 				</>
 			}

--- a/src/extend/inspector-control/controls/layout/options.js
+++ b/src/extend/inspector-control/controls/layout/options.js
@@ -1,3 +1,4 @@
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 const flexOptions = {
@@ -81,4 +82,45 @@ const flexOptions = {
 	],
 };
 
-export default flexOptions;
+const positionOptions = applyFilters(
+	'generateblocks.editor.layoutPositionOptions',
+	[
+		{
+			label: __( 'Default', 'generateblocks' ),
+			value: '',
+		},
+		{
+			label: __( 'Relative', 'generateblocks' ),
+			value: 'relative',
+		},
+	]
+);
+
+const overflowOptions = [
+	{
+		label: __( 'Default', 'generateblocks' ),
+		value: '',
+	},
+	{
+		label: __( 'Visible', 'generateblocks' ),
+		value: 'visible',
+	},
+	{
+		label: __( 'Hidden', 'generateblocks' ),
+		value: 'hidden',
+	},
+	{
+		label: __( 'Scroll', 'generateblocks' ),
+		value: 'scroll',
+	},
+	{
+		label: __( 'Auto', 'generateblocks' ),
+		value: 'auto',
+	},
+];
+
+export {
+	flexOptions,
+	positionOptions,
+	overflowOptions,
+};

--- a/src/extend/inspector-control/controls/shapes-panel/index.js
+++ b/src/extend/inspector-control/controls/shapes-panel/index.js
@@ -25,6 +25,7 @@ export default function ShapesPanel( { attributes, setAttributes } ) {
 	const {
 		backgroundColor,
 		shapeDividers,
+		position,
 	} = attributes;
 
 	const allShapes = [];
@@ -58,7 +59,10 @@ export default function ShapesPanel( { attributes, setAttributes } ) {
 			zindex: generateBlocksStyling.container.shapeDividers.zindex,
 		} );
 
-		setAttributes( { shapeDividers: shapeDividersValues } );
+		setAttributes( {
+			shapeDividers: shapeDividersValues,
+			position: ! position ? 'relative' : position,
+		} );
 	};
 
 	const handleRemoveShape = ( index ) => {


### PR DESCRIPTION
This adds position options to our blocks and overflow options to our Container block.

It also adds migration for existing instances of `position` and `overflow` being used by other options.

![position-overflow](https://user-images.githubusercontent.com/20714883/204923657-2085caec-4b3d-42e2-97c8-97d36c583159.jpg)
