### PR TITLE
Tweak: Add more specificity to button link

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -461,13 +461,11 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 			$defaults['button']
 		);
 
-		if ( $blockVersion < 3 ) {
-			$clean_selector = $selector;
-			$selector = 'a' . $selector;
+		$clean_selector = $selector;
+		$selector = 'a' . $selector;
 
-			if ( isset( $settings['hasUrl'] ) && ! $settings['hasUrl'] ) {
-				$selector = $clean_selector;
-			}
+		if ( ( isset( $settings['hasUrl'] ) && ! $settings['hasUrl'] ) || 'link' !== $settings['buttonType'] ) {
+			$selector = $clean_selector;
 		}
 
 		if ( $settings['hasButtonContainer'] || $blockVersion < 3 ) {


### PR DESCRIPTION
This adds the `a` back to the `.gb-button` selector when it has a URL and is set to be a link.

Removing the `a` from the selector was causing specificity issues with some setups.

`isset( $settings['hasUrl'] ) && ! $settings['hasUrl']`

I don't love using this kind of logic, but it's borrowed from how we did it in 1.6, so it's safer to keep it as is for right now.