### PR TITLE
Tweak: Improve Button selector specificity

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -461,11 +461,24 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 			$defaults['button']
 		);
 
-		$clean_selector = $selector;
-		$selector = 'a' . $selector;
+		if ( $blockVersion < 3 ) {
+			// Old versions of the this block used this backwards logic
+			// to determine whether to remove the "a" to the selector.
+			$clean_selector = $selector;
+			$selector = 'a' . $selector;
 
-		if ( ( isset( $settings['hasUrl'] ) && ! $settings['hasUrl'] ) || 'link' !== $settings['buttonType'] ) {
-			$selector = $clean_selector;
+			if ( isset( $attributes['hasUrl'] ) && ! $attributes['hasUrl'] ) {
+				$selector = $clean_selector;
+			}
+		} else {
+			$is_link = (
+				! empty( $settings['hasUrl'] ) ||
+				! empty( $settings['dynamicLinkType'] )
+			) && 'link' === $settings['buttonType'];
+
+			if ( $is_link ) {
+				$selector = 'a' . $selector;
+			}
 		}
 
 		if ( $settings['hasButtonContainer'] || $blockVersion < 3 ) {


### PR DESCRIPTION
This somewhat reverts #826 

The logic we were using feels backward because the Button block used to always be a link. When we added the ability for it to be a span, we adjusted the selector to remove the `a` from the selector.

This PR uses the old logic as it was for old versions of the Button block being used.

Once the block is updated to the latest version, it uses better logic to add the `a` if needed.

It also fixes a bug where dynamic links didn't have the `a` added to the selector.