### PR TITLE
Tweak: Add tag name selectors to Headlines and Buttons

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -479,6 +479,10 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 			if ( $is_link ) {
 				$selector = 'a' . $selector;
 			}
+
+			if ( 'button' === $settings['buttonType'] ) {
+				$selector = 'button' . $selector;
+			}
 		}
 
 		if ( $settings['hasButtonContainer'] || $blockVersion < 3 ) {
@@ -494,9 +498,7 @@ function generateblocks_set_block_css_selectors( $selector, $name, $attributes )
 			$defaults['headline']
 		);
 
-		$include_tagname_default = $blockVersion < 2;
-
-		if ( apply_filters( 'generateblocks_headline_selector_tagname', $include_tagname_default, $attributes ) ) {
+		if ( apply_filters( 'generateblocks_headline_selector_tagname', true, $attributes ) ) {
 			$selector = $settings['element'] . $selector;
 		}
 	}


### PR DESCRIPTION
Battling with theme CSS specificity is hard.

This PR adds (back) the Headline tagname to the CSS selector, and adds the `button` tagname to the Button block when it's set to display as a `<button>`.