### PR TITLE
Tweak: Make pagination button selectors more specific

### DIFF
--- a/includes/class-query-loop.php
+++ b/includes/class-query-loop.php
@@ -43,6 +43,7 @@ class GenerateBlocks_Query_Loop {
 	 */
 	public function __construct() {
 		add_filter( 'generateblocks_attr_grid-wrapper', array( $this, 'add_grid_wrapper_attributes' ), 10, 2 );
+		add_filter( 'generateblocks_attr_container', array( $this, 'add_container_attributes' ), 10, 2 );
 		add_filter( 'generateblocks_attr_grid-item', array( $this, 'add_grid_item_attributes' ), 10, 2 );
 		add_filter( 'generateblocks_attr_button-container', array( $this, 'add_button_wrapper_attributes' ), 10, 2 );
 		add_filter( 'generateblocks_defaults', array( $this, 'add_block_defaults' ) );
@@ -209,6 +210,7 @@ class GenerateBlocks_Query_Loop {
 	 */
 	public function add_block_defaults( $defaults ) {
 		$defaults['container']['isQueryLoopItem'] = false;
+		$defaults['container']['isPagination'] = false;
 		$defaults['gridContainer']['isQueryLoop'] = false;
 		$defaults['buttonContainer']['isPagination'] = false;
 
@@ -224,6 +226,20 @@ class GenerateBlocks_Query_Loop {
 	public function add_grid_wrapper_attributes( $attributes, $settings ) {
 		if ( $settings['isQueryLoop'] ) {
 			$attributes['class'] .= ' gb-query-loop-wrapper';
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Add HTML attributes to the Query Loop Containers.
+	 *
+	 * @param array $attributes Existing HTML attributes.
+	 * @param array $settings Block settings.
+	 */
+	public function add_container_attributes( $attributes, $settings ) {
+		if ( $settings['isPagination'] ) {
+			$attributes['class'] .= ' gb-query-loop-pagination';
 		}
 
 		return $attributes;

--- a/includes/general.php
+++ b/includes/general.php
@@ -470,6 +470,8 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 
 		if ( $settings['hasButtonContainer'] || $blockVersion < 3 ) {
 			$selector = '.gb-button-wrapper ' . $selector;
+		} elseif ( isset( $settings['isPagination'] ) && $settings['isPagination'] ) {
+			$selector = '.gb-query-loop-pagination ' . $selector;
 		}
 	}
 

--- a/src/blocks/query-loop/components/BlockControls.js
+++ b/src/blocks/query-loop/components/BlockControls.js
@@ -26,6 +26,7 @@ export default ( { clientId } ) => {
 			marginTop: '20',
 			variantRole: 'button-container',
 			display: 'flex',
+			isPagination: true,
 		},
 		[
 			[


### PR DESCRIPTION
Pagination buttons have their text color overwritten by the Content Link color in GP using Customize > Colors > Content.

This makes their selectors more specific to fix that by adding a class to the pagination Container.