### PR TITLE
Tweak: Improve Grid row-gap back-compat

### DIFF
--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -44,6 +44,7 @@ class GenerateBlocks_Block_Grid {
 			'horizontalAlignment' => '',
 			'horizontalAlignmentTablet' => '',
 			'horizontalAlignmentMobile' => '',
+			'useLegacyRowGap' => false,
 		];
 	}
 
@@ -132,7 +133,7 @@ class GenerateBlocks_Block_Grid {
 		$css->add_property( 'align-items', $settings['verticalAlignment'] );
 		$css->add_property( 'justify-content', $settings['horizontalAlignment'] );
 
-		if ( $blockVersion > 2 ) {
+		if ( $blockVersion > 2 && ! $settings['useLegacyRowGap'] ) {
 			$css->add_property( 'row-gap', $settings['verticalGap'], 'px' );
 		}
 
@@ -143,13 +144,13 @@ class GenerateBlocks_Block_Grid {
 		$css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$css->add_property( 'padding-' . $gap_direction, $settings['horizontalGap'], 'px' );
 
-		if ( $blockVersion < 3 ) {
+		if ( $blockVersion < 3 || $settings['useLegacyRowGap'] ) {
 			$css->add_property( 'padding-bottom', $settings['verticalGap'], 'px' );
 		}
 
 		$tablet_css->set_selector( '.gb-grid-wrapper-' . $id );
 
-		if ( $blockVersion > 2 ) {
+		if ( $blockVersion > 2 && ! $settings['useLegacyRowGap'] ) {
 			$tablet_css->add_property( 'row-gap', $settings['verticalGapTablet'], 'px' );
 		}
 
@@ -170,13 +171,13 @@ class GenerateBlocks_Block_Grid {
 		$tablet_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$tablet_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapTablet'], 'px' );
 
-		if ( $blockVersion < 3 ) {
+		if ( $blockVersion < 3 || $settings['useLegacyRowGap'] ) {
 			$tablet_css->add_property( 'padding-bottom', $settings['verticalGapTablet'], 'px' );
 		}
 
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id );
 
-		if ( $blockVersion > 2 ) {
+		if ( $blockVersion > 2 && ! $settings['useLegacyRowGap'] ) {
 			$mobile_css->add_property( 'row-gap', $settings['verticalGapMobile'], 'px' );
 		}
 
@@ -197,7 +198,7 @@ class GenerateBlocks_Block_Grid {
 		$mobile_css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
 		$mobile_css->add_property( 'padding-' . $gap_direction, $settings['horizontalGapMobile'], 'px' );
 
-		if ( $blockVersion < 3 ) {
+		if ( $blockVersion < 3 || $settings['useLegacyRowGap'] ) {
 			$mobile_css->add_property( 'padding-bottom', $settings['verticalGapMobile'], 'px' );
 		}
 

--- a/src/blocks/grid/attributes.js
+++ b/src/blocks/grid/attributes.js
@@ -70,6 +70,10 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	useLegacyRowGap: {
+		type: 'boolean',
+		default: false,
+	},
 	// deprecated since 1.2.0
 	elementId: {
 		type: 'string',

--- a/src/blocks/grid/css/main.js
+++ b/src/blocks/grid/css/main.js
@@ -20,6 +20,7 @@ export default class MainCSS extends Component {
 			verticalAlignment,
 			horizontalAlignment,
 			isQueryLoop,
+			useLegacyRowGap,
 		} = attributes;
 
 		let cssObj = [];
@@ -36,11 +37,12 @@ export default class MainCSS extends Component {
 			'align-items': verticalAlignment,
 			'justify-content': horizontalAlignment,
 			'margin-left': horizontalGap || 0 === horizontalGap ? '-' + horizontalGap + 'px' : null,
-			'row-gap': valueWithUnit( verticalGap, 'px' ),
+			'row-gap': ! useLegacyRowGap ? valueWithUnit( verticalGap, 'px' ) : '',
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGap, 'px' ),
+			'margin-bottom': !! useLegacyRowGap ? valueWithUnit( verticalGap, 'px' ) : '',
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.mainCSS', cssObj, this.props, 'grid' );

--- a/src/blocks/grid/css/mobile.js
+++ b/src/blocks/grid/css/mobile.js
@@ -20,6 +20,7 @@ export default class MobileCSS extends Component {
 			verticalAlignmentMobile,
 			horizontalAlignmentMobile,
 			isQueryLoop,
+			useLegacyRowGap,
 		} = attributes;
 
 		let cssObj = [];
@@ -36,11 +37,12 @@ export default class MobileCSS extends Component {
 			'align-items': 'inherit' !== verticalAlignmentMobile ? verticalAlignmentMobile : null,
 			'justify-content': 'inherit' !== horizontalAlignmentMobile ? horizontalAlignmentMobile : null,
 			'margin-left': horizontalGapMobile || 0 === horizontalGapMobile ? '-' + horizontalGapMobile + 'px' : null,
-			'row-gap': verticalGapMobile || 0 === verticalGapMobile ? valueWithUnit( verticalGapMobile, 'px' ) : null,
+			'row-gap': ! useLegacyRowGap && ( verticalGapMobile || 0 === verticalGapMobile ) ? valueWithUnit( verticalGapMobile, 'px' ) : null,
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGapMobile, 'px' ),
+			'margin-bottom': !! useLegacyRowGap && ( verticalGapMobile || 0 === verticalGapMobile ) ? valueWithUnit( verticalGapMobile, 'px' ) : null,
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.mobileCSS', cssObj, this.props, 'grid' );

--- a/src/blocks/grid/css/tablet.js
+++ b/src/blocks/grid/css/tablet.js
@@ -20,6 +20,7 @@ export default class TabletCSS extends Component {
 			verticalAlignmentTablet,
 			horizontalAlignmentTablet,
 			isQueryLoop,
+			useLegacyRowGap,
 		} = attributes;
 
 		let cssObj = [];
@@ -36,11 +37,12 @@ export default class TabletCSS extends Component {
 			'align-items': 'inherit' !== verticalAlignmentTablet ? verticalAlignmentTablet : null,
 			'justify-content': 'inherit' !== horizontalAlignmentTablet ? horizontalAlignmentTablet : null,
 			'margin-left': horizontalGapTablet || 0 === horizontalGapTablet ? '-' + horizontalGapTablet + 'px' : null,
-			'row-gap': verticalGapTablet || 0 === verticalGapTablet ? valueWithUnit( verticalGapTablet, 'px' ) : null,
+			'row-gap': ! useLegacyRowGap && ( verticalGapTablet || 0 === verticalGapTablet ) ? valueWithUnit( verticalGapTablet, 'px' ) : null,
 		} ];
 
 		cssObj[ gridItemSelector ] = [ {
 			'padding-left': valueWithUnit( horizontalGapTablet, 'px' ),
+			'margin-bottom': !! useLegacyRowGap && ( verticalGapTablet || 0 === verticalGapTablet ) ? valueWithUnit( verticalGapTablet, 'px' ) : null,
 		} ];
 
 		cssObj = applyFilters( 'generateblocks.editor.tabletCSS', cssObj, this.props, 'grid' );

--- a/src/components/number-control/index.js
+++ b/src/components/number-control/index.js
@@ -137,6 +137,12 @@ export default function NumberControl( props ) {
 										} else {
 											setAttributes( { [ attributeNames.value ]: '' } );
 										}
+
+										// Disable our legacy row gap option in the Grid block if this option is changed.
+										// Since 1.7.0.
+										if ( 'verticalGap' === attributeName ) {
+											setAttributes( { useLegacyRowGap: false } );
+										}
 									} }
 								>
 									{ presetLabel }
@@ -186,6 +192,12 @@ export default function NumberControl( props ) {
 								setAttributes( {
 									[ attributeNames.value ]: parseFloat( attributes[ attributeNames.value ] ),
 								} );
+							}
+
+							// Disable our legacy row gap option in the Grid block if this option is changed.
+							// Since 1.7.0.
+							if ( 'verticalGap' === attributeName ) {
+								setAttributes( { useLegacyRowGap: false } );
 							}
 						} }
 						onClick={ ( e ) => {

--- a/src/hoc/withGridLegacyMigration.js
+++ b/src/hoc/withGridLegacyMigration.js
@@ -15,6 +15,14 @@ export default ( WrappedComponent ) => {
 				setAttributes( { isDynamic: true } );
 			}
 
+			// Prevent layouts from switching to row-gap.
+			// @since 1.7.0
+			if ( ! wasBlockJustInserted( attributes ) && isBlockVersionLessThan( attributes.blockVersion, 3 ) ) {
+				setAttributes( {
+					useLegacyRowGap: true,
+				} );
+			}
+
 			// Set our old defaults as static values.
 			// @since 1.4.0.
 			if ( ! wasBlockJustInserted( attributes ) && isBlockVersionLessThan( attributes.blockVersion, 2 ) ) {


### PR DESCRIPTION
In #718 we switched the Vertical Gap Grid block option from using `margin-bottom` to `row-gap`.

We included backward-compatibility so this doesn't happen on the frontend until the user loads the page and saves it.

However, there are some instances where users relied on that `margin-bottom` for their layouts (the Relay - Footer pattern in the Library, yellow box). When they go to edit their page now, that margin is removed (and replaced with `row-gap`), which could cause issues for some users.

This PR adds another layer of back-compat by using the `useLegacyRowGap` attribute. This option is turned on when you edit a page with existing Grid blocks.

To remove the legacy gap on old blocks, the user has to focus the Vertical Gap option and it will turn off and use `row-gap` instead.