### PR TITLE
Tweak: Add tagname back to Headline selector

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -494,9 +494,7 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 			$defaults['headline']
 		);
 
-		$include_tagname_default = $blockVersion < 2;
-
-		if ( apply_filters( 'generateblocks_headline_selector_tagname', $include_tagname_default, $attributes ) ) {
+		if ( apply_filters( 'generateblocks_headline_selector_tagname', true, $attributes ) ) {
 			$selector = $settings['element'] . $selector;
 		}
 	}


### PR DESCRIPTION
This reverts a change we made in 1.7 where we removed the tagname from the Headline selector.

This has the potential to cause some issues until we figure out #824 