### PR TITLE
Fix: Double-click when selecting Grid template

### DIFF
--- a/src/blocks/grid/components/InspectorControls.js
+++ b/src/blocks/grid/components/InspectorControls.js
@@ -62,7 +62,6 @@ export default ( props ) => {
 					<SelectControl
 						label={ __( 'Vertical Alignment', 'generateblocks' ) }
 						value={ verticalAlignment }
-						help={ __( 'Align grid items. Removes same height columns and overrides grid item content alignment.', 'generateblocks' ) }
 						options={ [
 							{ label: __( 'Default', 'generateblocks' ), value: '' },
 							{ label: __( 'Top', 'generateblocks' ), value: 'flex-start' },

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -46,17 +46,22 @@ const GridEdit = ( props ) => {
 
 		if ( ! attributes.isQueryLoop && layout ) {
 			const columnsData = getColumnsFromLayout( layout, attributes.uniqueId );
+			const newColumns = [];
 
 			columnsData.forEach( ( colAttrs ) => {
+				newColumns.push( createBlock( 'generateblocks/container', colAttrs ) );
+			} );
+
+			setTimeout( () => {
 				insertBlocks(
-					createBlock( 'generateblocks/container', colAttrs ),
+					newColumns,
 					undefined,
 					props.clientId,
 					false
 				);
-			} );
 
-			setSelectedLayout( false );
+				setSelectedLayout( false );
+			}, 50 );
 		}
 	}, [
 		selectedLayout,


### PR DESCRIPTION
close #941 

This removes the outdated help text from the Vertical alignment option and fixes a bug that requires you to click a template twice in the Grid template selector.