### PR TITLE
Fix: Migrate global style attributes in the editor

### DIFF
--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -5,6 +5,7 @@ import withContainerLegacyMigration from './withContainerLegacyMigration';
 import withButtonContainerLegacyMigration from './withButtonContainerLegacyMigration';
 import withDeviceType from './withDeviceType';
 import './withDocumentation';
+import './migrations/migrateGlobalStyleAttrs';
 
 export {
 	withUniqueId,

--- a/src/hoc/migrations/migrateBorders.js
+++ b/src/hoc/migrations/migrateBorders.js
@@ -13,7 +13,7 @@ import hexToRGBA from '../../utils/hex-to-rgba';
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-function buildBorderAttributes( { attributesToMigrate = [], attributes, defaults } ) {
+function buildBorderAttributes( { attributesToMigrate = [], attributes = {}, defaults = {} } ) {
 	function unitValue( name ) {
 		if ( name.startsWith( 'borderSize' ) ) {
 			return 'px';
@@ -70,6 +70,7 @@ function buildBorderAttributes( { attributesToMigrate = [], attributes, defaults
 
 				if ( attributeName ) {
 					newAttributes[ attributeName + device ] = oldValue + unitValue( attribute );
+					const hasDefaults = Object.keys( defaults ).length;
 
 					if ( attributeName.includes( 'Width' ) ) {
 						// We used to manually use "solid" is a borderWidth existed.
@@ -77,28 +78,39 @@ function buildBorderAttributes( { attributesToMigrate = [], attributes, defaults
 
 						if ( attributes.borderColor ) {
 							newAttributes[ attributeName.replace( 'Width', 'Color' ) + device ] = hexToRGBA( attributes.borderColor, attributes.borderColorOpacity );
-							oldAttributes.borderColor = defaults.borderColor?.default;
-							oldAttributes.borderColorOpacity = defaults.borderColorOpacity?.default;
+
+							if ( hasDefaults ) {
+								oldAttributes.borderColor = defaults.borderColor?.default;
+								oldAttributes.borderColorOpacity = defaults.borderColorOpacity?.default;
+							}
 						}
 
 						if ( attributes.borderColorHover ) {
 							newAttributes[ attributeName.replace( 'Width', 'ColorHover' ) + device ] = hexToRGBA( attributes.borderColorHover, attributes.borderColorHoverOpacity );
-							oldAttributes.borderColorHover = defaults.borderColorHover?.default;
-							oldAttributes.borderColorHoverOpacity = defaults.borderColorHoverOpacity?.default;
+
+							if ( hasDefaults ) {
+								oldAttributes.borderColorHover = defaults.borderColorHover?.default;
+								oldAttributes.borderColorHoverOpacity = defaults.borderColorHoverOpacity?.default;
+							}
 						}
 
 						if ( attributes.borderColorCurrent ) {
 							newAttributes[ attributeName.replace( 'Width', 'ColorCurrent' ) + device ] = attributes.borderColorCurrent;
-							oldAttributes.borderColorCurrent = defaults.borderColorCurrent?.default;
+
+							if ( hasDefaults ) {
+								oldAttributes.borderColorCurrent = defaults.borderColorCurrent?.default;
+							}
 						}
 					}
 
-					oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
-						? defaults[ attribute + device ].default
-						: '';
+					if ( hasDefaults ) {
+						oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
+							? defaults[ attribute + device ].default
+							: '';
 
-					if ( attribute.startsWith( 'borderRadius' ) ) {
-						oldAttributes.borderRadiusUnit = defaults.borderRadiusUnit.default;
+						if ( attribute.startsWith( 'borderRadius' ) ) {
+							oldAttributes.borderRadiusUnit = defaults.borderRadiusUnit.default;
+						}
 					}
 				}
 			}
@@ -118,7 +130,7 @@ function buildBorderAttributes( { attributesToMigrate = [], attributes, defaults
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-export default function migrateBorders( { blockVersionLessThan, defaults, attributesToMigrate = [] } ) {
+export default function migrateBorders( { blockVersionLessThan, defaults = {}, attributesToMigrate = [] } ) {
 	return function( attrs, existingAttrs ) {
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, blockVersionLessThan ) ) {
 			const newSpacing = buildBorderAttributes( {

--- a/src/hoc/migrations/migrateGlobalStyleAttrs.js
+++ b/src/hoc/migrations/migrateGlobalStyleAttrs.js
@@ -1,0 +1,71 @@
+import { addFilter } from '@wordpress/hooks';
+import { migrateButtonAttributes } from '../withButtonLegacyMigration';
+import { migrateButtonContainerAttributes } from '../withButtonContainerLegacyMigration';
+import { migrateContainerAttributes } from '../withContainerLegacyMigration';
+import { migrateHeadlineAttributes } from '../withHeadlineLegacyMigration';
+import { migrateGridAttributes } from '../withGridLegacyMigration';
+import { migrateImageAttributes } from '../withImageLegacyMigration';
+
+/**
+ * This ensures that Global Styles pass the correct attributes
+ * to the CSS generation even when attributes change names.
+ */
+addFilter(
+	'generateblocks.editor.cssAttrs',
+	'generateblocks/migrateCssAttrs',
+	( attributes, props ) => {
+		const {
+			name,
+		} = props;
+
+		if ( ! attributes.useGlobalStyle ) {
+			return attributes;
+		}
+
+		let migrateFunction = null;
+
+		switch ( name ) {
+			case 'generateblocks/button':
+				migrateFunction = migrateButtonAttributes;
+				break;
+
+			case 'generateblocks/button-container':
+				migrateFunction = migrateButtonContainerAttributes;
+				break;
+
+			case 'generateblocks/container':
+				migrateFunction = migrateContainerAttributes;
+				break;
+
+			case 'generateblocks/headline':
+				migrateFunction = migrateHeadlineAttributes;
+				break;
+
+			case 'generateblocks/grid':
+				migrateFunction = migrateGridAttributes;
+				break;
+
+			case 'generateblocks/image':
+				migrateFunction = migrateImageAttributes;
+				break;
+		}
+
+		if ( null !== migrateFunction ) {
+			// This ensures that old attributes (coming from Global Styles) are migrated
+			// to their new attribute names so styling continues to work in the editor.
+			const migratedAttributes = migrateFunction( {
+				attributes: {
+					...attributes,
+					// Use the global style block version if possible.
+					blockVersion: attributes.globalBlockVersion || 1,
+				},
+				mode: 'css',
+			} );
+
+			return { ...attributes, ...migratedAttributes };
+		}
+
+		return attributes;
+	},
+	1000
+);

--- a/src/hoc/migrations/migrateIconPadding.js
+++ b/src/hoc/migrations/migrateIconPadding.js
@@ -11,7 +11,7 @@ import { addToAttrsObject } from './utils';
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-function buildPaddingAttributes( { attributes, defaults } ) {
+function buildPaddingAttributes( { attributes, defaults = {} } ) {
 	const newAttributes = {};
 	const oldAttributes = {};
 	const attributesToMigrate = [ 'iconPaddingTop', 'iconPaddingRight', 'iconPaddingBottom', 'iconPaddingLeft' ];
@@ -43,10 +43,13 @@ function buildPaddingAttributes( { attributes, defaults } ) {
 
 				if ( newAttributeName ) {
 					newAttributes[ newAttributeName + device ] = oldValue + attributes.iconPaddingUnit;
-					oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
-						? defaults[ attribute + device ].default
-						: '';
-					oldAttributes.iconPaddingUnit = defaults.iconPaddingUnit.default;
+
+					if ( Object.keys( defaults ).length ) {
+						oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
+							? defaults[ attribute + device ].default
+							: '';
+						oldAttributes.iconPaddingUnit = defaults.iconPaddingUnit.default;
+					}
 				}
 			}
 		} );
@@ -64,7 +67,7 @@ function buildPaddingAttributes( { attributes, defaults } ) {
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-export default function migrateIconPadding( { blockVersionLessThan, defaults } ) {
+export default function migrateIconPadding( { blockVersionLessThan, defaults = {} } ) {
 	return function( attrs, existingAttrs ) {
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, blockVersionLessThan ) ) {
 			const newPadding = buildPaddingAttributes( {

--- a/src/hoc/migrations/migrateSpacing.js
+++ b/src/hoc/migrations/migrateSpacing.js
@@ -12,7 +12,7 @@ import { addToAttrsObject } from './utils';
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-function buildSpacingAttributes( { attributesToMigrate = [], attributes, defaults } ) {
+function buildSpacingAttributes( { attributesToMigrate = [], attributes = {}, defaults = {} } ) {
 	function unitValue( name ) {
 		if ( name.startsWith( 'padding' ) ) {
 			return attributes.paddingUnit;
@@ -36,16 +36,18 @@ function buildSpacingAttributes( { attributesToMigrate = [], attributes, default
 						? oldValue + unitValue( attribute )
 						: oldValue;
 
-					oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
-						? defaults[ attribute + device ].default
-						: '';
+					if ( Object.keys( defaults ).length ) {
+						oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
+							? defaults[ attribute + device ].default
+							: '';
 
-					if ( attribute.startsWith( 'padding' ) ) {
-						oldAttributes.paddingUnit = defaults.paddingUnit.default;
-					}
+						if ( attribute.startsWith( 'padding' ) ) {
+							oldAttributes.paddingUnit = defaults.paddingUnit.default;
+						}
 
-					if ( attribute.startsWith( 'margin' ) ) {
-						oldAttributes.marginUnit = defaults.marginUnit.default;
+						if ( attribute.startsWith( 'margin' ) ) {
+							oldAttributes.marginUnit = defaults.marginUnit.default;
+						}
 					}
 				}
 			}
@@ -65,7 +67,7 @@ function buildSpacingAttributes( { attributesToMigrate = [], attributes, default
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-export default function migrateSpacing( { blockVersionLessThan, defaults, attributesToMigrate = [] } ) {
+export default function migrateSpacing( { blockVersionLessThan, defaults = {}, attributesToMigrate = [] } ) {
 	return function( attrs, existingAttrs ) {
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, blockVersionLessThan ) ) {
 			const newSpacing = buildSpacingAttributes( {

--- a/src/hoc/migrations/migrateTypography.js
+++ b/src/hoc/migrations/migrateTypography.js
@@ -12,7 +12,7 @@ import { addToAttrsObject } from './utils';
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-function buildTypographyAttributes( { attributesToMigrate, attributes, defaults } ) {
+function buildTypographyAttributes( { attributesToMigrate, attributes = {}, defaults = {} } ) {
 	function unitValue( name ) {
 		if ( 'fontSize' === name ) {
 			return attributes.fontSizeUnit;
@@ -45,16 +45,18 @@ function buildTypographyAttributes( { attributesToMigrate, attributes, defaults 
 					newAttributes[ attribute + device ] = oldValue;
 				}
 
-				oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
-					? defaults[ attribute + device ].default
-					: '';
+				if ( Object.keys( defaults ).length ) {
+					oldAttributes[ attribute + device ] = defaults[ attribute + device ]?.default
+						? defaults[ attribute + device ].default
+						: '';
 
-				if ( attribute.startsWith( 'fontSize' ) ) {
-					oldAttributes.fontSizeUnit = defaults.fontSizeUnit.default;
-				}
+					if ( attribute.startsWith( 'fontSize' ) ) {
+						oldAttributes.fontSizeUnit = defaults.fontSizeUnit.default;
+					}
 
-				if ( attribute.startsWith( 'lineHeight' ) ) {
-					oldAttributes.lineHeightUnit = defaults.lineHeightUnit.default;
+					if ( attribute.startsWith( 'lineHeight' ) ) {
+						oldAttributes.lineHeightUnit = defaults.lineHeightUnit.default;
+					}
 				}
 			}
 		} );
@@ -73,7 +75,7 @@ function buildTypographyAttributes( { attributesToMigrate, attributes, defaults 
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-export default function migrateTypography( { blockVersionLessThan, defaults, attributesToMigrate = [] } ) {
+export default function migrateTypography( { blockVersionLessThan, defaults = {}, attributesToMigrate = [] } ) {
 	return function( attrs, existingAttrs ) {
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, blockVersionLessThan ) ) {
 			const newTypography = buildTypographyAttributes( {

--- a/src/hoc/migrations/migratingIconSizing.js
+++ b/src/hoc/migrations/migratingIconSizing.js
@@ -11,7 +11,7 @@ import { addToAttrsObject } from './utils';
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-function buildIconSizingAttributes( { attributes, defaults } ) {
+function buildIconSizingAttributes( { attributes = {}, defaults = {} } ) {
 	const newAttributes = {};
 	const oldAttributes = {};
 
@@ -21,10 +21,13 @@ function buildIconSizingAttributes( { attributes, defaults } ) {
 		if ( oldValue || isNumeric( oldValue ) ) {
 			newAttributes[ 'width' + device ] = oldValue + attributes.iconSizeUnit;
 			newAttributes[ 'height' + device ] = oldValue + attributes.iconSizeUnit;
-			oldAttributes[ 'iconSize' + device ] = defaults[ 'iconSize' + device ]?.default
-				? defaults[ 'iconSize' + device ].default
-				: '';
-			oldAttributes.iconSizeUnit = defaults.iconSizeUnit.default;
+
+			if ( Object.keys( defaults ).length ) {
+				oldAttributes[ 'iconSize' + device ] = defaults[ 'iconSize' + device ]?.default
+					? defaults[ 'iconSize' + device ].default
+					: '';
+				oldAttributes.iconSizeUnit = defaults.iconSizeUnit.default;
+			}
 		}
 	} );
 
@@ -40,7 +43,7 @@ function buildIconSizingAttributes( { attributes, defaults } ) {
  * @return {Object} New attributes.
  * @since 1.8.0
  */
-export default function migrateIconSizing( { blockVersionLessThan, defaults } ) {
+export default function migrateIconSizing( { blockVersionLessThan, defaults = {} } ) {
 	return function( attrs, existingAttrs ) {
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, blockVersionLessThan ) ) {
 			const newSizing = buildIconSizingAttributes( {

--- a/src/hoc/migrations/utils.js
+++ b/src/hoc/migrations/utils.js
@@ -1,15 +1,19 @@
 import { isEmpty } from 'lodash';
 import isBlockVersionLessThan from '../../utils/check-block-version';
 
-function migrationPipe( existingAttributes, callbacks = [] ) {
+function migrationPipe( existingAttributes, callbacks = [], mode ) {
 	return callbacks.reduce( ( resultAttrs, callback ) => {
-		const result = callback( resultAttrs, existingAttributes );
+		const result = callback( resultAttrs, existingAttributes, mode );
 		return Object.assign( {}, result );
 	}, {} );
 }
 
 function updateBlockVersion( newBlockVersion ) {
-	return function( attrs, existingAttrs ) {
+	return function( attrs, existingAttrs, mode ) {
+		if ( 'css' === mode ) {
+			return attrs;
+		}
+
 		if ( isBlockVersionLessThan( existingAttrs.blockVersion, newBlockVersion ) ) {
 			attrs.blockVersion = newBlockVersion;
 		}
@@ -34,7 +38,11 @@ function addToAttrsObject( { attrs = {}, attributeName, existingAttrs = {}, newA
 	};
 }
 
-function setIsDynamic( attrs, existingAttrs ) {
+function setIsDynamic( attrs, existingAttrs, mode ) {
+	if ( 'css' === mode ) {
+		return attrs;
+	}
+
 	if ( ! existingAttrs.isDynamic ) {
 		attrs.isDynamic = true;
 	}

--- a/src/hoc/withImageLegacyMigration.js
+++ b/src/hoc/withImageLegacyMigration.js
@@ -5,6 +5,54 @@ import migrateSpacing from './migrations/migrateSpacing';
 import migrateBorders from './migrations/migrateBorders';
 import { isEmpty } from 'lodash';
 
+/**
+ * Migrate our Image attributes.
+ *
+ * @param {Object} Props            Function props.
+ * @param {Object} Props.attributes The block attributes.
+ * @param {Object} Props.defaults   The block defaults.
+ * @param {string} Props.mode       The migration mode.
+ * @return {Object} Updated attributes.
+ * @since 1.8.0
+ */
+export function migrateImageAttributes( { attributes, defaults, mode } ) {
+	return migrationPipe(
+		attributes,
+		[
+			migrateSpacing( {
+				blockVersionLessThan: 2,
+				defaults,
+				attributesToMigrate: [
+					'paddingTop',
+					'paddingRight',
+					'paddingBottom',
+					'paddingLeft',
+					'marginTop',
+					'marginRight',
+					'marginBottom',
+					'marginLeft',
+				],
+			} ),
+			migrateBorders( {
+				blockVersionLessThan: 2,
+				defaults,
+				attributesToMigrate: [
+					'borderSizeTop',
+					'borderSizeRight',
+					'borderSizeBottom',
+					'borderSizeLeft',
+					'borderRadiusTopRight',
+					'borderRadiusBottomRight',
+					'borderRadiusBottomLeft',
+					'borderRadiusTopLeft',
+				],
+			} ),
+			updateBlockVersion( 2 ),
+		],
+		mode
+	);
+}
+
 export default ( WrappedComponent ) => {
 	return ( props ) => {
 		const {
@@ -13,42 +61,10 @@ export default ( WrappedComponent ) => {
 		} = props;
 
 		useEffect( () => {
-			const defaults = getBlockType( 'generateblocks/image' )?.attributes;
-
-			const newAttributes = migrationPipe(
+			const newAttributes = migrateImageAttributes( {
 				attributes,
-				[
-					migrateSpacing( {
-						blockVersionLessThan: 2,
-						defaults,
-						attributesToMigrate: [
-							'paddingTop',
-							'paddingRight',
-							'paddingBottom',
-							'paddingLeft',
-							'marginTop',
-							'marginRight',
-							'marginBottom',
-							'marginLeft',
-						],
-					} ),
-					migrateBorders( {
-						blockVersionLessThan: 2,
-						defaults,
-						attributesToMigrate: [
-							'borderSizeTop',
-							'borderSizeRight',
-							'borderSizeBottom',
-							'borderSizeLeft',
-							'borderRadiusTopRight',
-							'borderRadiusBottomRight',
-							'borderRadiusBottomLeft',
-							'borderRadiusTopLeft',
-						],
-					} ),
-					updateBlockVersion( 2 ),
-				]
-			);
+				defaults: getBlockType( 'generateblocks/image' )?.attributes,
+			} );
 
 			if ( ! isEmpty( newAttributes ) ) {
 				setAttributes( newAttributes );


### PR DESCRIPTION
This runs our Global Style attributes through our migration functions to ensure blocks using old Global Styles appear properly in the editor.