### PR TITLE
Add Global Style warning in inner container migration modal

### DIFF
--- a/src/blocks/container/editor.scss
+++ b/src/blocks/container/editor.scss
@@ -324,4 +324,5 @@ body.gutenberg-editor-page [data-type="generateblocks/container"] .editor-block-
 .gblocks-inner-container-notice {
 	margin: 0 0 1em;
 	background: rgba(0,0,0,0.03);
+	max-width: 700px;
 }

--- a/src/components/migrate-inner-container/index.js
+++ b/src/components/migrate-inner-container/index.js
@@ -13,6 +13,8 @@ export default function MigrateInnerContainer( props ) {
 
 	const {
 		useInnerContainer,
+		useGlobalStyle,
+		isGlobalStyle,
 	} = attributes;
 
 	const { clientId } = useContext( ControlsContext );
@@ -67,6 +69,21 @@ export default function MigrateInnerContainer( props ) {
 							: ' ' + __( 'No, we do not believe you need an inner Container block based on your current layout.', 'generateblocks' )
 						}
 					</Notice>
+
+					{ !! useGlobalStyle &&
+						<Notice status="warning" isDismissible={ false } className="gblocks-inner-container-notice">
+							<strong>{ __( 'Warning:', 'generateblocks' ) }</strong>
+							{ ' ' + __( 'This block is using a Global Style. If the Global Style targets the width of the legacy inner container, proceeding with this migration will prevent it from working.', 'generateblocks' ) }
+							<p style={ { 'margin-bottom': 0 } }>{ __( 'If that is the case, we suggest creating a separate Global Style for the inner container that this migration will create for you.', 'generateblocks' ) }</p>
+						</Notice>
+					}
+
+					{ !! isGlobalStyle &&
+						<Notice status="warning" isDismissible={ false } className="gblocks-inner-container-notice">
+							<strong>{ __( 'Warning:', 'generateblocks' ) }</strong>
+							{ ' ' + __( 'This block is a Global Style. If you migrate the inner container on this block you will need to make sure that all Container blocks using it are migrated as well.', 'generateblocks' ) }
+						</Notice>
+					}
 					<Button
 						variant={ !! migrateInnerContainer ? 'primary' : 'tertiary' }
 						style={ { marginRight: '5px' } }


### PR DESCRIPTION
We'll update this message to include a link to the documentation once we have it.