### PR TITLE
Fix: Re-usable content removed during Container migration

### DIFF
--- a/src/components/migrate-inner-container/index.js
+++ b/src/components/migrate-inner-container/index.js
@@ -29,8 +29,7 @@ export default function MigrateInnerContainer( props ) {
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 
 	const {
-		insertBlocks,
-		removeBlocks,
+		replaceBlocks,
 	} = useDispatch( 'core/block-editor' );
 
 	function isInsideGridBlock( blockClientId ) {
@@ -54,12 +53,10 @@ export default function MigrateInnerContainer( props ) {
 			style={ { marginRight: '5px' } }
 			onClick={ () => {
 				doInnerContainerMigration( {
-					clientId,
 					attributes,
 					setAttributes,
 					parentBlock: getBlocksByClientId( clientId )[ 0 ],
-					insertBlocks,
-					removeBlocks,
+					replaceBlocks,
 				} );
 				closeModal();
 			} }

--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -226,6 +226,17 @@ function doInnerContainerMigration( props ) {
 	const hasDefaultContainerWidth = parseInt( containerWidth ) === parseInt( generateBlocksInfo.globalContainerWidth );
 	const layoutAttributes = getLayoutAttributes( attributes );
 
+	// We need to create new block instances for each inner block
+	// to prevent a bug where re-usable block content is removed
+	// during migration.
+	const newChildBlocks = childBlocks.map( ( block ) => {
+		return createBlock(
+			block.name,
+			block.attributes,
+			block.innerBlocks
+		);
+	} );
+
 	// Wrap our existing child blocks in a new Container block.
 	const newInnerBlocks = createBlock(
 		'generateblocks/container',
@@ -252,7 +263,7 @@ function doInnerContainerMigration( props ) {
 			zindex: innerZindex,
 			position: innerZindex || 0 === innerZindex ? 'relative' : '',
 		},
-		childBlocks
+		newChildBlocks
 	);
 
 	const childClientIds = childBlocks.map( ( block ) => block.clientId );

--- a/src/components/migrate-inner-container/utils.js
+++ b/src/components/migrate-inner-container/utils.js
@@ -190,12 +190,10 @@ function shouldMigrateInnerContainer( props ) {
  */
 function doInnerContainerMigration( props ) {
 	const {
-		clientId,
 		attributes,
 		setAttributes,
 		parentBlock,
-		removeBlocks,
-		insertBlocks,
+		replaceBlocks,
 	} = props;
 
 	const {
@@ -267,8 +265,7 @@ function doInnerContainerMigration( props ) {
 	);
 
 	const childClientIds = childBlocks.map( ( block ) => block.clientId );
-	removeBlocks( childClientIds );
-	insertBlocks( newInnerBlocks, 0, clientId );
+	replaceBlocks( childClientIds, newInnerBlocks );
 
 	// Update attributes for existing Container block.
 	setAttributes( {


### PR DESCRIPTION
This fixes a bug where re-usable blocks inside of a non-reusable Container lose their content during migration:

https://user-images.githubusercontent.com/20714883/212759214-50ccc752-2c54-4788-bd5c-c92a543bcd70.mp4

Gutenberg has a different reason for doing the same thing: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/group/transforms.js#L27