### PR TITLE
Fix: Use unit in `UnitControl` if value starts with decimal

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Fix: Flex icons based on direction in device previews
 * Fix: Container appender icon spacing
 * Fix: useDeviceType state was one state behind when triggered from core buttons
+* Fix: Use unit in UnitControl if value starts with decimal
 * Tweak: Require at least PHP 7.2
 * Tweak: Move block alignment to Layout panel
 * Tweak: Remove help text from Grid vertical alignment

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -52,7 +52,9 @@ export default function UnitControl( props ) {
 	const getNumericValue = ( values ) => values.length > 0 ? values[ 0 ] : '';
 	const defaultUnitValue = defaultUnit ? defaultUnit : units[ 0 ];
 	const getUnitValue = ( values ) => values.length > 1 ? values[ 1 ] : defaultUnitValue;
-	const startsWithNumber = ( number ) => /^\d/.test( number );
+
+	// Test if the value starts with a number or a decimal.
+	const startsWithNumber = ( number ) => /^[0-9.]/.test( number );
 
 	const setPlaceholders = () => {
 		if ( ! value ) {


### PR DESCRIPTION
This fixes a bug where the current `UnitControl` component sees values like `.9` as a non-numerical value, so it doesn't add the unit to it.