### PR TITLE
Fix: Show device-specific shape panel options

### DIFF
--- a/src/extend/inspector-control/controls/shapes-panel/index.js
+++ b/src/extend/inspector-control/controls/shapes-panel/index.js
@@ -491,14 +491,16 @@ export default function ShapesPanel( { attributes, setAttributes } ) {
 					} )
 				}
 
-				<div className="gblocks-add-new-shape">
-					<Button
-						isSecondary
-						onClick={ handleAddShape }
-					>
-						{ __( 'Add Shape', 'generateblocks' ) }
-					</Button>
-				</div>
+				{ 'Desktop' === deviceType &&
+					<div className="gblocks-add-new-shape">
+						<Button
+							isSecondary
+							onClick={ handleAddShape }
+						>
+							{ __( 'Add Shape', 'generateblocks' ) }
+						</Button>
+					</div>
+				}
 			</BaseControl>
 		</PanelArea>
 	);

--- a/src/extend/inspector-control/index.js
+++ b/src/extend/inspector-control/index.js
@@ -82,7 +82,7 @@ export default function GenerateBlocksInspectorControls( { attributes, setAttrib
 				/>
 			}
 
-			{ shapesPanel.enabled && 'Desktop' === device &&
+			{ shapesPanel.enabled && ( 'Desktop' === device || attributes?.shapeDividers.length > 0 ) &&
 				<ShapesPanel
 					attributes={ attributes }
 					setAttributes={ setAttributes }


### PR DESCRIPTION
close #888 

This exposes device-specific shape options in the "Tablet" and "Mobile" previews.