### PR TITLE
Add block label for query loop and grid blocks

### DIFF
--- a/src/blocks/container/block.js
+++ b/src/blocks/container/block.js
@@ -57,12 +57,16 @@ registerBlockType( 'generateblocks/container', {
 		);
 	},
 	deprecated,
-	__experimentalLabel: ( attrs ) => {
+	__experimentalLabel: ( attrs, { context } ) => {
 		if ( attrs.isQueryLoopItem ) {
 			return __( 'Post Template', 'generateblocks' );
 		}
 
-		return attrs.blockLabel || __( 'Container', 'generateblocks' );
+		if ( 'list-view' === context && attrs.blockLabel ) {
+			return attrs.blockLabel;
+		}
+
+		return __( 'Container', 'generateblocks' );
 	},
 	transforms,
 } );

--- a/src/blocks/container/components/InspectorAdvancedControls.js
+++ b/src/blocks/container/components/InspectorAdvancedControls.js
@@ -1,8 +1,7 @@
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import HTMLAnchor from '../../../components/html-anchor';
 import TagName from './TagName';
-import { TextControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import BlockLabel from '../../../extend/inspector-control/controls/block-label';
 
 export default ( props ) => {
 	const {
@@ -21,12 +20,12 @@ export default ( props ) => {
 				onChange={ ( value ) => setAttributes( { tagName: filterTagName( value ) } ) }
 			/>
 
-			<TextControl
-				label={ __( 'Block label', 'generateblocks' ) }
-				help={ __( 'Add a label for this block in the List View.', 'generateblocks' ) }
-				value={ attributes.blockLabel }
-				onChange={ ( blockLabel ) => setAttributes( { blockLabel } ) }
-			/>
+			{ ! attributes.isQueryLoopItem &&
+				<BlockLabel
+					value={ attributes.blockLabel }
+					onChange={ ( blockLabel ) => setAttributes( { blockLabel } ) }
+				/>
+			}
 		</InspectorAdvancedControls>
 	);
 };

--- a/src/blocks/grid/attributes.js
+++ b/src/blocks/grid/attributes.js
@@ -78,6 +78,10 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	blockLabel: {
+		type: 'string',
+		default: '',
+	},
 	// deprecated since 1.2.0
 	elementId: {
 		type: 'string',

--- a/src/blocks/grid/block.js
+++ b/src/blocks/grid/block.js
@@ -50,4 +50,11 @@ registerBlockType( 'generateblocks/grid', {
 		);
 	},
 	deprecated,
+	__experimentalLabel: ( attrs, { context } ) => {
+		if ( 'list-view' === context && attrs.blockLabel ) {
+			return attrs.blockLabel;
+		}
+
+		return __( 'Grid', 'generateblocks' );
+	},
 } );

--- a/src/blocks/grid/edit.js
+++ b/src/blocks/grid/edit.js
@@ -107,6 +107,7 @@ const GridEdit = ( props ) => {
 
 			<InspectorAdvancedControls
 				anchor={ attributes.anchor }
+				blockLabel={ attributes.blockLabel }
 				setAttributes={ setAttributes }
 			/>
 

--- a/src/blocks/query-loop/attributes.js
+++ b/src/blocks/query-loop/attributes.js
@@ -15,4 +15,9 @@ export default Object.assign( {}, gridAttributes, {
 		type: 'object',
 		default: {},
 	},
+
+	blockLabel: {
+		type: 'string',
+		default: '',
+	},
 } );

--- a/src/blocks/query-loop/block.js
+++ b/src/blocks/query-loop/block.js
@@ -34,4 +34,11 @@ registerBlockType( 'generateblocks/query-loop', {
 			<InnerBlocks.Content />
 		);
 	},
+	__experimentalLabel: ( attrs, { context } ) => {
+		if ( 'list-view' === context && attrs.blockLabel ) {
+			return attrs.blockLabel;
+		}
+
+		return __( 'Query Loop', 'generateblocks' );
+	},
 } );

--- a/src/blocks/query-loop/components/InspectorAdvancedControls.js
+++ b/src/blocks/query-loop/components/InspectorAdvancedControls.js
@@ -1,16 +1,13 @@
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
-import HTMLAnchor from '../../../components/html-anchor';
 import BlockLabel from '../../../extend/inspector-control/controls/block-label';
 
-export default ( { anchor, blockLabel, setAttributes } ) => {
+export default function( { blockLabel, setAttributes } ) {
 	return (
 		<InspectorAdvancedControls>
-			<HTMLAnchor anchor={ anchor } setAttributes={ setAttributes } />
-
 			<BlockLabel
 				value={ blockLabel }
 				onChange={ ( value ) => setAttributes( { blockLabel: value } ) }
 			/>
 		</InspectorAdvancedControls>
 	);
-};
+}

--- a/src/blocks/query-loop/edit.js
+++ b/src/blocks/query-loop/edit.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import LayoutSelector from './components/LayoutSelector';
 import { useSelect } from '@wordpress/data';
+import InspectorAdvancedControls from './components/InspectorAdvancedControls';
 
 export default function QueryLoopEdit( props ) {
 	const {
@@ -38,6 +39,11 @@ export default function QueryLoopEdit( props ) {
 							attributes={ filterAttributes( attributes, Object.keys( queryLoopAttributes ) ) }
 							setAttributes={ setAttributes }
 							clientId={ clientId }
+						/>
+
+						<InspectorAdvancedControls
+							blockLabel={ attributes.blockLabel }
+							setAttributes={ setAttributes }
 						/>
 
 						<BlockContextProvider value={ { 'generateblocks/query': attributes.query } }>

--- a/src/extend/inspector-control/controls/block-label/index.js
+++ b/src/extend/inspector-control/controls/block-label/index.js
@@ -1,0 +1,13 @@
+import { TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function BlockLabel( { value, onChange } ) {
+	return (
+		<TextControl
+			label={ __( 'Block label', 'generateblocks' ) }
+			help={ __( 'Add a label for this block in the List View.', 'generateblocks' ) }
+			value={ value }
+			onChange={ onChange }
+		/>
+	);
+}


### PR DESCRIPTION
Add block label to Grid and query loop. Also, it fixes block label control showing for the Post template variant.