### PR TITLE
Tweak: Clean up `UnitControl` display

### DIFF
--- a/src/components/dimensions/editor.scss
+++ b/src/components/dimensions/editor.scss
@@ -44,10 +44,10 @@
 					grid-area: top;
 					display: flex;
 					flex-direction: column-reverse;
-					gap: 5px;
 
 					.gblocks-dimensions-control__label {
 						text-align: center;
+						padding-bottom: 5px;
 					}
 				}
 
@@ -65,10 +65,10 @@
 					grid-area: bottom;
 					display: flex;
 					flex-direction: column;
-					gap: 5px;
 
 					.gblocks-dimensions-control__label {
 						text-align: center;
+						padding-top: 5px;
 					}
 				}
 

--- a/src/components/unit-control/editor.scss
+++ b/src/components/unit-control/editor.scss
@@ -7,18 +7,22 @@
 
 	&__override-action {
 		position: absolute;
-		right: 30px;
+		right: 28px;
 		top: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
 
 		button.components-button {
-			width: 30px;
-			height: 30px;
-			min-width: 30px;
+			width: 20px;
+			height: 20px;
+			min-width: 20px;
 			padding: 0;
+			border-radius: 100%;
 			justify-content: center !important;
 
 			svg {
-				width: 20px;
+				width: 15px;
 				margin: 0 !important;
 			}
 		}
@@ -49,12 +53,12 @@
 			letter-spacing: -0.5px;
 			outline: none;
 			padding: 2px 3px;
-			text-align-last: center;
 			text-transform: uppercase;
-			width: 30px;
+			width: 25px;
 			cursor: pointer;
 			height: 100%;
 			margin: 0;
+			border: 0;
 
 			&:disabled {
 				background: none;
@@ -65,11 +69,10 @@
 	}
 
 	&__unit-select {
-		-moz-box-align: center;
-		align-items: center;
-		align-self: stretch;
-		box-sizing: border-box;
-		display: flex;
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
 	}
 
 	&__popover {

--- a/src/extend/inspector-control/controls/sizing/index.js
+++ b/src/extend/inspector-control/controls/sizing/index.js
@@ -4,7 +4,6 @@ import getIcon from '../../../../utils/get-icon';
 import { useContext } from '@wordpress/element';
 import ControlsContext from '../../../../block-context';
 import { Tooltip, Button } from '@wordpress/components';
-import { globe } from '@wordpress/icons';
 import { applyFilters } from '@wordpress/hooks';
 import MinHeight from './components/MinHeight';
 import getAttribute from '../../../../utils/get-attribute';
@@ -143,7 +142,7 @@ export default function Sizing( props ) {
 							return (
 								<Tooltip text={ __( 'Use global max-width', 'generateblocks' ) }>
 									<Button
-										icon={ globe }
+										icon={ getIcon( 'globe' ) }
 										isPrimary={ !! useGlobalMaxWidth }
 										onClick={ () => {
 											setAttributes( {

--- a/src/utils/get-icon/index.js
+++ b/src/utils/get-icon/index.js
@@ -416,4 +416,14 @@ export default function getIcon( icon ) {
 			</svg>
 		);
 	}
+
+	if ( 'globe' === icon ) {
+		return (
+			<svg width="20" height="20" viewBox="0 0 256 256">
+				<path fill="none" d="M0 0h256v256H0z" />
+				<circle cx="128" cy="128" r="96" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="12" />
+				<path d="M88 128c0 37.46 13.33 70.92 34.28 93.49a7.77 7.77 0 0 0 11.44 0C154.67 198.92 168 165.46 168 128s-13.33-70.92-34.28-93.49a7.77 7.77 0 0 0-11.44 0C101.33 57.08 88 90.54 88 128ZM32 128h192" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="12" />
+			</svg>
+		);
+	}
 }


### PR DESCRIPTION
This adjusts the style of the unit picker in our `UnitControl` component so it looks consistent across all browsers.

![unit-control](https://github.com/tomusborne/generateblocks/assets/20714883/a35fcdd9-1fcc-45e5-9912-457030f81c64)

It also fixes a bug in Safari where the "Top" label in Spacing was right up against the input.