### PR TITLE
Tweak: Allow 0 as HTML attribute

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -614,7 +614,7 @@ function generateblocks_attr( $context, $attributes = array(), $settings = array
 	// Cycle through attributes, build tag attribute string.
 	foreach ( $attributes as $key => $value ) {
 
-		if ( ! $value ) {
+		if ( ! $value && '0' !== $value ) {
 			continue;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Tweak: Ignore button hover colors on current buttons
 * Tweak: Remove :visited pseudo selector from CSS
 * Tweak: Remove tag name from CSS selectors
+* Tweak: Allow "0" as HTML attribute value
 * Fix: Responsive placeholder not showing 0 value
 * Fix: Excerpt spelling mistake
 * Fix: Image placeholder position


### PR DESCRIPTION
This allows us to add "0" as an HTML attribute. For example: `tabindex="0"`