### PR TITLE
Fix: Migrate Container sizing for old blocks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 == Changelog ==
 
 = 1.7.1 =
+* Fix: Container width migration for old blockVersion: 1 blocks
 
 = 1.7.0 =
 * Feature: Add flexbox controls to all blocks

--- a/src/hoc/withContainerLegacyMigration.js
+++ b/src/hoc/withContainerLegacyMigration.js
@@ -92,6 +92,14 @@ export default ( WrappedComponent ) => {
 				items.forEach( ( item ) => {
 					if ( ! hasNumericValue( attributes[ item ] ) ) {
 						newAttrs[ item ] = legacyDefaults[ item ];
+
+						if ( 'width' === item || 'widthMobile' === item ) {
+							if ( ! newAttrs.sizing ) {
+								newAttrs.sizing = {};
+							}
+
+							newAttrs.sizing[ item ] = String( legacyDefaults[ item ] + '%' );
+						}
 					}
 				} );
 

--- a/src/hoc/withContainerLegacyMigration.js
+++ b/src/hoc/withContainerLegacyMigration.js
@@ -100,6 +100,8 @@ export default ( WrappedComponent ) => {
 						} else {
 							newAttrs.sizing[ item ] = String( attributes[ item ] + '%' );
 						}
+					} else if ( ! hasNumericValue( attributes[ item ] ) ) {
+						newAttrs[ item ] = legacyDefaults[ item ];
 					}
 				} );
 

--- a/src/hoc/withContainerLegacyMigration.js
+++ b/src/hoc/withContainerLegacyMigration.js
@@ -89,16 +89,16 @@ export default ( WrappedComponent ) => {
 					);
 				}
 
+				if ( ! newAttrs.sizing ) {
+					newAttrs.sizing = {};
+				}
+
 				items.forEach( ( item ) => {
-					if ( ! hasNumericValue( attributes[ item ] ) ) {
-						newAttrs[ item ] = legacyDefaults[ item ];
-
-						if ( 'width' === item || 'widthMobile' === item ) {
-							if ( ! newAttrs.sizing ) {
-								newAttrs.sizing = {};
-							}
-
+					if ( 'width' === item || 'widthMobile' === item ) {
+						if ( ! hasNumericValue( attributes[ item ] ) ) {
 							newAttrs.sizing[ item ] = String( legacyDefaults[ item ] + '%' );
+						} else {
+							newAttrs.sizing[ item ] = String( attributes[ item ] + '%' );
 						}
 					}
 				} );


### PR DESCRIPTION
This fixes a bug where old Container blocks using the 50% default for grid items weren't migrating to the new `sizing` object. 

To replicate the bug:

1. Use GB 1.3.5
2. Add Grid to page, keep items at 50% (and some at other widths)
3. Update to this 1.7, width attributes will be gone