### PR TITLE
Fix: Old block deprecations

### DIFF
--- a/src/blocks/button-container/deprecated.js
+++ b/src/blocks/button-container/deprecated.js
@@ -12,10 +12,22 @@ import {
 	applyFilters,
 } from '@wordpress/hooks';
 
+import { getBlockAttributes } from '../../block-context';
+import buttonContainerContext from '../../block-context/button-container';
+
+const allAttributes = Object.assign(
+	{},
+	getBlockAttributes(
+		blockAttributes,
+		buttonContainerContext,
+		generateBlocksDefaults.buttonContainer
+	),
+);
+
 const deprecated = [
 	// v1 of container block. Deprecated the gb-grid-column wrapper in save component.
 	{
-		attributes: blockAttributes,
+		attributes: allAttributes,
 		supports: {
 			anchor: false,
 			className: false,

--- a/src/blocks/button/deprecated.js
+++ b/src/blocks/button/deprecated.js
@@ -13,11 +13,23 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 
+import { getBlockAttributes } from '../../block-context';
+import buttonContext from '../../block-context/button';
+
+const allAttributes = Object.assign(
+	{},
+	getBlockAttributes(
+		blockAttributes,
+		buttonContext,
+		generateBlocksDefaults.button
+	),
+);
+
 const deprecated = [
 	// v1 of button block.
 	{
 		attributes: {
-			...blockAttributes,
+			...allAttributes,
 			text: {
 				type: 'array',
 				source: 'children',

--- a/src/blocks/container/deprecated.js
+++ b/src/blocks/container/deprecated.js
@@ -13,10 +13,22 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 
+import { getBlockAttributes } from '../../block-context';
+import containerContext from '../../block-context/container';
+
+const allAttributes = Object.assign(
+	{},
+	getBlockAttributes(
+		blockAttributes,
+		containerContext,
+		generateBlocksDefaults.container
+	),
+);
+
 const deprecated = [
 	// v1 of container block. Deprecated the gb-grid-column wrapper in save component.
 	{
-		attributes: blockAttributes,
+		attributes: allAttributes,
 		supports: {
 			align: false,
 			anchor: false,

--- a/src/blocks/grid/deprecated.js
+++ b/src/blocks/grid/deprecated.js
@@ -12,10 +12,22 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 
+import { getBlockAttributes } from '../../block-context';
+import gridContext from '../../block-context/grid';
+
+const allAttributes = Object.assign(
+	{},
+	getBlockAttributes(
+		blockAttributes,
+		gridContext,
+		generateBlocksDefaults.gridContainer
+	),
+);
+
 const deprecated = [
 	// v1 of container block. Deprecated the gb-grid-column wrapper in save component.
 	{
-		attributes: blockAttributes,
+		attributes: allAttributes,
 		supports: {
 			anchor: false,
 			className: false,

--- a/src/blocks/headline/deprecated.js
+++ b/src/blocks/headline/deprecated.js
@@ -10,11 +10,23 @@ import {
 	applyFilters,
 } from '@wordpress/hooks';
 
+import { getBlockAttributes } from '../../block-context';
+import headlineContext from '../../block-context/headline';
+
+const allAttributes = Object.assign(
+	{},
+	getBlockAttributes(
+		blockAttributes,
+		headlineContext,
+		generateBlocksDefaults.headline
+	),
+);
+
 const deprecated = [
 	// v2 - remove wrapper.
 	{
 		attributes: {
-			...blockAttributes,
+			...allAttributes,
 			content: {
 				type: 'array',
 				source: 'children',
@@ -99,7 +111,7 @@ const deprecated = [
 	// v1 - change default h2 to p.
 	{
 		attributes: {
-			...blockAttributes,
+			...allAttributes,
 			element: {
 				type: 'string',
 				default: 'p',


### PR DESCRIPTION
Our old block deprecations are no longer working in 1.7.0.

Example of old GB 1.2 blocks:

```
<!-- wp:generateblocks/headline {"uniqueId":"c601c0db","hasIcon":true} -->
<div class="gb-headline-wrapper gb-headline-wrapper-c601c0db"><span class="gb-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" aria-hidden="true"><path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm92.49 313l-20 25a16 16 0 01-22.49 2.5l-67-49.72a40 40 0 01-15-31.23V112a16 16 0 0116-16h32a16 16 0 0116 16v144l58 42.5a16 16 0 012.49 22.5z" fill="currentColor"></path></svg></span><h2 class="gb-headline gb-headline-c601c0db">Testing</h2></div>
<!-- /wp:generateblocks/headline -->

<!-- wp:generateblocks/container {"uniqueId":"795fad93"} -->
<div class="gb-container gb-container-795fad93"><div class="gb-inside-container"></div></div>
<!-- /wp:generateblocks/container -->

<!-- wp:generateblocks/grid {"uniqueId":"d1077ac0","columns":2} -->
<div class="gb-grid-wrapper gb-grid-wrapper-d1077ac0"><!-- wp:generateblocks/container {"uniqueId":"f6a7d89f","isGrid":true,"gridId":"d1077ac0","paddingTop":"0","paddingRight":"0","paddingBottom":"0","paddingLeft":"0"} -->
<div class="gb-grid-column gb-grid-column-f6a7d89f"><div class="gb-container gb-container-f6a7d89f"><div class="gb-inside-container"></div></div></div>
<!-- /wp:generateblocks/container -->

<!-- wp:generateblocks/container {"uniqueId":"50eb8b50","isGrid":true,"gridId":"d1077ac0","paddingTop":"0","paddingRight":"0","paddingBottom":"0","paddingLeft":"0"} -->
<div class="gb-grid-column gb-grid-column-50eb8b50"><div class="gb-container gb-container-50eb8b50"><div class="gb-inside-container"></div></div></div>
<!-- /wp:generateblocks/container --></div>
<!-- /wp:generateblocks/grid -->

<!-- wp:generateblocks/button-container {"uniqueId":"11e8e106"} -->
<div class="gb-button-wrapper gb-button-wrapper-11e8e106"><!-- wp:generateblocks/button {"uniqueId":"b71cae1d","backgroundColor":"#0366d6","textColor":"#ffffff","backgroundColorHover":"#222222","textColorHover":"#ffffff","paddingTop":"15","paddingRight":"20","paddingBottom":"15","paddingLeft":"20"} -->
<a class="gb-button gb-button-b71cae1d"><span class="button-text">Button</span></a>
<!-- /wp:generateblocks/button -->

<!-- wp:generateblocks/button {"uniqueId":"0304758f","backgroundColor":"#0366d6","textColor":"#ffffff","backgroundColorHover":"#222222","textColorHover":"#ffffff","paddingTop":"15","paddingRight":"20","paddingBottom":"15","paddingLeft":"20"} -->
<a class="gb-button gb-button-0304758f"><span class="button-text">Button</span></a>
<!-- /wp:generateblocks/button --></div>
<!-- /wp:generateblocks/button-container -->
```