### PR TITLE
Tweak: Improve inner container migrate popover

### DIFF
--- a/src/blocks/container/editor.scss
+++ b/src/blocks/container/editor.scss
@@ -324,5 +324,10 @@ body.gutenberg-editor-page [data-type="generateblocks/container"] .editor-block-
 .gblocks-inner-container-notice {
 	margin: 0 0 1em;
 	background: rgba(0,0,0,0.03);
-	max-width: 700px;
+	max-width: 720px;
+}
+
+.gblocks-layout-system-ul {
+	list-style-type: disc;
+	margin-left: 1em;
 }

--- a/src/components/migrate-inner-container/index.js
+++ b/src/components/migrate-inner-container/index.js
@@ -48,25 +48,72 @@ export default function MigrateInnerContainer( props ) {
 		childBlock: getChildBlock( clientId ),
 	} );
 
+	function migrateInnerContainerButton() {
+		return <Button
+			variant={ !! migrateInnerContainer ? 'primary' : 'secondary' }
+			style={ { marginRight: '5px' } }
+			onClick={ () => {
+				doInnerContainerMigration( {
+					clientId,
+					attributes,
+					setAttributes,
+					parentBlock: getBlocksByClientId( clientId )[ 0 ],
+					insertBlocks,
+					removeBlocks,
+				} );
+				closeModal();
+			} }
+		>
+			{ __( 'Enable new system with inner Container block', 'generateblocks' ) }
+		</Button>;
+	}
+
+	function enableNewSystemButton() {
+		return <Button
+			variant={ ! migrateInnerContainer ? 'primary' : 'secondary' }
+			style={ { marginRight: '5px' } }
+			onClick={ () => {
+				doSimpleMigration( { attributes, setAttributes } );
+				closeModal();
+			} }
+		>
+			{ __( 'Enable new system only', 'generateblocks' ) }
+		</Button>;
+	}
+
 	return (
 		<>
 			{ !! useInnerContainer &&
 				<ToggleControl
-					label={ __( 'Use legacy inner container', 'generateblocks' ) }
-					help={ __( 'Old versions of the Container block had an inner container div. This will remove that inner div for you.', 'generateblocks' ) }
+					label={ __( 'Use legacy layout system', 'generateblocks' ) }
+					help={ __( 'This Container is using an old layout system. Toggle this to migrate to the new system.', 'generateblocks' ) }
 					checked={ !! useInnerContainer }
 					onChange={ openModal }
 				/>
 			}
 
 			{ !! isInnerContainerMigrateOpen &&
-				<Modal title={ __( 'Add inner Container block', 'generateblocks' ) } onRequestClose={ closeModal }>
-					<p>{ __( 'We can automatically add an inner Container block to this block if your layout relies on it.', 'generateblocks' ) }</p>
+				<Modal title={ __( 'New Layout System', 'generateblocks' ) } onRequestClose={ closeModal }>
+					<p>{ __( 'Migrating to our new layout system will do the following:', 'generateblocks' ) }</p>
+					<ul className="gblocks-layout-system-ul">
+						<li>{ __( 'Remove the inner div element that was included by default in the old system.', 'generateblocks' ) }</li>
+						<li>{ __( 'Enable our new layout system for this Container block.', 'generateblocks' ) }</li>
+					</ul>
+					<p>{ __( 'We can automatically replace the old inner div element with a Container block if your layout relies on it.', 'generateblocks' ) }</p>
 					<Notice status="info" isDismissible={ false } className="gblocks-inner-container-notice">
-						<strong>{ __( 'Recommendation:', 'generateblocks' ) }</strong>
 						{ !! migrateInnerContainer
-							? ' ' + __( 'Yes, we recommend you add an inner Container block to maintain your current layout.', 'generateblocks' )
-							: ' ' + __( 'No, we do not believe you need an inner Container block based on your current layout.', 'generateblocks' )
+							? (
+								<>
+									<p style={ { 'margin-top': 0 } }><strong>{ __( 'Recommendation:', 'generateblocks' ) }</strong> { __( 'Yes, we recommend you add a new inner Container block to maintain your current layout.', 'generateblocks' ) }</p>
+
+									{ migrateInnerContainerButton() }
+								</>
+							) : (
+								<>
+									<p style={ { 'margin-top': 0 } }><strong>{ __( 'Recommendation:', 'generateblocks' ) }</strong> { __( 'No, we do not believe you need an inner Container block based on your current layout.', 'generateblocks' ) }</p>
+									{ enableNewSystemButton() }
+								</>
+							)
 						}
 					</Notice>
 
@@ -84,32 +131,20 @@ export default function MigrateInnerContainer( props ) {
 							{ ' ' + __( 'This block is a Global Style. If you migrate the inner container on this block you will need to make sure that all Container blocks using it are migrated as well.', 'generateblocks' ) }
 						</Notice>
 					}
-					<Button
-						variant={ !! migrateInnerContainer ? 'primary' : 'tertiary' }
-						style={ { marginRight: '5px' } }
-						onClick={ () => {
-							doInnerContainerMigration( {
-								clientId,
-								attributes,
-								setAttributes,
-								parentBlock: getBlocksByClientId( clientId )[ 0 ],
-								insertBlocks,
-								removeBlocks,
-							} );
-							closeModal();
-						} }
-					>
-						{ __( 'Yes, add an inner Container block', 'generateblocks' ) }
-					</Button>
+
+					{ ! migrateInnerContainer &&
+						migrateInnerContainerButton()
+					}
+
+					{ !! migrateInnerContainer &&
+						enableNewSystemButton()
+					}
 
 					<Button
-						variant={ ! migrateInnerContainer ? 'primary' : 'tertiary' }
-						onClick={ () => {
-							doSimpleMigration( { attributes, setAttributes } );
-							closeModal();
-						} }
+						variant="secondary"
+						onClick={ closeModal }
 					>
-						{ __( 'No, just remove the legacy inner container div', 'generateblocks' ) }
+						{ __( 'Cancel', 'generateblocks' ) }
 					</Button>
 				</Modal>
 			}


### PR DESCRIPTION
This attempts to make the inner container migration more clear for users.

Instead of a "Use inner container" toggle, we switch it to "Use legacy layout system":

![legacy-layout](https://user-images.githubusercontent.com/20714883/208476950-7dbfc24c-f114-47f7-a5b0-32a4185cdb81.jpg)

Inside the popover, we attempt to outline exactly what happens when the migration takes place.

This is the popover when we suggest adding an inner Container block:

![add-inner-container-2](https://user-images.githubusercontent.com/20714883/208477122-ddb96616-dbc7-43ac-8bb4-7f50a003875a.jpg)

This is the popover when we suggest turning on the new layout system without adding an inner Container block:

![add-inner-container-3](https://user-images.githubusercontent.com/20714883/208477203-19e60b9d-de8b-40fd-8146-29af6820fe6d.jpg)
