### PR TITLE
Fix: Block max-width

### DIFF
--- a/src/blocks/image/css/main.js
+++ b/src/blocks/image/css/main.js
@@ -43,6 +43,7 @@ export default function MainCSS( props ) {
 		float: alignment.startsWith( 'float' ) ? floats[ alignment ] : 'none',
 		position: alignment.startsWith( 'float' ) ? 'relative' : null,
 		'z-index': alignment.startsWith( 'float' ) ? '22' : null,
+		'max-width': 'unset',
 	} ];
 
 	SpacingCSS( cssObj, '.editor-styles-wrapper .gb-block-image-' + uniqueId, attributes );

--- a/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
+++ b/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
@@ -11,7 +11,7 @@ export default function SizingCSS( css, selector, attributes, device = '' ) {
 		height: sizingValue( 'height' + device, sizing ),
 		'min-width': sizingValue( 'min-width' + device, sizing ),
 		'min-height': sizingValue( 'minHeight' + device, sizing ),
-		'max-width': sizingValue( 'maxWidth' + device, sizing ) || 'unset',
+		'max-width': sizingValue( 'maxWidth' + device, sizing ),
 		'max-height': sizingValue( 'maxHeight' + device, sizing ),
 	};
 
@@ -25,6 +25,10 @@ export default function SizingCSS( css, selector, attributes, device = '' ) {
 		delete styles.width;
 		delete styles[ 'min-width' ];
 		delete styles[ 'max-width' ];
+	}
+
+	if ( ! styles[ 'max-width' ] ) {
+		styles[ 'max-width' ] = 'unset';
 	}
 
 	return (


### PR DESCRIPTION
close #813 

Previously, we used to have this CSS to prevent blocks inside of our Containers from having `max-width`:

```
body .gb-container .wp-block {
    max-width: none;
}
```

We had to remove this to allow our blocks to have their own `max-width` set.

However, we need to make sure that our blocks unset their `max-width` to prevent the standard WP CSS from applying:

```
html :where(.wp-block) {
    max-width: 840px;
    margin-top: 28px;
    margin-bottom: 28px;
}
```

We can overwrite this core CSS because we have a `gb-is-root-block` div surrounding our root blocks which the above CSS will apply to.