### PR TITLE
Fix: Insert inner container button showing for variations

### DIFF
--- a/src/blocks/container/block-controls.js
+++ b/src/blocks/container/block-controls.js
@@ -45,6 +45,7 @@ const withBlockControls = createHigherOrderComponent(
 			isGrid,
 			isQueryLoopItem,
 			align,
+			variantRole,
 		} = attributes;
 
 		let parentGridId = false;
@@ -66,7 +67,7 @@ const withBlockControls = createHigherOrderComponent(
 
 		return (
 			<Fragment>
-				{ ! hasParentBlock && 0 === innerBlocksCount &&
+				{ ! hasParentBlock && 0 === innerBlocksCount && '' === variantRole &&
 					<BlockControls>
 						<ToolbarGroup>
 							<ToolbarButton


### PR DESCRIPTION
Hide the `Insert inner container` button when the block is a variation.

Having an empty Accordion shows the button. Tabs would show too but because the template selector is not visible.