### PR TITLE
Fix: Allow objects in useDeviceAttributes

### DIFF
--- a/src/extend/inspector-control/controls/icon/components/icon-padding.js
+++ b/src/extend/inspector-control/controls/icon/components/icon-padding.js
@@ -6,23 +6,18 @@ import getResponsivePlaceholder from '../../../../../utils/get-responsive-placeh
 
 export default function IconPadding( { attributes, setAttributes } ) {
 	const device = getDeviceType();
-	const [ deviceAttributes, setDeviceAttributes ] = useDeviceAttributes( attributes.iconStyles, setAttributes );
+	const [ deviceAttributes, setDeviceAttributes ] = useDeviceAttributes( attributes, setAttributes );
 	const attributeNames = [ 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft' ];
 
 	return (
 		<DimensionsControl
 			label={ __( 'Padding', 'generateblocks' ) }
 			attributeNames={ attributeNames }
-			values={ deviceAttributes }
+			values={ deviceAttributes.iconStyles }
 			placeholders={ attributeNames.reduce( ( o, key ) => (
 				{ ...o, [ key ]: getResponsivePlaceholder( key, attributes.iconStyles, device, '' ) }
 			), {} ) }
-			onChange={ ( values ) => setDeviceAttributes( {
-				iconStyles: {
-					...attributes.iconStyles,
-					...values,
-				},
-			} ) }
+			onChange={ ( newAttributes ) => setDeviceAttributes( newAttributes, 'iconStyles' ) }
 		/>
 	);
 }

--- a/src/hooks/useDeviceAttributes.js
+++ b/src/hooks/useDeviceAttributes.js
@@ -110,6 +110,7 @@ export function addDeviceToAttributes( attrs, device = 'Tablet' ) {
 	return Object.entries( attrs ).reduce( ( result, [ key, value ] ) => {
 		if ( attributesWithDevice.includes( key ) ) {
 			result[ key + device ] = value;
+
 			return result;
 		}
 

--- a/src/hooks/useDeviceAttributes.js
+++ b/src/hooks/useDeviceAttributes.js
@@ -1,7 +1,6 @@
 import { useDeviceType } from './index';
 import { useMemo } from '@wordpress/element';
 import isObject from 'lodash/isObject';
-import merge from 'lodash/merge';
 
 /**
  * List of attributes that are device related.
@@ -45,6 +44,7 @@ const attributesWithDevice = [
 	'stack',
 	'fillHorizontalSpace',
 	'alignment',
+	'textAlign',
 	'fontSize',
 	'lineHeight',
 	'letterSpacing',
@@ -110,7 +110,6 @@ export function addDeviceToAttributes( attrs, device = 'Tablet' ) {
 	return Object.entries( attrs ).reduce( ( result, [ key, value ] ) => {
 		if ( attributesWithDevice.includes( key ) ) {
 			result[ key + device ] = value;
-
 			return result;
 		}
 
@@ -134,27 +133,30 @@ export function addDeviceToAttributes( attrs, device = 'Tablet' ) {
  */
 export default function useDeviceAttributes( attributes, setAttributes ) {
 	const [ device ] = useDeviceType();
+	const deviceName = 'Desktop' !== device
+		? device
+		: '';
 
 	const deviceAttributes = useMemo( () => (
 		splitAttributes( attributes )
 	), [ JSON.stringify( attributes ) ] );
 
-	const tabletSetAttributes = useMemo( () => ( attrs = {} ) => {
-		setAttributes( merge( attributes, addDeviceToAttributes( attrs, 'Tablet' ) ) );
-	}, [ setAttributes, JSON.stringify( attributes ) ] );
+	const setDeviceAttributes = useMemo( () => ( attrs = {}, objName = '' ) => {
+		if ( objName ) {
+			setAttributes( {
+				[ objName ]: {
+					...attributes[ objName ],
+					...addDeviceToAttributes( attrs, deviceName ),
+				},
+			} );
 
-	const mobileSetAttributes = useMemo( () => ( attrs = {} ) => {
-		setAttributes( merge( attributes, addDeviceToAttributes( attrs, 'Mobile' ) ) );
-	}, [ setAttributes, JSON.stringify( attributes ) ] );
+			return;
+		}
 
-	const deviceSetAttributes = {
-		desktop: setAttributes,
-		tablet: tabletSetAttributes,
-		mobile: mobileSetAttributes,
-	};
+		setAttributes( addDeviceToAttributes( attrs, deviceName ) );
+	}, [ deviceName, setAttributes, JSON.stringify( attributes ) ] );
 
 	const activeDevice = device.toLowerCase();
 
-	return [ deviceAttributes[ activeDevice ], deviceSetAttributes[ activeDevice ] ];
+	return [ deviceAttributes[ activeDevice ], setDeviceAttributes ];
 }
-


### PR DESCRIPTION
This fixes some bugs in `setDeviceAttributes` so we can easily add new device attributes to an object.

We just need to pass the object name as the second parameter in `setDeviceAttributes()`:

`setDeviceAttributes( { textAlign: 'center' }, 'typography' )`

Not sure if this means we can ditch the `attributesWithDevice` array, as we can choose to only use `useDeviceAttributes` with attributes that have support for devices. Only issue there is if we're passing a mix of attributes with and without devices.