### PR TITLE
Tweak: Force lowercase units in `UnitControl`

### DIFF
--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -47,7 +47,7 @@ export default function UnitControl( props ) {
 		const splitRegex = new RegExp( `(${ unitRegex })` );
 
 		return values
-			? values.toString().split( splitRegex ).filter( ( singleValue ) => '' !== singleValue )
+			? values.toString().toLowerCase().split( splitRegex ).filter( ( singleValue ) => '' !== singleValue )
 			: [];
 	};
 


### PR DESCRIPTION
This fixes cases where the user uses uppercase units which results in values like this: `10PXpx`