### PR TITLE
Tweak: Don't apply sizing to inner Container

### DIFF
--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -245,7 +245,6 @@ function doInnerContainerMigration( props ) {
 			paddingUnit,
 			useGlobalMaxWidth: 'contained' === innerContainer ? !! hasDefaultContainerWidth : useGlobalMaxWidth,
 			sizing: {
-				...attributes.sizing,
 				maxWidth: 'contained' === innerContainer && ! hasDefaultContainerWidth && containerWidth ? containerWidth + 'px' : '',
 			},
 			marginLeft: 'auto',


### PR DESCRIPTION
We're currently bringing all `sizing` attributes from the surrounding Container block into the inner Container block. The inner Container block only needs `max-width`.