### PR TITLE
Fix: Broken device buttons when sync preview turned off

### DIFF
--- a/src/hooks/useDeviceType.js
+++ b/src/hooks/useDeviceType.js
@@ -10,7 +10,7 @@ export default ( initialDeviceType = 'Desktop' ) => {
 		}
 	);
 
-	if ( ! dispatch( 'core/edit-post' ) ) {
+	if ( ! dispatch( 'core/edit-post' ) || ( generateBlocksInfo && ! generateBlocksInfo.syncResponsivePreviews ) ) {
 		const setDeviceType = ( type ) => {
 			setLocalDeviceType( type );
 		};
@@ -37,10 +37,7 @@ export default ( initialDeviceType = 'Desktop' ) => {
 	}, [ previewDeviceType ] );
 
 	const setDeviceType = ( type ) => {
-		if ( generateBlocksInfo && generateBlocksInfo.syncResponsivePreviews ) {
-			setPreviewDeviceType( type );
-		}
-
+		setPreviewDeviceType( type );
 		setLocalDeviceType( type );
 	};
 


### PR DESCRIPTION
The device buttons are currently broken if you turn off Sync Responsive Previews in "GenerateBlocks > Settings".