### PR TITLE
Tweak: Don't set default button styles when using variant

### DIFF
--- a/includes/defaults.php
+++ b/includes/defaults.php
@@ -64,6 +64,7 @@ function generateblocks_get_default_styles() {
 			'paddingRight' => $defaults['button']['paddingRight'] ? $defaults['button']['paddingRight'] : '20',
 			'paddingBottom' => $defaults['button']['paddingBottom'] ? $defaults['button']['paddingBottom'] : '15',
 			'paddingLeft' => $defaults['button']['paddingLeft'] ? $defaults['button']['paddingLeft'] : '20',
+			'display' => 'inline-flex',
 		),
 		'container' => array(
 			'gridItemPaddingTop' => '',

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -32,8 +32,8 @@ const ButtonEdit = ( props ) => {
 		isBlockPreview = false,
 		hasButtonContainer,
 		blockVersion,
-		display,
 		buttonType,
+		variantRole,
 	} = attributes;
 
 	const ref = useRef( null );
@@ -70,11 +70,8 @@ const ButtonEdit = ( props ) => {
 
 	useEffect( () => {
 		// Add our default Button styles when inserted.
-		if ( wasBlockJustInserted( attributes ) && ! blockVersion ) {
-			setAttributes( {
-				...generateBlocksStyling.button,
-				display: ! display ? 'inline-block' : display,
-			} );
+		if ( wasBlockJustInserted( attributes ) && ! blockVersion && ! variantRole ) {
+			setAttributes( generateBlocksStyling.button );
 		}
 	}, [] );
 


### PR DESCRIPTION
This checks to make sure a Button doesn't have a `variantRole` before it adds the default styling when it's inserted.

This allows us to define custom Button styling when adding variations without having them conflict with the default Button styling that happens when they're first inserted.