### PR TITLE
Fix: Static image caption showing multiple times

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -1078,7 +1078,9 @@ class GenerateBlocks_Dynamic_Content {
 			) {
 				// phpcs:ignore -- DOMDocument doesn't use snake-case.
 				foreach ( $node->childNodes as $childNode ) {
-					$static_content .= $doc->saveHTML( $childNode );
+					if ( isset($childNode->tagName) && 'img' === $childNode->tagName ) {
+						$static_content .= $doc->saveHTML( $childNode );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
References:
https://secure.helpscout.net/conversation/2134167229/373534
https://generatepress.com/forums/topic/the-caption-in-the-image-block-appears-3-times/#post-2506778