### PR TITLE
Fix: Container appender icon spacing

### DIFF
--- a/src/blocks/container/editor.scss
+++ b/src/blocks/container/editor.scss
@@ -257,8 +257,7 @@ body.gutenberg-editor-page [data-type="generateblocks/container"] .editor-block-
 .gb-container.block-editor-block-list__block {
 	& > .block-list-appender {
 		position: relative;
-		display: inline-block;
-		vertical-align: middle;
+		width: 35px;
 		padding: 0;
 		margin-top: 10px;
 
@@ -306,6 +305,8 @@ body.gutenberg-editor-page [data-type="generateblocks/container"] .editor-block-
 		transition: opacity 500ms ease;
 
 		svg {
+			width: 35px;
+			height: 35px;
 			transform: scale(0.7);
 
 			path {


### PR DESCRIPTION
This fixes a gap above the Container appender icon when the Container is empty.

It also fixes a bug where the Container icon in the appender wasn't showing up in Safari.