### PR TITLE
Fix: Headline device spacing in editor

### DIFF
--- a/src/blocks/headline/css/mobile.js
+++ b/src/blocks/headline/css/mobile.js
@@ -74,7 +74,7 @@ export default class MobileCSS extends Component {
 			'border-bottom-left-radius': valueWithUnit( borderRadiusBottomLeftMobile, borderRadiusUnit ),
 		} ];
 
-		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes );
+		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );
 		SizingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );
 		FlexChildCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );

--- a/src/blocks/headline/css/tablet.js
+++ b/src/blocks/headline/css/tablet.js
@@ -74,7 +74,7 @@ export default class TabletCSS extends Component {
 			'border-bottom-left-radius': valueWithUnit( borderRadiusBottomLeftTablet, borderRadiusUnit ),
 		} ];
 
-		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes );
+		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );
 		SizingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );
 		FlexChildCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );


### PR DESCRIPTION
Headline spacing options weren't working on tablet/mobile in the editor.