### PR TITLE
Fix: Flex icons based on direction in device previews

### DIFF
--- a/src/extend/inspector-control/controls/layout/index.js
+++ b/src/extend/inspector-control/controls/layout/index.js
@@ -39,7 +39,7 @@ export default function Layout( { attributes, setAttributes } ) {
 		align,
 	} = attributes;
 
-	const directionValue = getResponsivePlaceholder( 'flexDirection', attributes, device, 'row' );
+	const directionValue = getAttribute( 'flexDirection', componentProps ) || getResponsivePlaceholder( 'flexDirection', attributes, device, 'row' );
 
 	return (
 		<PanelArea


### PR DESCRIPTION
close #1032 