### PR TITLE
Feature: Migrate typography & add more unit control

### DIFF
--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -33,31 +33,17 @@ class GenerateBlocks_Block_Button {
 	public static function defaults() {
 		return [
 			'backgroundColor' => '',
-			'backgroundColorOpacity' => 1,
 			'backgroundColorHover' => '',
-			'backgroundColorHoverOpacity' => 1,
 			'backgroundColorCurrent' => '',
 			'textColor' => '',
 			'textColorHover' => '',
 			'textColorCurrent' => '',
 			'borderColor' => '',
-			'borderColorOpacity' => 1,
 			'borderColorHover' => '',
-			'borderColorHoverOpacity' => 1,
 			'borderColorCurrent' => '',
-			'fontFamily' => '',
 			'fontFamilyFallback' => '',
 			'googleFont' => false,
 			'googleFontVariants' => '',
-			'fontWeight' => '',
-			'fontSize' => false,
-			'fontSizeTablet' => false,
-			'fontSizeMobile' => false,
-			'fontSizeUnit' => 'px',
-			'textTransform' => '',
-			'letterSpacing' => '',
-			'letterSpacingTablet' => '',
-			'letterSpacingMobile' => '',
 			'icon' => '',
 			'hasIcon' => false,
 			'iconLocation' => 'left',
@@ -89,11 +75,26 @@ class GenerateBlocks_Block_Button {
 			'iconSizeMobile' => '',
 			'iconSizeUnit' => 'em',
 			'hasButtonContainer' => false,
+			'variantRole' => '',
+			'buttonType' => 'link',
+			// Deprecated attributes.
+			'backgroundColorOpacity' => 1,
+			'backgroundColorHoverOpacity' => 1,
+			'borderColorHoverOpacity' => 1,
+			'borderColorOpacity' => 1,
+			'fontSize' => false,
+			'fontSizeTablet' => false,
+			'fontSizeMobile' => false,
+			'fontSizeUnit' => 'px',
+			'letterSpacing' => '',
+			'letterSpacingTablet' => '',
+			'letterSpacingMobile' => '',
+			'fontWeight' => '',
+			'textTransform' => '',
 			'alignment' => '',
 			'alignmentTablet' => '',
 			'alignmentMobile' => '',
-			'variantRole' => '',
-			'buttonType' => 'link',
+			'fontFamily' => '',
 		];
 	}
 
@@ -156,12 +157,6 @@ class GenerateBlocks_Block_Button {
 			$settings['hasIcon'] = true;
 		}
 
-		$fontFamily = $settings['fontFamily'];
-
-		if ( $fontFamily && $settings['fontFamilyFallback'] ) {
-			$fontFamily = $fontFamily . ', ' . $settings['fontFamilyFallback'];
-		}
-
 		$gradientColorStopOneValue = '';
 		$gradientColorStopTwoValue = '';
 
@@ -203,6 +198,7 @@ class GenerateBlocks_Block_Button {
 		generateblocks_add_layout_css( $css, $settings );
 		generateblocks_add_sizing_css( $css, $settings );
 		generateblocks_add_flex_child_css( $css, $settings );
+		generateblocks_add_typography_css( $css, $settings );
 		$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
 		$css->add_property( 'color', $settings['textColor'] );
 
@@ -210,12 +206,6 @@ class GenerateBlocks_Block_Button {
 			$css->add_property( 'background-image', 'linear-gradient(' . $settings['gradientDirection'] . 'deg, ' . generateblocks_hex2rgba( $settings['gradientColorOne'], $settings['gradientColorOneOpacity'] ) . $gradientColorStopOneValue . ', ' . generateblocks_hex2rgba( $settings['gradientColorTwo'], $settings['gradientColorTwoOpacity'] ) . $gradientColorStopTwoValue . ')' );
 		}
 
-		$css->add_property( 'font-family', $fontFamily );
-		$css->add_property( 'font-size', $settings['fontSize'], $settings['fontSizeUnit'] );
-		$css->add_property( 'font-weight', $settings['fontWeight'] );
-		$css->add_property( 'text-transform', $settings['textTransform'] );
-		$css->add_property( 'text-align', $settings['alignment'] );
-		$css->add_property( 'letter-spacing', $settings['letterSpacing'], 'em' );
 		$css->add_property( 'padding', array( $settings['paddingTop'], $settings['paddingRight'], $settings['paddingBottom'], $settings['paddingLeft'] ), $settings['paddingUnit'] );
 		$css->add_property( 'border-radius', array( $settings['borderRadiusTopLeft'], $settings['borderRadiusTopRight'], $settings['borderRadiusBottomRight'], $settings['borderRadiusBottomLeft'] ), $settings['borderRadiusUnit'] );
 		$css->add_property( 'margin', array( $settings['marginTop'], $settings['marginRight'], $settings['marginBottom'], $settings['marginLeft'] ), $settings['marginUnit'] );
@@ -267,9 +257,7 @@ class GenerateBlocks_Block_Button {
 		generateblocks_add_layout_css( $tablet_css, $settings, 'Tablet' );
 		generateblocks_add_sizing_css( $tablet_css, $settings, 'Tablet' );
 		generateblocks_add_flex_child_css( $tablet_css, $settings, 'Tablet' );
-		$tablet_css->add_property( 'font-size', $settings['fontSizeTablet'], $settings['fontSizeUnit'] );
-		$tablet_css->add_property( 'letter-spacing', $settings['letterSpacingTablet'], 'em' );
-		$tablet_css->add_property( 'text-align', $settings['alignmentTablet'] );
+		generateblocks_add_typography_css( $tablet_css, $settings, 'Tablet' );
 		$tablet_css->add_property( 'padding', array( $settings['paddingTopTablet'], $settings['paddingRightTablet'], $settings['paddingBottomTablet'], $settings['paddingLeftTablet'] ), $settings['paddingUnit'] );
 		$tablet_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftTablet'], $settings['borderRadiusTopRightTablet'], $settings['borderRadiusBottomRightTablet'], $settings['borderRadiusBottomLeftTablet'] ), $settings['borderRadiusUnit'] );
 		$tablet_css->add_property( 'margin', array( $settings['marginTopTablet'], $settings['marginRightTablet'], $settings['marginBottomTablet'], $settings['marginLeftTablet'] ), $settings['marginUnit'] );
@@ -288,9 +276,7 @@ class GenerateBlocks_Block_Button {
 		generateblocks_add_layout_css( $mobile_css, $settings, 'Mobile' );
 		generateblocks_add_sizing_css( $mobile_css, $settings, 'Mobile' );
 		generateblocks_add_flex_child_css( $mobile_css, $settings, 'Mobile' );
-		$mobile_css->add_property( 'font-size', $settings['fontSizeMobile'], $settings['fontSizeUnit'] );
-		$mobile_css->add_property( 'letter-spacing', $settings['letterSpacingMobile'], 'em' );
-		$mobile_css->add_property( 'text-align', $settings['alignmentMobile'] );
+		generateblocks_add_typography_css( $mobile_css, $settings, 'Mobile' );
 		$mobile_css->add_property( 'padding', array( $settings['paddingTopMobile'], $settings['paddingRightMobile'], $settings['paddingBottomMobile'], $settings['paddingLeftMobile'] ), $settings['paddingUnit'] );
 		$mobile_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftMobile'], $settings['borderRadiusTopRightMobile'], $settings['borderRadiusBottomRightMobile'], $settings['borderRadiusBottomLeftMobile'] ), $settings['borderRadiusUnit'] );
 		$mobile_css->add_property( 'margin', array( $settings['marginTopMobile'], $settings['marginRightMobile'], $settings['marginBottomMobile'], $settings['marginLeftMobile'] ), $settings['marginUnit'] );

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -40,19 +40,8 @@ class GenerateBlocks_Block_Container {
 		return [
 			'tagName' => 'div',
 			'isGrid' => false,
-			'containerWidth' => $container_width,
-			'outerContainer' => 'full',
-			'innerContainer' => 'contained',
-			'minHeight' => false,
-			'minHeightUnit' => 'px',
-			'minHeightTablet' => false,
-			'minHeightUnitTablet' => 'px',
-			'minHeightMobile' => false,
-			'minHeightUnitMobile' => 'px',
 			'borderColor' => '',
-			'borderColorOpacity' => 1,
 			'backgroundColor' => '',
-			'backgroundColorOpacity' => 1,
 			'gradient' => false,
 			'gradientDirection' => '',
 			'gradientColorOne' => '',
@@ -77,6 +66,22 @@ class GenerateBlocks_Block_Container {
 			),
 			'bgImageSize' => 'full',
 			'bgImageInline' => false,
+			'innerZindex' => '',
+			'fontFamilyFallback' => '',
+			'googleFont' => false,
+			'googleFontVariants' => '',
+			'useInnerContainer' => false,
+			'variantRole' => '',
+			// Deprecated attributes.
+			'containerWidth' => $container_width,
+			'outerContainer' => 'full',
+			'innerContainer' => 'contained',
+			'minHeight' => false,
+			'minHeightUnit' => 'px',
+			'minHeightTablet' => false,
+			'minHeightUnitTablet' => 'px',
+			'minHeightMobile' => false,
+			'minHeightUnitMobile' => 'px',
 			'width' => '',
 			'widthTablet' => '',
 			'widthMobile' => '',
@@ -87,25 +92,21 @@ class GenerateBlocks_Block_Container {
 			'verticalAlignment' => '',
 			'verticalAlignmentTablet' => 'inherit',
 			'verticalAlignmentMobile' => 'inherit',
-			'innerZindex' => '',
-			'removeVerticalGap' => false,
-			'removeVerticalGapTablet' => false,
-			'removeVerticalGapMobile' => false,
-			'alignment' => '',
-			'alignmentTablet' => '',
-			'alignmentMobile' => '',
-			'fontFamily' => '',
-			'fontFamilyFallback' => '',
-			'googleFont' => false,
-			'googleFontVariants' => '',
-			'fontWeight' => '',
+			'borderColorOpacity' => 1,
+			'backgroundColorOpacity' => 1,
 			'fontSize' => '',
 			'fontSizeTablet' => '',
 			'fontSizeMobile' => '',
 			'fontSizeUnit' => 'px',
+			'fontWeight' => '',
 			'textTransform' => '',
-			'useInnerContainer' => false,
-			'variantRole' => '',
+			'alignment' => '',
+			'alignmentTablet' => '',
+			'alignmentMobile' => '',
+			'removeVerticalGap' => false,
+			'removeVerticalGapTablet' => false,
+			'removeVerticalGapMobile' => false,
+			'fontFamily' => '',
 		];
 	}
 
@@ -160,12 +161,6 @@ class GenerateBlocks_Block_Container {
 		$settings['useInnerContainer'] = $blockVersion < 3 || $settings['useInnerContainer'];
 		$useInnerContainer = $settings['useInnerContainer'];
 
-		$fontFamily = $settings['fontFamily'];
-
-		if ( $fontFamily && $settings['fontFamilyFallback'] ) {
-			$fontFamily = $fontFamily . ', ' . $settings['fontFamilyFallback'];
-		}
-
 		if ( ! isset( $settings['bgOptions']['selector'] ) ) {
 			$settings['bgOptions']['selector'] = 'element';
 		}
@@ -215,17 +210,13 @@ class GenerateBlocks_Block_Container {
 		generateblocks_add_sizing_css( $css, $settings );
 		generateblocks_add_layout_css( $css, $settings );
 		generateblocks_add_flex_child_css( $css, $settings );
-		$css->add_property( 'font-family', $fontFamily );
-		$css->add_property( 'font-size', $settings['fontSize'], $settings['fontSizeUnit'] );
-		$css->add_property( 'font-weight', $settings['fontWeight'] );
-		$css->add_property( 'text-transform', $settings['textTransform'] );
+		generateblocks_add_typography_css( $css, $settings );
 		$css->add_property( 'margin', array( $settings['marginTop'], $settings['marginRight'], $settings['marginBottom'], $settings['marginLeft'] ), $settings['marginUnit'] );
 		$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
 		$css->add_property( 'color', $settings['textColor'] );
 		$css->add_property( 'border-radius', array( $settings['borderRadiusTopLeft'], $settings['borderRadiusTopRight'], $settings['borderRadiusBottomRight'], $settings['borderRadiusBottomLeft'] ), $settings['borderRadiusUnit'] );
 		$css->add_property( 'border-width', array( $settings['borderSizeTop'], $settings['borderSizeRight'], $settings['borderSizeBottom'], $settings['borderSizeLeft'] ), 'px' );
 		$css->add_property( 'border-color', generateblocks_hex2rgba( $settings['borderColor'], $settings['borderColorOpacity'] ) );
-		$css->add_property( 'text-align', $settings['alignment'] );
 
 		if ( ! $useInnerContainer ) {
 			$css->add_property( 'padding', array( $settings['paddingTop'], $settings['paddingRight'], $settings['paddingBottom'], $settings['paddingLeft'] ), $settings['paddingUnit'] );
@@ -529,11 +520,10 @@ class GenerateBlocks_Block_Container {
 		generateblocks_add_sizing_css( $tablet_css, $settings, 'Tablet' );
 		generateblocks_add_layout_css( $tablet_css, $settings, 'Tablet' );
 		generateblocks_add_flex_child_css( $tablet_css, $settings, 'Tablet' );
-		$tablet_css->add_property( 'font-size', $settings['fontSizeTablet'], $settings['fontSizeUnit'] );
+		generateblocks_add_typography_css( $tablet_css, $settings, 'Tablet' );
 		$tablet_css->add_property( 'margin', array( $settings['marginTopTablet'], $settings['marginRightTablet'], $settings['marginBottomTablet'], $settings['marginLeftTablet'] ), $settings['marginUnit'] );
 		$tablet_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftTablet'], $settings['borderRadiusTopRightTablet'], $settings['borderRadiusBottomRightTablet'], $settings['borderRadiusBottomLeftTablet'] ), $settings['borderRadiusUnit'] );
 		$tablet_css->add_property( 'border-width', array( $settings['borderSizeTopTablet'], $settings['borderSizeRightTablet'], $settings['borderSizeBottomTablet'], $settings['borderSizeLeftTablet'] ), 'px' );
-		$tablet_css->add_property( 'text-align', $settings['alignmentTablet'] );
 
 		if ( $blockVersion < 3 ) {
 			$tablet_css->add_property( 'min-height', $settings['minHeightTablet'], $settings['minHeightUnitTablet'] );
@@ -683,11 +673,10 @@ class GenerateBlocks_Block_Container {
 		generateblocks_add_sizing_css( $mobile_css, $settings, 'Mobile' );
 		generateblocks_add_layout_css( $mobile_css, $settings, 'Mobile' );
 		generateblocks_add_flex_child_css( $mobile_css, $settings, 'Mobile' );
-		$mobile_css->add_property( 'font-size', $settings['fontSizeMobile'], $settings['fontSizeUnit'] );
+		generateblocks_add_typography_css( $mobile_css, $settings, 'Mobile' );
 		$mobile_css->add_property( 'margin', array( $settings['marginTopMobile'], $settings['marginRightMobile'], $settings['marginBottomMobile'], $settings['marginLeftMobile'] ), $settings['marginUnit'] );
 		$mobile_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftMobile'], $settings['borderRadiusTopRightMobile'], $settings['borderRadiusBottomRightMobile'], $settings['borderRadiusBottomLeftMobile'] ), $settings['borderRadiusUnit'] );
 		$mobile_css->add_property( 'border-width', array( $settings['borderSizeTopMobile'], $settings['borderSizeRightMobile'], $settings['borderSizeBottomMobile'], $settings['borderSizeLeftMobile'] ), 'px' );
-		$mobile_css->add_property( 'text-align', $settings['alignmentMobile'] );
 
 		if ( ! $useInnerContainer ) {
 			$mobile_css->add_property( 'padding', array( $settings['paddingTopMobile'], $settings['paddingRightMobile'], $settings['paddingBottomMobile'], $settings['paddingLeftMobile'] ), $settings['paddingUnit'] );

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -34,44 +34,21 @@ class GenerateBlocks_Block_Headline {
 		return [
 			'element' => 'h2',
 			'cssClasses' => '',
-			'alignment' => false,
-			'alignmentTablet' => false,
-			'alignmentMobile' => false,
-			'backgroundColor' => false,
-			'backgroundColorOpacity' => 1,
-			'textColor' => false,
-			'linkColor' => false,
-			'linkColorHover' => false,
-			'borderColor' => false,
-			'borderColorOpacity' => 1,
-			'highlightTextColor' => false,
-			'fontFamily' => '',
+			'backgroundColor' => '',
+			'textColor' => '',
+			'linkColor' => '',
+			'linkColorHover' => '',
+			'borderColor' => '',
+			'highlightTextColor' => '',
 			'fontFamilyFallback' => '',
 			'googleFont' => false,
 			'googleFontVariants' => '',
-			'fontWeight' => '',
-			'fontSize' => '',
-			'fontSizeTablet' => '',
-			'fontSizeMobile' => '',
-			'fontSizeUnit' => 'px',
-			'textTransform' => '',
-			'lineHeight' => '',
-			'lineHeightTablet' => '',
-			'lineHeightMobile' => '',
-			'lineHeightUnit' => 'em',
-			'letterSpacing' => '',
-			'letterSpacingTablet' => '',
-			'letterSpacingMobile' => '',
 			'icon' => '',
 			'hasIcon' => false,
-			'iconColor' => false,
-			'iconColorOpacity' => 1,
+			'iconColor' => '',
 			'iconLocation' => 'inline',
 			'iconLocationTablet' => '',
 			'iconLocationMobile' => '',
-			'iconVerticalAlignment' => 'center',
-			'iconVerticalAlignmentTablet' => '',
-			'iconVerticalAlignmentMobile' => '',
 			'iconPaddingTop' => '',
 			'iconPaddingRight' => '',
 			'iconPaddingBottom' => '',
@@ -89,11 +66,35 @@ class GenerateBlocks_Block_Headline {
 			'iconSizeTablet' => '',
 			'iconSizeMobile' => '',
 			'iconSizeUnit' => 'em',
+			'removeText' => false,
+			'ariaLabel' => '',
+			// Deprecated attributes.
+			'backgroundColorOpacity' => 1,
+			'borderColorOpacity' => 1,
+			'iconColorOpacity' => 1,
+			'fontSize' => '',
+			'fontSizeTablet' => '',
+			'fontSizeMobile' => '',
+			'fontSizeUnit' => 'px',
+			'lineHeight' => '',
+			'lineHeightTablet' => '',
+			'lineHeightMobile' => '',
+			'lineHeightUnit' => 'em',
+			'letterSpacing' => '',
+			'letterSpacingTablet' => '',
+			'letterSpacingMobile' => '',
+			'fontWeight' => '',
+			'textTransform' => '',
+			'alignment' => '',
+			'alignmentTablet' => '',
+			'alignmentMobile' => '',
+			'iconVerticalAlignment' => 'center',
+			'iconVerticalAlignmentTablet' => '',
+			'iconVerticalAlignmentMobile' => '',
 			'inlineWidth' => false,
 			'inlineWidthTablet' => false,
 			'inlineWidthMobile' => false,
-			'removeText' => false,
-			'ariaLabel' => '',
+			'fontFamily' => '',
 		];
 	}
 
@@ -149,12 +150,6 @@ class GenerateBlocks_Block_Headline {
 			$settings['hasIcon'] = true;
 		}
 
-		$fontFamily = $settings['fontFamily'];
-
-		if ( $fontFamily && $settings['fontFamilyFallback'] ) {
-			$fontFamily = $fontFamily . ', ' . $settings['fontFamilyFallback'];
-		}
-
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
 			$css->set_selector( '.gb-icon svg' );
@@ -181,15 +176,9 @@ class GenerateBlocks_Block_Headline {
 			generateblocks_add_layout_css( $css, $settings );
 			generateblocks_add_sizing_css( $css, $settings );
 			generateblocks_add_flex_child_css( $css, $settings );
-			$css->add_property( 'font-family', $fontFamily );
-			$css->add_property( 'text-align', $settings['alignment'] );
+			generateblocks_add_typography_css( $css, $settings );
 			$css->add_property( 'color', $settings['textColor'] );
 			$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
-			$css->add_property( 'font-size', $settings['fontSize'], $settings['fontSizeUnit'] );
-			$css->add_property( 'font-weight', $settings['fontWeight'] );
-			$css->add_property( 'text-transform', $settings['textTransform'] );
-			$css->add_property( 'line-height', $settings['lineHeight'], $settings['lineHeightUnit'] );
-			$css->add_property( 'letter-spacing', $settings['letterSpacing'], 'em' );
 			$css->add_property( 'padding', array( $settings['paddingTop'], $settings['paddingRight'], $settings['paddingBottom'], $settings['paddingLeft'] ), $settings['paddingUnit'] );
 			$css->add_property( 'margin', array( $settings['marginTop'], $settings['marginRight'], $settings['marginBottom'], $settings['marginLeft'] ), $settings['marginUnit'] );
 			$css->add_property( 'border-radius', array( $settings['borderRadiusTopLeft'], $settings['borderRadiusTopRight'], $settings['borderRadiusBottomRight'], $settings['borderRadiusBottomLeft'] ), $settings['borderRadiusUnit'] );
@@ -261,10 +250,7 @@ class GenerateBlocks_Block_Headline {
 			generateblocks_add_layout_css( $tablet_css, $settings, 'Tablet' );
 			generateblocks_add_sizing_css( $tablet_css, $settings, 'Tablet' );
 			generateblocks_add_flex_child_css( $tablet_css, $settings, 'Tablet' );
-			$tablet_css->add_property( 'text-align', $settings['alignmentTablet'] );
-			$tablet_css->add_property( 'font-size', $settings['fontSizeTablet'], $settings['fontSizeUnit'] );
-			$tablet_css->add_property( 'line-height', $settings['lineHeightTablet'], $settings['lineHeightUnit'] );
-			$tablet_css->add_property( 'letter-spacing', $settings['letterSpacingTablet'], 'em' );
+			generateblocks_add_typography_css( $tablet_css, $settings, 'Tablet' );
 			$tablet_css->add_property( 'margin', array( $settings['marginTopTablet'], $settings['marginRightTablet'], $settings['marginBottomTablet'], $settings['marginLeftTablet'] ), $settings['marginUnit'] );
 			$tablet_css->add_property( 'padding', array( $settings['paddingTopTablet'], $settings['paddingRightTablet'], $settings['paddingBottomTablet'], $settings['paddingLeftTablet'] ), $settings['paddingUnit'] );
 			$tablet_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftTablet'], $settings['borderRadiusTopRightTablet'], $settings['borderRadiusBottomRightTablet'], $settings['borderRadiusBottomLeftTablet'] ), $settings['borderRadiusUnit'] );
@@ -316,10 +302,7 @@ class GenerateBlocks_Block_Headline {
 			generateblocks_add_layout_css( $mobile_css, $settings, 'Mobile' );
 			generateblocks_add_sizing_css( $mobile_css, $settings, 'Mobile' );
 			generateblocks_add_flex_child_css( $mobile_css, $settings, 'Mobile' );
-			$mobile_css->add_property( 'text-align', $settings['alignmentMobile'] );
-			$mobile_css->add_property( 'font-size', $settings['fontSizeMobile'], $settings['fontSizeUnit'] );
-			$mobile_css->add_property( 'line-height', $settings['lineHeightMobile'], $settings['lineHeightUnit'] );
-			$mobile_css->add_property( 'letter-spacing', $settings['letterSpacingMobile'], 'em' );
+			generateblocks_add_typography_css( $mobile_css, $settings, 'Mobile' );
 			$mobile_css->add_property( 'margin', array( $settings['marginTopMobile'], $settings['marginRightMobile'], $settings['marginBottomMobile'], $settings['marginLeftMobile'] ), $settings['marginUnit'] );
 			$mobile_css->add_property( 'padding', array( $settings['paddingTopMobile'], $settings['paddingRightMobile'], $settings['paddingBottomMobile'], $settings['paddingLeftMobile'] ), $settings['paddingUnit'] );
 			$mobile_css->add_property( 'border-radius', array( $settings['borderRadiusTopLeftMobile'], $settings['borderRadiusTopRightMobile'], $settings['borderRadiusBottomRightMobile'], $settings['borderRadiusBottomLeftMobile'] ), $settings['borderRadiusUnit'] );

--- a/src/blocks/button/components/BlockControls.js
+++ b/src/blocks/button/components/BlockControls.js
@@ -76,10 +76,13 @@ export default ( props ) => {
 
 				{ ! isFlexItem( { device: deviceType, display, displayTablet, displayMobile } ) &&
 					<AlignmentToolbar
-						value={ getAttribute( 'alignment', { attributes, deviceType } ) }
+						value={ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType } ) }
 						onChange={ ( value ) => {
 							setAttributes( {
-								[ getAttribute( 'alignment', { attributes, deviceType }, true ) ]: value,
+								typography: {
+									...attributes.typography,
+									[ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType }, true ) ]: value,
+								},
 							} );
 						} }
 						alignmentControls={ typographyOptions.alignments }

--- a/src/blocks/button/css/main.js
+++ b/src/blocks/button/css/main.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/hooks';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
 import { sprintf } from '@wordpress/i18n';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 export default class MainCSS extends Component {
 	render() {
@@ -32,11 +33,6 @@ export default class MainCSS extends Component {
 			textColorHover,
 			fontFamily,
 			fontFamilyFallback,
-			fontWeight,
-			textTransform,
-			letterSpacing,
-			fontSize,
-			fontSizeUnit,
 			paddingTop,
 			paddingRight,
 			paddingBottom,
@@ -71,7 +67,6 @@ export default class MainCSS extends Component {
 			iconSize,
 			iconSizeUnit,
 			hasButtonContainer,
-			alignment,
 			backgroundColorCurrent,
 			textColorCurrent,
 			borderColorCurrent,
@@ -113,14 +108,10 @@ export default class MainCSS extends Component {
 			'padding': shorthandCSS( paddingTop, paddingRight, paddingBottom, paddingLeft, paddingUnit ), // eslint-disable-line quote-props
 			'border-radius': shorthandCSS( borderRadiusTopLeft, borderRadiusTopRight, borderRadiusBottomRight, borderRadiusBottomLeft, borderRadiusUnit ),
 			'font-family': fontFamily + fontFamilyFallbackValue,
-			'font-weight': fontWeight,
-			'text-transform': textTransform,
-			'font-size': valueWithUnit( fontSize, fontSizeUnit ),
-			'text-align': alignment,
-			'letter-spacing': valueWithUnit( letterSpacing, 'em' ),
 			'border-color': hexToRGBA( borderColor, borderColorOpacity ),
 		} ];
 
+		TypographyCSS( cssObj, selector, { ...attributes.typography, fontFamilyFallback } );
 		SpacingCSS( cssObj, selector, attributes );
 		LayoutCSS( cssObj, selector, attributes );
 		SizingCSS( cssObj, selector, attributes );

--- a/src/blocks/button/css/mobile.js
+++ b/src/blocks/button/css/mobile.js
@@ -5,6 +5,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import SizingCSS from '../../../extend/inspector-control/controls/sizing/components/SizingCSS';
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -21,9 +22,6 @@ export default class MobileCSS extends Component {
 		const {
 			uniqueId,
 			removeText,
-			letterSpacingMobile,
-			fontSizeMobile,
-			fontSizeUnit,
 			paddingTopMobile,
 			paddingRightMobile,
 			paddingBottomMobile,
@@ -43,7 +41,6 @@ export default class MobileCSS extends Component {
 			iconSizeMobile,
 			iconSizeUnit,
 			hasButtonContainer,
-			alignmentMobile,
 		} = attributes;
 
 		const containerSelector = !! hasButtonContainer ? '.gb-button-wrapper ' : '';
@@ -61,11 +58,9 @@ export default class MobileCSS extends Component {
 			'border-top-right-radius': borderRadiusTopRightMobile,
 			'border-bottom-right-radius': borderRadiusBottomRightMobile,
 			'border-bottom-left-radius': borderRadiusBottomLeftMobile,
-			'font-size': valueWithUnit( fontSizeMobile, fontSizeUnit ),
-			'letter-spacing': valueWithUnit( letterSpacingMobile, 'em' ),
-			'text-align': alignmentMobile,
 		} ];
 
+		TypographyCSS( cssObj, selector, attributes.typography, 'Mobile' );
 		SpacingCSS( cssObj, selector, attributes, 'Mobile' );
 		LayoutCSS( cssObj, selector, attributes, 'Mobile' );
 		SizingCSS( cssObj, selector, attributes, 'Mobile' );

--- a/src/blocks/button/css/tablet.js
+++ b/src/blocks/button/css/tablet.js
@@ -5,6 +5,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import SizingCSS from '../../../extend/inspector-control/controls/sizing/components/SizingCSS';
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -21,9 +22,6 @@ export default class TabletCSS extends Component {
 		const {
 			uniqueId,
 			removeText,
-			letterSpacingTablet,
-			fontSizeTablet,
-			fontSizeUnit,
 			paddingTopTablet,
 			paddingRightTablet,
 			paddingBottomTablet,
@@ -43,7 +41,6 @@ export default class TabletCSS extends Component {
 			iconSizeTablet,
 			iconSizeUnit,
 			hasButtonContainer,
-			alignmentTablet,
 		} = attributes;
 
 		const containerSelector = !! hasButtonContainer ? '.gb-button-wrapper ' : '';
@@ -61,11 +58,9 @@ export default class TabletCSS extends Component {
 			'border-top-right-radius': borderRadiusTopRightTablet,
 			'border-bottom-right-radius': borderRadiusBottomRightTablet,
 			'border-bottom-left-radius': borderRadiusBottomLeftTablet,
-			'font-size': valueWithUnit( fontSizeTablet, fontSizeUnit ),
-			'letter-spacing': valueWithUnit( letterSpacingTablet, 'em' ),
-			'text-align': alignmentTablet,
 		} ];
 
+		TypographyCSS( cssObj, selector, attributes.typography, 'Tablet' );
 		SpacingCSS( cssObj, selector, attributes, 'Tablet' );
 		LayoutCSS( cssObj, selector, attributes, 'Tablet' );
 		SizingCSS( cssObj, selector, attributes, 'Tablet' );

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -26,7 +26,7 @@ const ButtonEdit = ( props ) => {
 	const {
 		anchor,
 		ariaLabel,
-		fontFamily,
+		typography,
 		googleFont,
 		googleFontVariants,
 		isBlockPreview = false,
@@ -99,7 +99,7 @@ const ButtonEdit = ( props ) => {
 			<ComponentCSS { ...props } deviceType={ deviceType } />
 
 			<GoogleFontLink
-				fontFamily={ fontFamily }
+				fontFamily={ typography.fontFamily }
 				googleFont={ googleFont }
 				googleFontVariants={ googleFontVariants }
 				isBlockPreview={ isBlockPreview }

--- a/src/blocks/container/components/BlockControls.js
+++ b/src/blocks/container/components/BlockControls.js
@@ -26,10 +26,13 @@ export default ( { attributes, setAttributes } ) => {
 		<BlockControls group="block">
 			{ ! isFlexItem( { device: deviceType, display, displayTablet, displayMobile } ) &&
 				<AlignmentToolbar
-					value={ getAttribute( 'alignment', { attributes, deviceType } ) }
+					value={ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType } ) }
 					onChange={ ( value ) => {
 						setAttributes( {
-							[ getAttribute( 'alignment', { attributes, deviceType }, true ) ]: value,
+							typography: {
+								...attributes.typography,
+								[ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType }, true ) ]: value,
+							},
 						} );
 					} }
 					alignmentControls={ typographyOptions.alignments }

--- a/src/blocks/container/css/main.js
+++ b/src/blocks/container/css/main.js
@@ -13,6 +13,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import isFlexItem from '../../../utils/is-flex-item';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 export default function MainCSS( props ) {
 	const attributes = applyFilters( 'generateblocks.editor.cssAttrs', props.attributes, props );
@@ -59,13 +60,8 @@ export default function MainCSS( props ) {
 		verticalAlignment,
 		zindex,
 		innerZindex,
-		alignment,
 		fontFamily,
 		fontFamilyFallback,
-		fontWeight,
-		fontSize,
-		fontSizeUnit,
-		textTransform,
 		shapeDividers,
 		gridId,
 		useDynamicData,
@@ -100,14 +96,11 @@ export default function MainCSS( props ) {
 		'background-color': hexToRGBA( backgroundColor, backgroundColorOpacity ),
 		'color': textColor, // eslint-disable-line quote-props
 		'border-radius': shorthandCSS( borderRadiusTopLeft, borderRadiusTopRight, borderRadiusBottomRight, borderRadiusBottomLeft, borderRadiusUnit ),
-		'text-align': alignment,
 		'font-family': fontFamily + fontFamilyFallbackValue,
-		'font-weight': fontWeight,
-		'text-transform': textTransform,
-		'font-size': valueWithUnit( fontSize, fontSizeUnit ),
 		'border-color': hexToRGBA( borderColor, borderColorOpacity ),
 	} ];
 
+	TypographyCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, { ...attributes.typography, fontFamilyFallback } );
 	SpacingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes );
 	SizingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes );
 	LayoutCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes );

--- a/src/blocks/container/css/mobile.js
+++ b/src/blocks/container/css/mobile.js
@@ -4,6 +4,7 @@ import valueWithUnit from '../../../utils/value-with-unit';
 import LayoutCSS from '../../../extend/inspector-control/controls/layout/components/LayoutCSS';
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -39,9 +40,6 @@ export default class MobileCSS extends Component {
 			borderRadiusTopLeftMobile,
 			verticalAlignmentMobile,
 			removeVerticalGapMobile,
-			alignmentMobile,
-			fontSizeMobile,
-			fontSizeUnit,
 			orderMobile,
 			shapeDividers,
 			bgImage,
@@ -57,10 +55,9 @@ export default class MobileCSS extends Component {
 			'border-top-right-radius': borderRadiusTopRightMobile,
 			'border-bottom-right-radius': borderRadiusBottomRightMobile,
 			'border-bottom-left-radius': borderRadiusBottomLeftMobile,
-			'text-align': alignmentMobile,
-			'font-size': valueWithUnit( fontSizeMobile, fontSizeUnit ),
 		} ];
 
+		TypographyCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes.typography, 'Mobile' );
 		SpacingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Mobile' );
 		SizingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Mobile' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Mobile' );

--- a/src/blocks/container/css/tablet.js
+++ b/src/blocks/container/css/tablet.js
@@ -5,6 +5,7 @@ import SizingCSS from '../../../extend/inspector-control/controls/sizing/compone
 import LayoutCSS from '../../../extend/inspector-control/controls/layout/components/LayoutCSS';
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -38,9 +39,6 @@ export default class TabletCSS extends Component {
 			borderRadiusBottomLeftTablet,
 			borderRadiusTopLeftTablet,
 			verticalAlignmentTablet,
-			alignmentTablet,
-			fontSizeTablet,
-			fontSizeUnit,
 			orderTablet,
 			shapeDividers,
 			bgImage,
@@ -56,10 +54,9 @@ export default class TabletCSS extends Component {
 			'border-top-right-radius': borderRadiusTopRightTablet,
 			'border-bottom-right-radius': borderRadiusBottomRightTablet,
 			'border-bottom-left-radius': borderRadiusBottomLeftTablet,
-			'text-align': alignmentTablet,
-			'font-size': valueWithUnit( fontSizeTablet, fontSizeUnit ),
 		} ];
 
+		TypographyCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes.typography, 'Tablet' );
 		SpacingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Tablet' );
 		SizingCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Tablet' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper .gb-container-' + uniqueId, attributes, 'Tablet' );

--- a/src/blocks/container/edit.js
+++ b/src/blocks/container/edit.js
@@ -23,7 +23,7 @@ const ContainerEdit = ( props ) => {
 
 	const {
 		anchor,
-		fontFamily,
+		typography,
 		googleFont,
 		googleFontVariants,
 		isBlockPreview = false,
@@ -123,7 +123,7 @@ const ContainerEdit = ( props ) => {
 			/>
 
 			<GoogleFontLink
-				fontFamily={ fontFamily }
+				fontFamily={ typography.fontFamily }
 				googleFont={ googleFont }
 				googleFontVariants={ googleFontVariants }
 				isBlockPreview={ isBlockPreview }

--- a/src/blocks/headline/components/BlockControls.js
+++ b/src/blocks/headline/components/BlockControls.js
@@ -1,12 +1,11 @@
 import ToolbarGroup from './ToolbarGroup';
-import { memo } from '@wordpress/element';
 import { AlignmentToolbar, BlockControls } from '@wordpress/block-editor';
 import isFlexItem from '../../../utils/is-flex-item';
 import getAttribute from '../../../utils/get-attribute';
 import typographyOptions from '../../../extend/inspector-control/controls/typography/options';
 import getDeviceType from '../../../utils/get-device-type';
 
-function HeadlineBlockControls( props ) {
+export default function HeadlineBlockControls( props ) {
 	const {
 		attributes,
 		setAttributes,
@@ -33,10 +32,13 @@ function HeadlineBlockControls( props ) {
 			{ ! isFlexItem( { device, display, displayTablet, displayMobile } ) &&
 				<>
 					<AlignmentToolbar
-						value={ getAttribute( 'alignment', { attributes, deviceType: device } ) }
+						value={ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType: device } ) }
 						onChange={ ( value ) => {
 							setAttributes( {
-								[ getAttribute( 'alignment', { attributes, deviceType: device }, true ) ]: value,
+								typography: {
+									...attributes.typography,
+									[ getAttribute( 'textAlign', { attributes: attributes.typography, deviceType: device }, true ) ]: value,
+								},
 							} );
 						} }
 						alignmentControls={ typographyOptions.alignments }
@@ -46,17 +48,3 @@ function HeadlineBlockControls( props ) {
 		</BlockControls>
 	);
 }
-
-export default memo( HeadlineBlockControls, ( prevProps, nextProps ) => {
-	return [
-		'element',
-		'alignment',
-		'alignmentTablet',
-		'alignmentMobile',
-		'display',
-		'displayTablet',
-		'displayMobile',
-	].every( ( key ) => {
-		return prevProps.attributes[ key ] === nextProps.attributes[ key ];
-	} ) && prevProps.deviceType === nextProps.deviceType;
-} );

--- a/src/blocks/headline/css/main.js
+++ b/src/blocks/headline/css/main.js
@@ -6,6 +6,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SizingCSS from '../../../extend/inspector-control/controls/sizing/components/SizingCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -26,7 +27,6 @@ export default class MainCSS extends Component {
 		const {
 			uniqueId,
 			element,
-			alignment,
 			backgroundColor,
 			backgroundColorOpacity,
 			textColor,
@@ -37,13 +37,6 @@ export default class MainCSS extends Component {
 			highlightTextColor,
 			fontFamily,
 			fontFamilyFallback,
-			fontWeight,
-			fontSize,
-			fontSizeUnit,
-			textTransform,
-			lineHeight,
-			lineHeightUnit,
-			letterSpacing,
 			paddingTop,
 			paddingRight,
 			paddingBottom,
@@ -85,14 +78,9 @@ export default class MainCSS extends Component {
 		cssObj[ '.editor-styles-wrapper ' + selector ] = [ {
 			color: textColor,
 			'font-family': fontFamily + fontFamilyFallbackValue,
-			'font-weight': fontWeight,
-			'text-transform': textTransform,
-			'text-align': alignment,
-			'font-size': valueWithUnit( fontSize, fontSizeUnit ),
-			'line-height': valueWithUnit( lineHeight, lineHeightUnit ),
-			'letter-spacing': valueWithUnit( letterSpacing, 'em' ),
 		} ];
 
+		TypographyCSS( cssObj, '.editor-styles-wrapper ' + selector, { ...attributes.typography, fontFamilyFallback } );
 		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes );
 		LayoutCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes );
 		SizingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes );

--- a/src/blocks/headline/css/mobile.js
+++ b/src/blocks/headline/css/mobile.js
@@ -4,6 +4,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SizingCSS from '../../../extend/inspector-control/controls/sizing/components/SizingCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -24,12 +25,6 @@ export default class MobileCSS extends Component {
 		const {
 			uniqueId,
 			element,
-			alignmentMobile,
-			fontSizeMobile,
-			fontSizeUnit,
-			lineHeightMobile,
-			lineHeightUnit,
-			letterSpacingMobile,
 			paddingTopMobile,
 			paddingRightMobile,
 			paddingBottomMobile,
@@ -57,10 +52,6 @@ export default class MobileCSS extends Component {
 		let cssObj = [];
 
 		cssObj[ '.editor-styles-wrapper ' + selector ] = [ {
-			'text-align': alignmentMobile,
-			'font-size': valueWithUnit( fontSizeMobile, fontSizeUnit ),
-			'line-height': valueWithUnit( lineHeightMobile, lineHeightUnit ),
-			'letter-spacing': valueWithUnit( letterSpacingMobile, 'em' ),
 			'padding-top': paddingTopMobile,
 			'padding-right': paddingRightMobile,
 			'padding-bottom': paddingBottomMobile,
@@ -71,6 +62,7 @@ export default class MobileCSS extends Component {
 			'border-bottom-left-radius': borderRadiusBottomLeftMobile,
 		} ];
 
+		TypographyCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes.typography, 'Mobile' );
 		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );
 		SizingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Mobile' );

--- a/src/blocks/headline/css/tablet.js
+++ b/src/blocks/headline/css/tablet.js
@@ -4,6 +4,7 @@ import LayoutCSS from '../../../extend/inspector-control/controls/layout/compone
 import FlexChildCSS from '../../../extend/inspector-control/controls/flex-child-panel/components/FlexChildCSS';
 import SizingCSS from '../../../extend/inspector-control/controls/sizing/components/SizingCSS';
 import SpacingCSS from '../../../extend/inspector-control/controls/spacing/components/SpacingCSS';
+import TypographyCSS from '../../../extend/inspector-control/controls/typography/components/TypographyCSS';
 
 import {
 	Component,
@@ -24,12 +25,6 @@ export default class TabletCSS extends Component {
 		const {
 			uniqueId,
 			element,
-			alignmentTablet,
-			fontSizeTablet,
-			fontSizeUnit,
-			lineHeightTablet,
-			lineHeightUnit,
-			letterSpacingTablet,
 			paddingTopTablet,
 			paddingRightTablet,
 			paddingBottomTablet,
@@ -57,10 +52,6 @@ export default class TabletCSS extends Component {
 		let cssObj = [];
 
 		cssObj[ '.editor-styles-wrapper ' + selector ] = [ {
-			'text-align': alignmentTablet,
-			'font-size': valueWithUnit( fontSizeTablet, fontSizeUnit ),
-			'line-height': valueWithUnit( lineHeightTablet, lineHeightUnit ),
-			'letter-spacing': valueWithUnit( letterSpacingTablet, 'em' ),
 			'padding-top': paddingTopTablet,
 			'padding-right': paddingRightTablet,
 			'padding-bottom': paddingBottomTablet,
@@ -71,6 +62,7 @@ export default class TabletCSS extends Component {
 			'border-bottom-left-radius': borderRadiusBottomLeftTablet,
 		} ];
 
+		TypographyCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes.typography, 'Tablet' );
 		SpacingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );
 		LayoutCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );
 		SizingCSS( cssObj, '.editor-styles-wrapper ' + selector, attributes, 'Tablet' );

--- a/src/blocks/headline/edit.js
+++ b/src/blocks/headline/edit.js
@@ -44,7 +44,7 @@ const HeadlineEdit = ( props ) => {
 
 	const {
 		anchor,
-		fontFamily,
+		typography,
 		googleFont,
 		googleFontVariants,
 		icon,
@@ -98,7 +98,7 @@ const HeadlineEdit = ( props ) => {
 			<ComponentCSS { ...props } deviceType={ deviceType } />
 
 			<GoogleFontLink
-				fontFamily={ fontFamily }
+				fontFamily={ typography.fontFamily }
 				googleFont={ googleFont }
 				googleFontVariants={ googleFontVariants }
 				isBlockPreview={ isBlockPreview }

--- a/src/components/google-font-link/index.js
+++ b/src/components/google-font-link/index.js
@@ -5,6 +5,10 @@ export default ( { fontFamily, googleFont, googleFontVariants, isBlockPreview } 
 		return null;
 	}
 
+	if ( ! fontFamily ) {
+		return null;
+	}
+
 	const gFontsUrl = 'https://fonts.googleapis.com/css?family=';
 	const googleFontsAttr = googleFontVariants ? `:${ googleFontVariants }` : '';
 	const href = gFontsUrl + fontFamily.replace( / /g, '+' ) + googleFontsAttr;

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -15,6 +15,7 @@ export default function UnitControl( props ) {
 	const {
 		label,
 		units = [ 'px', 'em', '%', 'rem' ],
+		defaultUnit = '',
 		min = 0,
 		max,
 		step,
@@ -49,7 +50,8 @@ export default function UnitControl( props ) {
 	};
 
 	const getNumericValue = ( values ) => values.length > 0 ? values[ 0 ] : '';
-	const getUnitValue = ( values ) => values.length > 1 ? values[ 1 ] : units[ 0 ];
+	const defaultUnitValue = defaultUnit ? defaultUnit : units[ 0 ];
+	const getUnitValue = ( values ) => values.length > 1 ? values[ 1 ] : defaultUnitValue;
 	const startsWithNumber = ( number ) => /^\d/.test( number );
 
 	const setPlaceholders = () => {

--- a/src/extend/inspector-control/controls/typography/attributes.js
+++ b/src/extend/inspector-control/controls/typography/attributes.js
@@ -1,15 +1,17 @@
 export default function getTypographyAttributes( defaults ) {
 	return {
+		typography: {
+			type: 'object',
+			default: {},
+		},
 		fontWeight: {
 			type: 'string',
 			default: defaults.fontWeight,
 		},
-
 		textTransform: {
 			type: 'string',
 			default: '',
 		},
-
 		alignment: {
 			type: 'string',
 			default: defaults.alignment,
@@ -22,7 +24,6 @@ export default function getTypographyAttributes( defaults ) {
 			type: 'string',
 			default: defaults.alignmentMobile,
 		},
-
 		// FONT SIZE ATTRIBUTES
 		fontSize: {
 			type: 'number',

--- a/src/extend/inspector-control/controls/typography/components/TypographyCSS.js
+++ b/src/extend/inspector-control/controls/typography/components/TypographyCSS.js
@@ -1,0 +1,20 @@
+import addToCSS from '../../../../../utils/add-to-css';
+
+export default function TypographyCSS( css, selector, attributes, device = '' ) {
+	const fontFamilyValues = [ attributes.fontFamily, attributes.fontFamilyFallback ].filter( ( v ) => v );
+	const fontFamily = fontFamilyValues.join( ', ' );
+
+	const styles = {
+		'font-family': fontFamily,
+		'font-size': attributes[ 'fontSize' + device ],
+		'line-height': attributes[ 'lineHeight' + device ],
+		'letter-spacing': attributes[ 'letterSpacing' + device ],
+		'font-weight': attributes[ 'fontWeight' + device ],
+		'text-transform': attributes[ 'textTransform' + device ],
+		'text-align': attributes[ 'textAlign' + device ],
+	};
+
+	return (
+		addToCSS( css, selector, styles )
+	);
+}

--- a/src/extend/inspector-control/controls/typography/components/font-family.js
+++ b/src/extend/inspector-control/controls/typography/components/font-family.js
@@ -76,7 +76,7 @@ export default function FontFamily( { attributes, setAttributes } ) {
 				/>
 			</BaseControl>
 
-			{ '' !== typography.fontFamily &&
+			{ !! typography.fontFamily &&
 				<Fragment>
 					<ToggleControl
 						label={ __( 'Use Google Fonts API', 'generateblocks' ) }

--- a/src/extend/inspector-control/controls/typography/components/font-family.js
+++ b/src/extend/inspector-control/controls/typography/components/font-family.js
@@ -7,7 +7,7 @@ import AdvancedSelect from '../../../../../components/advanced-select';
 
 export default function FontFamily( { attributes, setAttributes } ) {
 	const {
-		fontFamily,
+		typography,
 		fontFamilyFallback,
 		googleFont,
 		googleFontVariants,
@@ -33,7 +33,12 @@ export default function FontFamily( { attributes, setAttributes } ) {
 	}, [] );
 
 	function onFontChange( value ) {
-		setAttributes( { fontFamily: value } );
+		setAttributes( {
+			typography: {
+				...typography,
+				fontFamily: value,
+			},
+		} );
 
 		if ( typeof googleFonts[ value ] !== 'undefined' ) {
 			setAttributes( {
@@ -50,7 +55,7 @@ export default function FontFamily( { attributes, setAttributes } ) {
 		}
 	}
 
-	const value = !! fontFamily ? { value: fontFamily, label: fontFamily } : '';
+	const value = !! typography.fontFamily ? { value: typography.fontFamily, label: typography.fontFamily } : '';
 
 	return (
 		<>
@@ -71,7 +76,7 @@ export default function FontFamily( { attributes, setAttributes } ) {
 				/>
 			</BaseControl>
 
-			{ '' !== fontFamily &&
+			{ '' !== typography.fontFamily &&
 				<Fragment>
 					<ToggleControl
 						label={ __( 'Use Google Fonts API', 'generateblocks' ) }
@@ -82,10 +87,10 @@ export default function FontFamily( { attributes, setAttributes } ) {
 							} );
 
 							if ( newGoogleFontValue ) {
-								if ( typeof googleFonts[ fontFamily ] !== 'undefined' ) {
+								if ( typeof googleFonts[ typography.fontFamily ] !== 'undefined' ) {
 									setAttributes( {
-										fontFamilyFallback: googleFonts[ fontFamily ].fallback,
-										googleFontVariants: googleFonts[ fontFamily ].weight.join( ', ' ),
+										fontFamilyFallback: googleFonts[ typography.fontFamily ].fallback,
+										googleFontVariants: googleFonts[ typography.fontFamily ].weight.join( ', ' ),
 									} );
 								}
 							}

--- a/src/extend/inspector-control/controls/typography/components/font-size.js
+++ b/src/extend/inspector-control/controls/typography/components/font-size.js
@@ -1,29 +1,15 @@
-import NumberControl from '../../../../../components/number-control';
 import { __ } from '@wordpress/i18n';
+import UnitControl from '../../../../../components/unit-control';
 
-export default function FontSize( { attributes, computedStyles, setAttributes, device } ) {
+export default function FontSize( { units, value, placeholder, onChange } ) {
 	return (
-		<NumberControl
+		<UnitControl
 			label={ __( 'Font Size', 'generateblocks' ) }
-			attributeName="fontSize"
-			units={ [ 'px', 'em', '%' ] }
-			defaultPlaceholder={
-				computedStyles.fontSize && 'px' === attributes.fontSizeUnit
-					? computedStyles.fontSize
-					: ''
-			}
-			presets={
-				[
-					{
-						unit: 'px',
-						data: [ 13, 17, 25, 35 ],
-					},
-				]
-			}
-			min="1"
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			device={ device }
+			id="gblocks-font-size"
+			units={ units }
+			value={ value }
+			placeholder={ placeholder }
+			onChange={ onChange }
 		/>
 	);
 }

--- a/src/extend/inspector-control/controls/typography/components/letter-spacing.js
+++ b/src/extend/inspector-control/controls/typography/components/letter-spacing.js
@@ -1,12 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function LetterSpacing( { units, value, placeholder, onChange } ) {
+export default function LetterSpacing( { units, value, placeholder, onChange, defaultUnit } ) {
 	return (
 		<UnitControl
 			label={ __( 'Letter Spacing', 'generateblocks' ) }
 			id="gblocks-letter-spacing"
 			units={ units }
+			defaultUnit={ defaultUnit }
 			value={ value }
 			placeholder={ placeholder }
 			onChange={ onChange }

--- a/src/extend/inspector-control/controls/typography/components/letter-spacing.js
+++ b/src/extend/inspector-control/controls/typography/components/letter-spacing.js
@@ -1,39 +1,15 @@
 import { __ } from '@wordpress/i18n';
-import NumberControl from '../../../../../components/number-control';
+import UnitControl from '../../../../../components/unit-control';
 
-export default function LetterSpacing( { attributes, setAttributes, device } ) {
+export default function LetterSpacing( { units, value, placeholder, onChange } ) {
 	return (
-		<NumberControl
+		<UnitControl
 			label={ __( 'Letter Spacing', 'generateblocks' ) }
-			attributeName="letterSpacing"
-			unit="em"
-			units={ [ 'em' ] }
-			device={ device }
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			presets={
-				[
-					{
-						unit: 'em',
-						data: [
-							{
-								label: __( 'Small', 'generateblocks' ),
-								value: -0.02,
-							},
-							{
-								label: __( 'Medium', 'generateblocks' ),
-								value: 0.02,
-							},
-							{
-								label: __( 'Large', 'generateblocks' ),
-								value: 0.05,
-							},
-						],
-					},
-				]
-			}
-			min={ -1 }
-			step={ .01 }
+			id="gblocks-letter-spacing"
+			units={ units }
+			value={ value }
+			placeholder={ placeholder }
+			onChange={ onChange }
 		/>
 	);
 }

--- a/src/extend/inspector-control/controls/typography/components/line-height.js
+++ b/src/extend/inspector-control/controls/typography/components/line-height.js
@@ -1,38 +1,15 @@
 import { __ } from '@wordpress/i18n';
-import NumberControl from '../../../../../components/number-control';
+import UnitControl from '../../../../../components/unit-control';
 
-export default function LineHeight( { attributes, setAttributes, device } ) {
+export default function LineHeight( { units, value, placeholder, onChange } ) {
 	return (
-		<NumberControl
+		<UnitControl
 			label={ __( 'Line Height', 'generateblocks' ) }
-			attributeName="lineHeight"
-			units={ [ 'px', 'em', '%' ] }
-			device={ device }
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-			presets={
-				[
-					{
-						unit: 'em',
-						data: [
-							{
-								label: __( 'Small', 'generateblocks' ),
-								value: 0.8,
-							},
-							{
-								label: __( 'Medium', 'generateblocks' ),
-								value: 1,
-							},
-							{
-								label: __( 'Large', 'generateblocks' ),
-								value: 1.5,
-							},
-						],
-					},
-				]
-			}
-			min="0"
-			step={ .1 }
+			id="gblocks-line-height"
+			units={ units }
+			value={ value }
+			placeholder={ placeholder }
+			onChange={ onChange }
 		/>
 	);
 }

--- a/src/extend/inspector-control/controls/typography/components/line-height.js
+++ b/src/extend/inspector-control/controls/typography/components/line-height.js
@@ -1,12 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import UnitControl from '../../../../../components/unit-control';
 
-export default function LineHeight( { units, value, placeholder, onChange } ) {
+export default function LineHeight( { units, value, placeholder, onChange, defaultUnit } ) {
 	return (
 		<UnitControl
 			label={ __( 'Line Height', 'generateblocks' ) }
 			id="gblocks-line-height"
 			units={ units }
+			defaultUnit={ defaultUnit }
 			value={ value }
 			placeholder={ placeholder }
 			onChange={ onChange }

--- a/src/extend/inspector-control/controls/typography/index.js
+++ b/src/extend/inspector-control/controls/typography/index.js
@@ -13,11 +13,13 @@ import Alignment from './components/alignment';
 import getAttribute from '../../../../utils/get-attribute';
 import FlexControl from '../../../../components/flex-control';
 import getDeviceType from '../../../../utils/get-device-type';
+import getResponsivePlaceholder from '../../../../utils/get-responsive-placeholder';
 import './editor.scss';
 
 export default function Typography( { attributes, setAttributes, computedStyles } ) {
 	const device = getDeviceType();
-	const { id, supports: { typography } } = useContext( ControlsContext );
+	const { id, supports: { typography: typographySupports } } = useContext( ControlsContext );
+	const { typography } = attributes;
 	const isDesktop = 'Desktop' === device;
 
 	return (
@@ -28,53 +30,97 @@ export default function Typography( { attributes, setAttributes, computedStyles 
 			className="gblocks-panel-label"
 			id={ `${ id }Typography` }
 		>
-			{ typography.alignment &&
+			{ typographySupports.alignment &&
 				<Alignment
-					value={ getAttribute( 'alignment', { attributes, deviceType: device } ) }
-					onChange={ ( value ) => setAttributes( { [ getAttribute( 'alignment', { attributes, deviceType: device }, true ) ]: value } ) }
+					value={ getAttribute( 'textAlign', { attributes: typography, deviceType: device } ) }
+					onChange={ ( value ) => {
+						setAttributes( {
+							typography: {
+								...typography,
+								[ getAttribute( 'textAlign', { attributes: typography, deviceType: device }, true ) ]: value,
+							},
+						} );
+					} }
 				/>
 			}
 
-			{ !! isDesktop && ( typography.fontWeight || typography.textTransform ) &&
+			{ !! isDesktop && ( typographySupports.fontWeight || typographySupports.textTransform ) &&
 				<FlexControl>
 					<FontWeight
-						value={ attributes.fontWeight }
-						onChange={ ( value ) => setAttributes( { fontWeight: value } ) }
+						value={ typography?.fontWeight }
+						onChange={ ( value ) => {
+							setAttributes( {
+								typography: {
+									...typography,
+									[ getAttribute( 'fontWeight', { attributes: typography, deviceType: device }, true ) ]: value,
+								},
+							} );
+						} }
 					/>
 
 					<TextTransform
-						value={ attributes.textTransform }
-						onChange={ ( textTransform ) => setAttributes( { textTransform } ) }
+						value={ typography?.textTransform }
+						onChange={ ( value ) => {
+							setAttributes( {
+								typography: {
+									...typography,
+									[ getAttribute( 'textTransform', { attributes: typography, deviceType: device }, true ) ]: value,
+								},
+							} );
+						} }
 					/>
 				</FlexControl>
 			}
 
-			{ typography.fontSize &&
+			{ typographySupports.fontSize &&
 				<FontSize
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					computedStyles={ computedStyles }
-					device={ device }
+					units={ [ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ] }
+					value={ getAttribute( 'fontSize', { attributes: typography, deviceType: device } ) }
+					placeholder={ getResponsivePlaceholder( 'fontSize', typography, device, computedStyles.fontSize ) }
+					onChange={ ( value ) => {
+						setAttributes( {
+							typography: {
+								...typography,
+								[ getAttribute( 'fontSize', { attributes: typography, deviceType: device }, true ) ]: value,
+							},
+						} );
+					} }
 				/>
 			}
 
-			{ typography.lineHeight &&
+			{ typographySupports.lineHeight &&
 				<LineHeight
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					device={ device }
+					units={ [ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ] }
+					value={ getAttribute( 'lineHeight', { attributes: typography, deviceType: device } ) }
+					placeholder={ getResponsivePlaceholder( 'lineHeight', typography, device, computedStyles.lineHeight ) }
+					onChange={ ( value ) => {
+						setAttributes( {
+							typography: {
+								...typography,
+								[ getAttribute( 'lineHeight', { attributes: typography, deviceType: device }, true ) ]: value,
+							},
+						} );
+					} }
 				/>
 			}
 
-			{ typography.letterSpacing &&
+			{ typographySupports.letterSpacing &&
 				<LetterSpacing
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					device={ device }
+					units={ [ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ] }
+					value={ getAttribute( 'letterSpacing', { attributes: typography, deviceType: device } ) }
+					placeholder={ getResponsivePlaceholder( 'letterSpacing', typography, device, computedStyles.letterSpacing ) }
+					onChange={ ( value ) => {
+						setAttributes( {
+							typography: {
+								...typography,
+								[ getAttribute( 'letterSpacing', { attributes: typography, deviceType: device }, true ) ]: value,
+							},
+						} );
+					} }
 				/>
 			}
 
-			{ typography.fontFamily && isDesktop &&
+			{ typographySupports.fontFamily && isDesktop &&
 				<FontFamily
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/src/extend/inspector-control/controls/typography/index.js
+++ b/src/extend/inspector-control/controls/typography/index.js
@@ -91,6 +91,7 @@ export default function Typography( { attributes, setAttributes, computedStyles 
 			{ typographySupports.lineHeight &&
 				<LineHeight
 					units={ [ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ] }
+					defaultUnit="em"
 					value={ getAttribute( 'lineHeight', { attributes: typography, deviceType: device } ) }
 					placeholder={ getResponsivePlaceholder( 'lineHeight', typography, device, computedStyles.lineHeight ) }
 					onChange={ ( value ) => {
@@ -107,6 +108,7 @@ export default function Typography( { attributes, setAttributes, computedStyles 
 			{ typographySupports.letterSpacing &&
 				<LetterSpacing
 					units={ [ 'px', 'em', '%', 'rem', 'vw', 'vh', 'ch' ] }
+					defaultUnit="em"
 					value={ getAttribute( 'letterSpacing', { attributes: typography, deviceType: device } ) }
 					placeholder={ getResponsivePlaceholder( 'letterSpacing', typography, device, computedStyles.letterSpacing ) }
 					onChange={ ( value ) => {

--- a/src/hoc/migrations/migrateTypography.js
+++ b/src/hoc/migrations/migrateTypography.js
@@ -1,0 +1,52 @@
+import isNumeric from '../../utils/is-numeric';
+
+export default function MigrateTypography( { attributesToMigrate, attributes, defaults } ) {
+	function unitValue( name ) {
+		if ( 'fontSize' === name ) {
+			return attributes.fontSizeUnit;
+		}
+
+		if ( 'lineHeight' === name ) {
+			return attributes.lineHeightUnit;
+		}
+
+		if ( 'letterSpacing' === name ) {
+			return 'em';
+		}
+	}
+
+	const newAttributes = {};
+	const oldAttributes = {};
+
+	[ '', 'Tablet', 'Mobile' ].forEach( ( device ) => {
+		attributesToMigrate.forEach( ( attribute ) => {
+			const oldValue = attributes[ attribute + device ];
+
+			if ( oldValue || isNumeric( oldValue ) ) {
+				const unit = unitValue( attribute );
+
+				if ( isNumeric( oldValue ) && unit ) {
+					newAttributes[ attribute + device ] = oldValue + unit;
+				} else if ( 'alignment' === attribute ) {
+					newAttributes[ 'textAlign' + device ] = oldValue;
+				} else {
+					newAttributes[ attribute + device ] = oldValue;
+				}
+
+				oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
+					? defaults[ attribute + device ].default
+					: '';
+
+				if ( attribute.startsWith( 'fontSize' ) ) {
+					oldAttributes.fontSizeUnit = defaults.fontSizeUnit.default;
+				}
+
+				if ( attribute.startsWith( 'lineHeight' ) ) {
+					oldAttributes.lineHeightUnit = defaults.lineHeightUnit.default;
+				}
+			}
+		} );
+	} );
+
+	return { newAttributes, oldAttributes };
+}

--- a/src/hoc/withButtonLegacyMigration.js
+++ b/src/hoc/withButtonLegacyMigration.js
@@ -1,8 +1,10 @@
 import { useEffect } from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
 import wasBlockJustInserted from '../utils/was-block-just-inserted';
 import isBlockVersionLessThan from '../utils/check-block-version';
 import hasNumericValue from '../utils/has-numeric-value';
 import MigrateDimensions from './migrations/migrateDimensions';
+import MigrateTypography from './migrations/migrateTypography';
 
 export default ( WrappedComponent ) => {
 	return ( props ) => {
@@ -117,6 +119,38 @@ export default ( WrappedComponent ) => {
 
 				if ( Object.keys( newDimensions ).length ) {
 					setAttributes( newDimensions );
+				}
+			}
+		}, [] );
+
+		// Migrate typography controls.
+		// @since 1.8.0.
+		useEffect( () => {
+			if ( ! wasBlockJustInserted( attributes ) && isBlockVersionLessThan( attributes.blockVersion, 4 ) ) {
+				const newTypography = MigrateTypography( {
+					attributesToMigrate: [
+						'fontFamily',
+						'fontSize',
+						'letterSpacing',
+						'fontWeight',
+						'textTransform',
+						'alignment',
+					],
+					attributes,
+					defaults: getBlockType( 'generateblocks/button' )?.attributes,
+				} );
+
+				if (
+					Object.keys( newTypography.newAttributes ).length &&
+					Object.keys( newTypography.oldAttributes ).length
+				) {
+					setAttributes( {
+						typography: {
+							...attributes.typography,
+							...newTypography.newAttributes,
+						},
+						...newTypography.oldAttributes,
+					} );
 				}
 			}
 		}, [] );

--- a/src/hoc/withContainerLegacyMigration.js
+++ b/src/hoc/withContainerLegacyMigration.js
@@ -1,9 +1,11 @@
 import { useEffect } from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
 import hasNumericValue from '../utils/has-numeric-value';
 import wasBlockJustInserted from '../utils/was-block-just-inserted';
 import isBlockVersionLessThan from '../utils/check-block-version';
 import MigrateSizing from '../blocks/container/migrate-sizing';
 import MigrateDimensions from './migrations/migrateDimensions';
+import MigrateTypography from './migrations/migrateTypography';
 
 export default ( WrappedComponent ) => {
 	return ( props ) => {
@@ -160,6 +162,37 @@ export default ( WrappedComponent ) => {
 
 				if ( Object.keys( newDimensions ).length ) {
 					setAttributes( newDimensions );
+				}
+			}
+		}, [] );
+
+		// Migrate typography controls.
+		// @since 1.8.0.
+		useEffect( () => {
+			if ( ! wasBlockJustInserted( attributes ) && isBlockVersionLessThan( attributes.blockVersion, 4 ) ) {
+				const newTypography = MigrateTypography( {
+					attributesToMigrate: [
+						'fontFamily',
+						'fontSize',
+						'fontWeight',
+						'textTransform',
+						'alignment',
+					],
+					attributes,
+					defaults: getBlockType( 'generateblocks/container' )?.attributes,
+				} );
+
+				if (
+					Object.keys( newTypography.newAttributes ).length &&
+					Object.keys( newTypography.oldAttributes ).length
+				) {
+					setAttributes( {
+						typography: {
+							...attributes.typography,
+							...newTypography.newAttributes,
+						},
+						...newTypography.oldAttributes,
+					} );
 				}
 			}
 		}, [] );

--- a/src/hoc/withHeadlineLegacyMigration.js
+++ b/src/hoc/withHeadlineLegacyMigration.js
@@ -1,9 +1,11 @@
 import { useEffect } from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
 import isBlockVersionLessThan from '../utils/check-block-version';
 import wasBlockJustInserted from '../utils/was-block-just-inserted';
 import flexboxAlignment from '../utils/flexbox-alignment';
 import MigrateDimensions from './migrations/migrateDimensions';
 import hasNumericValue from '../utils/has-numeric-value';
+import MigrateTypography from './migrations/migrateTypography';
 
 export default ( WrappedComponent ) => {
 	return ( props ) => {
@@ -101,6 +103,39 @@ export default ( WrappedComponent ) => {
 
 				if ( Object.keys( newDimensions ).length ) {
 					setAttributes( newDimensions );
+				}
+			}
+		}, [] );
+
+		// Migrate typography controls.
+		// @since 1.8.0.
+		useEffect( () => {
+			if ( ! wasBlockJustInserted( attributes ) && isBlockVersionLessThan( attributes.blockVersion, 3 ) ) {
+				const newTypography = MigrateTypography( {
+					attributesToMigrate: [
+						'fontFamily',
+						'fontSize',
+						'lineHeight',
+						'letterSpacing',
+						'fontWeight',
+						'textTransform',
+						'alignment',
+					],
+					attributes,
+					defaults: getBlockType( 'generateblocks/headline' )?.attributes,
+				} );
+
+				if (
+					Object.keys( newTypography.newAttributes ).length &&
+					Object.keys( newTypography.oldAttributes ).length
+				) {
+					setAttributes( {
+						typography: {
+							...attributes.typography,
+							...newTypography.newAttributes,
+						},
+						...newTypography.oldAttributes,
+					} );
 				}
 			}
 		}, [] );

--- a/src/tests/unit/migrateTypography.test.js
+++ b/src/tests/unit/migrateTypography.test.js
@@ -1,0 +1,191 @@
+import MigrateTypography from '../../hoc/migrations/migrateTypography';
+
+describe( 'Test typography migrations', () => {
+	const defaults = {
+		fontFamily: {
+			default: '',
+		},
+		fontWeight: {
+			default: '',
+		},
+		textTransform: {
+			default: '',
+		},
+		fontSize: {
+			default: '',
+		},
+		fontSizeTablet: {
+			default: '',
+		},
+		fontSizeMobile: {
+			default: '',
+		},
+		fontSizeUnit: {
+			default: 'px',
+		},
+		lineHeight: {
+			default: '',
+		},
+		lineHeightTablet: {
+			default: '',
+		},
+		lineHeightMobile: {
+			default: '',
+		},
+		lineHeightUnit: {
+			default: 'em',
+		},
+		letterSpacing: {
+			default: '',
+		},
+	};
+
+	it( 'can migrate font family', () => {
+		const oldAttributes = {
+			fontFamily: 'Roboto',
+			fontFamilyFallback: 'sans-serif',
+			googleFont: true,
+			fontWeight: 'bold',
+			textTransform: 'uppercase',
+		};
+
+		const newTypography = MigrateTypography( {
+			attributesToMigrate: [ 'fontFamily', 'fontWeight', 'textTransform' ],
+			attributes: oldAttributes,
+			defaults,
+		} );
+
+		const existingTypography = {};
+
+		const newAttributes = {
+			typography: {
+				...existingTypography,
+				...newTypography.newAttributes,
+			},
+			...newTypography.oldAttributes,
+		};
+
+		expect( newAttributes ).toEqual( {
+			typography: {
+				fontFamily: 'Roboto',
+				fontWeight: 'bold',
+				textTransform: 'uppercase',
+			},
+			fontFamily: '',
+			fontWeight: '',
+			textTransform: '',
+		} );
+	} );
+
+	it( 'can migrate font size', () => {
+		const oldAttributes = {
+			fontSize: 12,
+			fontSizeTablet: 11,
+			fontSizeMobile: 10,
+			fontSizeUnit: 'em',
+		};
+
+		const newTypography = MigrateTypography( {
+			attributesToMigrate: [ 'fontSize' ],
+			attributes: oldAttributes,
+			defaults,
+		} );
+
+		const existingTypography = {};
+
+		const newAttributes = {
+			typography: {
+				...existingTypography,
+				...newTypography.newAttributes,
+			},
+			...newTypography.oldAttributes,
+		};
+
+		expect( newAttributes ).toEqual( {
+			typography: {
+				fontSize: '12em',
+				fontSizeTablet: '11em',
+				fontSizeMobile: '10em',
+			},
+			fontSize: '',
+			fontSizeTablet: '',
+			fontSizeMobile: '',
+			fontSizeUnit: 'px',
+		} );
+	} );
+
+	it( 'can migrate line height', () => {
+		const oldAttributes = {
+			lineHeight: 1.2,
+			lineHeightTablet: 1.1,
+			lineHeightMobile: 1,
+			lineHeightUnit: 'em',
+		};
+
+		const newTypography = MigrateTypography( {
+			attributesToMigrate: [ 'lineHeight' ],
+			attributes: oldAttributes,
+			defaults,
+		} );
+
+		const existingTypography = {
+			fontSize: '10px',
+		};
+
+		const newAttributes = {
+			typography: {
+				...existingTypography,
+				...newTypography.newAttributes,
+			},
+			...newTypography.oldAttributes,
+		};
+
+		expect( newAttributes ).toEqual( {
+			typography: {
+				fontSize: '10px',
+				lineHeight: '1.2em',
+				lineHeightTablet: '1.1em',
+				lineHeightMobile: '1em',
+			},
+			lineHeight: '',
+			lineHeightTablet: '',
+			lineHeightMobile: '',
+			lineHeightUnit: 'em',
+		} );
+	} );
+
+	it( 'can migrate letter spacing', () => {
+		const oldAttributes = {
+			letterSpacing: 0.02,
+			letterSpacingTablet: 0.01,
+		};
+
+		const newTypography = MigrateTypography( {
+			attributesToMigrate: [ 'letterSpacing' ],
+			attributes: oldAttributes,
+			defaults,
+		} );
+
+		const existingTypography = {
+			lineHeight: '1.1em',
+		};
+
+		const newAttributes = {
+			typography: {
+				...existingTypography,
+				...newTypography.newAttributes,
+			},
+			...newTypography.oldAttributes,
+		};
+
+		expect( newAttributes ).toEqual( {
+			typography: {
+				lineHeight: '1.1em',
+				letterSpacing: '0.02em',
+				letterSpacingTablet: '0.01em',
+			},
+			letterSpacing: '',
+			letterSpacingTablet: '', // Intentionally has no default defined.
+		} );
+	} );
+} );

--- a/src/utils/get-responsive-placeholder/index.js
+++ b/src/utils/get-responsive-placeholder/index.js
@@ -8,7 +8,7 @@ export default function getResponsivePlaceholder( name, attributes, device, fall
 		responsivePlaceholder = attributes[ name + 'Tablet' ];
 	}
 
-	if ( '' === responsivePlaceholder || false === responsivePlaceholder ) {
+	if ( '' === responsivePlaceholder || false === responsivePlaceholder || undefined === responsivePlaceholder ) {
 		responsivePlaceholder = fallback;
 	}
 


### PR DESCRIPTION
This PR migrates our typography CSS attributes into a `typography` object.

It also makes use of the `UnitControl` component so users can choose from more units and change them up on different devices.