### PR TITLE
Improve global max-width option

### DIFF
--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -105,7 +105,6 @@ class GenerateBlocks_Block_Container {
 			'fontSizeUnit' => 'px',
 			'textTransform' => '',
 			'useInnerContainer' => false,
-			'useGlobalContainerWidth' => false,
 			'variantRole' => '',
 		];
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1220,7 +1220,7 @@ function generateblocks_add_sizing_css( $css, $settings, $device = '' ) {
 		$option_name = $option . $device;
 		$value = generateblocks_get_array_attribute_value( $option_name, $settings['sizing'] );
 
-		if ( 'max-width' === $property && ! empty( $settings['useGlobalContainerWidth'] ) && ! $device ) {
+		if ( 'max-width' === $property && ! empty( $settings['useGlobalMaxWidth'] ) && ! $device ) {
 			$value = generateblocks_get_global_container_width();
 		}
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -371,6 +371,7 @@ add_filter( 'generateblocks_defaults', 'generateblocks_set_sizing_component_defa
 function generateblocks_set_sizing_component_defaults( $defaults ) {
 	foreach ( $defaults as $block => $values ) {
 		$defaults[ $block ]['sizing'] = [];
+		$defaults[ $block ]['useGlobalMaxWidth'] = false;
 	}
 
 	return $defaults;

--- a/src/block-context/button.js
+++ b/src/block-context/button.js
@@ -35,6 +35,7 @@ const buttonContext = defaultsDeep( {
 			minHeight: true,
 			maxWidth: true,
 			maxHeight: true,
+			useGlobalMaxWidth: true,
 		},
 		typography: {
 			enabled: true,

--- a/src/block-context/headline.js
+++ b/src/block-context/headline.js
@@ -31,6 +31,7 @@ const headlineContext = defaultsDeep( {
 			minHeight: true,
 			maxWidth: true,
 			maxHeight: true,
+			useGlobalMaxWidth: true,
 		},
 		typography: {
 			enabled: true,

--- a/src/blocks/container/attributes.js
+++ b/src/blocks/container/attributes.js
@@ -257,10 +257,6 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	useGlobalContainerWidth: {
-		type: 'boolean',
-		default: false,
-	},
 	variantRole: {
 		type: 'string',
 		default: '',

--- a/src/blocks/container/block-controls.js
+++ b/src/blocks/container/block-controls.js
@@ -75,7 +75,7 @@ const withBlockControls = createHigherOrderComponent(
 								onClick={ () => {
 									insertBlocks(
 										createBlock( 'generateblocks/container', {
-											useGlobalContainerWidth: true,
+											useGlobalMaxWidth: true,
 											marginLeft: 'auto',
 											marginRight: 'auto',
 										} ),

--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -219,7 +219,7 @@ function doInnerContainerMigration( props ) {
 		innerZindex,
 		marginLeft,
 		marginRight,
-		useGlobalContainerWidth,
+		useGlobalMaxWidth,
 	} = attributes;
 
 	const childBlocks = parentBlock.innerBlocks;
@@ -243,7 +243,7 @@ function doInnerContainerMigration( props ) {
 			paddingBottomMobile,
 			paddingLeftMobile,
 			paddingUnit,
-			useGlobalContainerWidth: 'contained' === innerContainer ? !! hasDefaultContainerWidth : useGlobalContainerWidth,
+			useGlobalMaxWidth: 'contained' === innerContainer ? !! hasDefaultContainerWidth : useGlobalMaxWidth,
 			sizing: {
 				...attributes.sizing,
 				maxWidth: 'contained' === innerContainer && ! hasDefaultContainerWidth && containerWidth ? containerWidth + 'px' : '',
@@ -276,7 +276,7 @@ function doInnerContainerMigration( props ) {
 		paddingBottomMobile: '',
 		paddingLeftMobile: '',
 		paddingUnit: generateBlocksDefaults.container.paddingUnit,
-		useGlobalContainerWidth: ! isGrid && 'contained' === outerContainer && !! hasDefaultContainerWidth,
+		useGlobalMaxWidth: ! isGrid && 'contained' === outerContainer && !! hasDefaultContainerWidth,
 		marginLeft: ! isGrid && 'contained' === outerContainer ? 'auto' : marginLeft,
 		marginRight: ! isGrid && 'contained' === outerContainer ? 'auto' : marginRight,
 		sizing: {
@@ -313,7 +313,7 @@ function doSimpleMigration( props ) {
 
 	setAttributes( {
 		useInnerContainer: false,
-		useGlobalContainerWidth: ! isGrid && 'contained' === outerContainer && !! hasDefaultContainerWidth,
+		useGlobalMaxWidth: ! isGrid && 'contained' === outerContainer && !! hasDefaultContainerWidth,
 		marginLeft: ! isGrid && 'contained' === outerContainer ? 'auto' : marginLeft,
 		marginRight: ! isGrid && 'contained' === outerContainer ? 'auto' : marginRight,
 		sizing: {

--- a/src/components/unit-control/editor.scss
+++ b/src/components/unit-control/editor.scss
@@ -1,11 +1,33 @@
 .gblocks-unit-control {
 	&__disabled {
-		opacity: 0.5;
+		.gblocks-unit-control__input > *:not(.gblocks-unit-control__override-action):not(.popover-slot) {
+			opacity: 0.5;
+		}
+	}
+
+	&__override-action {
+		position: absolute;
+		right: 30px;
+		top: 0;
+
+		button.components-button {
+			width: 30px;
+			height: 30px;
+			min-width: 30px;
+			padding: 0;
+			justify-content: center !important;
+
+			svg {
+				width: 20px;
+				margin: 0 !important;
+			}
+		}
 	}
 
 	&__input {
 		display: flex;
 		align-items: flex-start;
+		position: relative;
 
 		.components-base-control:first-child {
 			flex-grow: 1;

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -22,6 +22,7 @@ export default function UnitControl( props ) {
 		id,
 		disabled = false,
 		overrideValue = null,
+		overrideAction = () => null,
 		onChange,
 		value,
 		desktopValue,
@@ -179,6 +180,8 @@ export default function UnitControl( props ) {
 						onFocus={ () => setShowPresets( true ) }
 						ref={ inputRef }
 					/>
+
+					{ !! overrideAction && <div className="gblocks-unit-control__override-action">{ overrideAction() } </div> }
 
 					{ (
 						startsWithNumber( numericValue ) ||

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -84,7 +84,7 @@ export default function UnitControl( props ) {
 
 	// Split the number and unit into two values.
 	useEffect( () => {
-		const newValue = overrideValue || value;
+		const newValue = overrideValue && disabled ? overrideValue : value;
 
 		// Split our values if we're starting with a number.
 		if ( startsWithNumber( newValue ) ) {
@@ -109,6 +109,8 @@ export default function UnitControl( props ) {
 			return;
 		}
 
+		const hasOverride = !! overrideValue && !! disabled;
+
 		const fullValue = startsWithNumber( numericValue )
 			? numericValue + unitValue
 			: numericValue;
@@ -129,7 +131,7 @@ export default function UnitControl( props ) {
 			}
 		}
 
-		if ( ! overrideValue && fullValue !== value ) {
+		if ( ! hasOverride && fullValue !== value ) {
 			onChange( fullValue );
 		}
 	}, [ numericValue, unitValue ] );

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -62,11 +62,12 @@ export default function UnitControl( props ) {
 					'Tablet' === device ||
 					(
 						'Mobile' === device &&
-						desktopValue
+						( desktopValue || overrideValue )
 					)
 				) {
-					setPlaceholderValue( getNumericValue( desktopValues ) );
-					setUnitValue( getUnitValue( desktopValues ) );
+					const overridePlaceholder = splitValues( overrideValue );
+					setPlaceholderValue( getNumericValue( desktopValues.length ? desktopValues : overridePlaceholder ) );
+					setUnitValue( getUnitValue( desktopValues.length ? desktopValues : overridePlaceholder ) );
 				}
 			}
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -113,10 +113,10 @@ class App extends Component {
 
 								<TextControl
 									type="number"
-									label={ __( 'Default Container Width', 'generateblocks' ) }
+									label={ __( 'Global max-width', 'generateblocks' ) }
 									help={ !! generateBlocksSettings.gpContainerWidth
-										? __( 'The default width of the Container block is set by GeneratePress in the Customizer.', 'generateblocks' )
-										: __( 'The default width of the Container block.', 'generateblocks' )
+										? __( 'The global max-width is set by GeneratePress in the Customizer.', 'generateblocks' )
+										: __( 'The global max-width value you can use in your blocks.', 'generateblocks' )
 									}
 									disabled={ !! generateBlocksSettings.gpContainerWidth }
 									value={ generateBlocksSettings.gpContainerWidth || this.getSetting( 'container_width' ) }

--- a/src/extend/inspector-control/controls/sizing/attributes.js
+++ b/src/extend/inspector-control/controls/sizing/attributes.js
@@ -4,5 +4,9 @@ export default function getSizingAttributes() {
 			type: 'object',
 			default: {},
 		},
+		useGlobalMaxWidth: {
+			type: 'boolean',
+			default: false,
+		},
 	};
 }

--- a/src/extend/inspector-control/controls/sizing/components/MaxWidth.js
+++ b/src/extend/inspector-control/controls/sizing/components/MaxWidth.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function MaxWidth( { value, desktopValue, tabletValue, onChange, disabled, overrideValue, units } ) {
+export default function MaxWidth( { value, desktopValue, tabletValue, onChange, disabled, overrideValue, units, overrideAction } ) {
 	return (
 		<>
 			<UnitControl
@@ -14,6 +14,7 @@ export default function MaxWidth( { value, desktopValue, tabletValue, onChange, 
 				desktopValue={ desktopValue }
 				tabletValue={ tabletValue }
 				onChange={ onChange }
+				overrideAction={ overrideAction }
 			/>
 		</>
 	);

--- a/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
+++ b/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
@@ -17,7 +17,7 @@ export default function SizingCSS( css, selector, attributes, device = '' ) {
 
 	if ( attributes.useInnerContainer ) {
 		delete styles[ 'max-width' ];
-	} else if ( attributes.useGlobalContainerWidth && ! device ) {
+	} else if ( attributes.useGlobalMaxWidth && ! device ) {
 		styles[ 'max-width' ] = generateBlocksInfo.globalContainerWidth;
 	}
 

--- a/src/extend/inspector-control/controls/sizing/index.js
+++ b/src/extend/inspector-control/controls/sizing/index.js
@@ -3,7 +3,8 @@ import PanelArea from '../../../../components/panel-area';
 import getIcon from '../../../../utils/get-icon';
 import { useContext } from '@wordpress/element';
 import ControlsContext from '../../../../block-context';
-import { ToggleControl } from '@wordpress/components';
+import { Tooltip, Button } from '@wordpress/components';
+import { globe } from '@wordpress/icons';
 import { applyFilters } from '@wordpress/hooks';
 import MinHeight from './components/MinHeight';
 import getAttribute from '../../../../utils/get-attribute';
@@ -138,6 +139,25 @@ export default function Sizing( props ) {
 								},
 							} );
 						} }
+						overrideAction={ () => {
+							if ( ! sizingPanel.useGlobalMaxWidth || useInnerContainer || isGrid || 'Desktop' !== device || getValue( 'maxWidth' ) ) {
+								return null;
+							}
+
+							return (
+								<Tooltip text={ __( 'Use global max-width', 'generateblocks' ) }>
+									<Button
+										icon={ globe }
+										isPrimary={ !! useGlobalMaxWidth }
+										onClick={ () => {
+											setAttributes( {
+												useGlobalMaxWidth: useGlobalMaxWidth ? false : true,
+											} );
+										} }
+									/>
+								</Tooltip>
+							);
+						} }
 					/>
 				}
 
@@ -158,19 +178,6 @@ export default function Sizing( props ) {
 					/>
 				}
 			</div>
-
-			{ sizingPanel.useGlobalMaxWidth && ! useInnerContainer && ! isGrid &&
-				<ToggleControl
-					label={ __( 'Use Global max-width', 'generateblocks' ) }
-					className={ 'gblocks-global-container-width' }
-					checked={ !! useGlobalContainerWidth }
-					onChange={ ( value ) => {
-						setAttributes( {
-							useGlobalContainerWidth: value,
-						} );
-					} }
-				/>
-			}
 		</PanelArea>
 	);
 }

--- a/src/extend/inspector-control/controls/sizing/index.js
+++ b/src/extend/inspector-control/controls/sizing/index.js
@@ -24,7 +24,7 @@ export default function Sizing( props ) {
 	} = props;
 
 	const {
-		useGlobalContainerWidth = false,
+		useGlobalMaxWidth = false,
 		useInnerContainer = false,
 		isGrid = false,
 		sizing,
@@ -128,8 +128,8 @@ export default function Sizing( props ) {
 						desktopValue={ sizing?.maxWidth }
 						tabletValue={ sizing?.maxWidthTablet }
 						units={ getUnits( 'maxWidth' ) }
-						overrideValue={ !! useGlobalContainerWidth ? generateBlocksInfo.globalContainerWidth : null }
-						disabled={ useInnerContainer || useGlobalContainerWidth || isGrid }
+						overrideValue={ !! useGlobalMaxWidth ? generateBlocksInfo.globalContainerWidth : null }
+						disabled={ useInnerContainer || isGrid || ( useGlobalMaxWidth && 'Desktop' === device ) }
 						onChange={ ( value ) => {
 							setAttributes( {
 								sizing: {


### PR DESCRIPTION
close #777 

This PR does a handful of things:

1. It changes the `useGlobalContainerWidth` attribute name to `useGlobalMaxWidth`
2. It moves the "Use global max-width" option into the `max-width` input as a button
3. It fixes a bug where you couldn't update the tablet/mobile max-width if you were using the global max-width on desktop.
4. It uses the global max-width as a placeholder on tablet and mobile if needed
5. It adds the global max-width option to the Button and Headline blocks

![global-max-width](https://user-images.githubusercontent.com/20714883/206270732-af6d83d2-f854-467a-a7f2-d8d3b4aea4f6.jpg)
