### PR TITLE
Revert: Triple captions using static image with dynamic link

### DIFF
--- a/includes/class-dynamic-content.php
+++ b/includes/class-dynamic-content.php
@@ -1076,19 +1076,6 @@ class GenerateBlocks_Dynamic_Content {
 				in_array( 'gb-headline-text', $classes ) ||
 				in_array( 'gb-block-image', $classes )
 			) {
-				// Captions are added dynamically in class-image.php, so we can remove
-				// the static one here if it exists.
-				if ( in_array( 'gb-block-image', $classes ) ) {
-					$figcaptions = $node->getElementsByTagName( 'figcaption' );
-
-					if ( ! empty( $figcaptions ) ) {
-						foreach ( $figcaptions as $figcaption ) {
-							// phpcs:ignore -- DOMDocument doesn't use snake-case.
-							$figcaption->parentNode->removeChild( $figcaption );
-						}
-					}
-				}
-
 				// phpcs:ignore -- DOMDocument doesn't use snake-case.
 				foreach ( $node->childNodes as $childNode ) {
 					$static_content .= $doc->saveHTML( $childNode );

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,6 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Fix: Prevent faded background image in editor
 * Fix: Pass $block to generateblocks_parse_attr function
 * Fix: WP Filesystem error missing credentials
-* Fix: Triple captions using static image with dynamic link
 
 = 1.6.0 =
 * Feature: Add support for FSE styling


### PR DESCRIPTION
Not super comfortable with this fix. As it's such an obscure bug I think we can look at it in 1.8 as we'll be revamping dynamic data anyways.