### PR TITLE
Tweak: Prevent faded background image in editor

### DIFF
--- a/src/blocks/container/components/ContainerContentRenderer.js
+++ b/src/blocks/container/components/ContainerContentRenderer.js
@@ -30,6 +30,7 @@ export default function ContainerContentRenderer( props ) {
 		isGrid,
 		bgOptions,
 		bgImageInline,
+		bgImage,
 		align,
 		isBlockPreview = false,
 		useInnerContainer,
@@ -48,6 +49,7 @@ export default function ContainerContentRenderer( props ) {
 
 	let hasStyling = (
 		!! backgroundColor ||
+		!! bgImage ||
 		attributes.borderSizeTop ||
 		attributes.borderSizeRight ||
 		attributes.borderSizeBottom ||


### PR DESCRIPTION
When adding a pseudo-element background image to an empty Container, our `visual-guidelines` class set the `:before` opacity to `0.2`, causing the background image to fade out.

We don't need visual guidelines in a background image exists.