### PR TITLE
Fix: Onboarding keys registered by GBP weren't optional

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -400,11 +400,9 @@ add_action( 'init', 'generateblocks_register_user_meta' );
  * @return void
  */
 function generateblocks_register_user_meta() {
-	$onboarding_properties = apply_filters(
+	$additional_properties = apply_filters(
 		'generateblocks_onboarding_user_meta_properties',
-		array(
-			'insert_inner_container' => array( 'type' => 'boolean' ),
-		)
+		array()
 	);
 
 	register_meta(
@@ -416,7 +414,10 @@ function generateblocks_register_user_meta() {
 			'show_in_rest' => array(
 				'schema' => array(
 					'type'  => 'object',
-					'properties' => $onboarding_properties,
+					'properties' => array(
+						'insert_inner_container' => array( 'type' => 'boolean' ),
+					),
+					'additionalProperties' => $additional_properties,
 				),
 			),
 		)


### PR DESCRIPTION
This causes root containers to break.

How to replicate:

1. With GB and GBP active, add either an accordion or a tab block to the page and click "Got it" on the onboarding popup
2. Save the page, and disable GBP
3. Clear the session storage for the onboarding keys
4. Add a root container