### PR TITLE
Tweak: Ignore button hover colors on current buttons

### DIFF
--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -233,7 +233,12 @@ class GenerateBlocks_Block_Button {
 			? ', ' . $selector . '.gb-button__current:visited'
 			: '';
 
-		$css->set_selector( $selector . '.gb-button__current' . $visited_selector );
+		$current_selector = sprintf(
+			'%1$s.gb-button__current, %1$s.gb-button__current:hover, %1$s.gb-button__current:active, %1$s.gb-button__current:focus',
+			$selector
+		);
+
+		$css->set_selector( $current_selector . $visited_selector );
 		$css->add_property( 'background-color', $settings['backgroundColorCurrent'] );
 		$css->add_property( 'color', $settings['textColorCurrent'] );
 		$css->add_property( 'border-color', $settings['borderColorCurrent'] );

--- a/src/blocks/button/css/main.js
+++ b/src/blocks/button/css/main.js
@@ -15,6 +15,7 @@ import {
 	applyFilters,
 } from '@wordpress/hooks';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import { sprintf } from '@wordpress/i18n';
 
 export default class MainCSS extends Component {
 	render() {
@@ -132,7 +133,12 @@ export default class MainCSS extends Component {
 			} );
 		}
 
-		cssObj[ selector + '[data-button-is-current]' ] = [ {
+		const currentSelector = sprintf(
+			'%1$s[data-button-is-current], %1$s[data-button-is-current]:hover, %1$s[data-button-is-current]:active, %1$s[data-button-is-current]:focus',
+			selector
+		);
+
+		cssObj[ currentSelector ] = [ {
 			'background-color': backgroundColorCurrent,
 			color: textColorCurrent,
 			'border-color': borderColorCurrent,


### PR DESCRIPTION
blocked by #784 

This makes it so Button hover colors don't apply to the "current" button class.