### PR TITLE
Add generateblocks.editor.settingsPanel filter

### DIFF
--- a/src/blocks/button-container/edit.js
+++ b/src/blocks/button-container/edit.js
@@ -68,7 +68,12 @@ const ButtonContainerEdit = ( props ) => {
 				deviceType={ deviceType }
 			/>
 
-			<GenerateBlocksInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
+			<GenerateBlocksInspectorControls
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			>
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
+			</GenerateBlocksInspectorControls>
 
 			<InspectorAdvancedControls anchor={ anchor } setAttributes={ setAttributes } />
 

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -89,7 +89,7 @@ const ButtonEdit = ( props ) => {
 				setAttributes={ setAttributes }
 				computedStyles={ computedStyles }
 			>
-				{ applyFilters( 'generateblocks.editor.buttonSettingsPanel', undefined, props ) }
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
 			</GenerateBlocksInspectorControls>
 
 			<InspectorAdvancedControls

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -112,7 +112,7 @@ const ContainerEdit = ( props ) => {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			>
-				{ applyFilters( 'generateblocks.editor.containerSettingsPanel', undefined, props ) }
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
 			</GenerateBlocksInspectorControls>
 
 			<InspectorAdvancedControls

--- a/src/blocks/grid/components/WidthControls.js
+++ b/src/blocks/grid/components/WidthControls.js
@@ -6,17 +6,17 @@ import getAttribute from '../../../utils/get-attribute';
 import { useDeviceType } from '../../../hooks';
 
 function GridItemSettings( content, props ) {
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, name } = props;
 	const { isGrid, sizing } = attributes;
 	const [ device ] = useDeviceType();
 
-	if ( ! isGrid ) {
+	if ( 'generateblocks/container' !== name || ! isGrid ) {
 		return content;
 	}
 
-	function getValue( name ) {
-		return sizing && sizing[ getAttribute( name, { attributes, deviceType: device }, true ) ]
-			? sizing[ getAttribute( name, { attributes, deviceType: device }, true ) ]
+	function getValue( attributeName ) {
+		return sizing && sizing[ getAttribute( attributeName, { attributes, deviceType: device }, true ) ]
+			? sizing[ getAttribute( attributeName, { attributes, deviceType: device }, true ) ]
 			: '';
 	}
 
@@ -60,7 +60,7 @@ function GridItemSettings( content, props ) {
 }
 
 addFilter(
-	'generateblocks.editor.containerSettingsPanel',
+	'generateblocks.editor.settingsPanel',
 	'generateblocks/grid/gridItemSettings',
 	GridItemSettings
 );

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -91,6 +91,8 @@ const GridEdit = ( props ) => {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			>
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
+
 				<InspectorControls
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/src/blocks/headline/edit.js
+++ b/src/blocks/headline/edit.js
@@ -85,7 +85,9 @@ const HeadlineEdit = ( props ) => {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				computedStyles={ computedStyles }
-			/>
+			>
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
+			</GenerateBlocksInspectorControls>
 
 			<InspectorAdvancedControls anchor={ anchor } setAttributes={ setAttributes } />
 

--- a/src/blocks/image/edit.js
+++ b/src/blocks/image/edit.js
@@ -16,6 +16,7 @@ import HTMLAnchor from '../../components/html-anchor';
 import { pick } from 'lodash';
 import { withBlockContext } from '../../block-context';
 import GenerateBlocksInspectorControls from '../../extend/inspector-control';
+import { applyFilters } from '@wordpress/hooks';
 
 function ImageEdit( props ) {
 	const {
@@ -164,6 +165,8 @@ function ImageEdit( props ) {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			>
+				{ applyFilters( 'generateblocks.editor.settingsPanel', undefined, { ...props, device: deviceType } ) }
+
 				<ImageSettingsControls
 					attributes={ attributes }
 					setAttributes={ setAttributes }


### PR DESCRIPTION
This adds a generic `generateblocks.editor.settingsPanel` filter to each block. We should use one filter name here as we can target specific blocks using the `name` props.