### PR TITLE
Tweak: Use "Icon" as list view label

### DIFF
--- a/src/blocks/button/block.js
+++ b/src/blocks/button/block.js
@@ -58,9 +58,13 @@ registerBlockType( 'generateblocks/button', {
 	__experimentalLabel: ( attrs, { context } ) => {
 		if (
 			context === 'list-view' &&
-			attrs.text &&
+			( attrs.text || attrs.removeText ) &&
 			! attrs.useDynamicData
 		) {
+			if ( attrs.removeText ) {
+				return __( 'Icon', 'generateblocks' );
+			}
+
 			return attrs.text;
 		}
 

--- a/src/blocks/headline/block.js
+++ b/src/blocks/headline/block.js
@@ -61,10 +61,14 @@ registerBlockType( 'generateblocks/headline', {
 	__experimentalLabel: ( attrs, { context } ) => {
 		if (
 			context === 'list-view' &&
-			attrs.content &&
+			( attrs.content || attrs.removeText ) &&
 			! attrs.useDynamicData &&
 			! attrs.isCaption
 		) {
+			if ( attrs.removeText ) {
+				return __( 'Icon', 'generateblocks' );
+			}
+
 			return attrs.content;
 		}
 


### PR DESCRIPTION
This uses "Icon" as the list view label for the Button and Headline if "Remove Text" is toggled.