### PR TITLE
Tweak: Remove `isSmall` from sync buttons

### DIFF
--- a/src/components/dimensions/index.js
+++ b/src/components/dimensions/index.js
@@ -76,7 +76,6 @@ export default function Dimensions( props ) {
 					variant={ !! sync ? 'primary' : '' }
 					aria-pressed={ !! sync }
 					onClick={ () => syncUnits() }
-					isSmall
 				>
 					{ !! sync ? link : linkOff }
 				</Button>

--- a/src/extend/inspector-control/controls/borders/index.js
+++ b/src/extend/inspector-control/controls/borders/index.js
@@ -111,7 +111,6 @@ export default function Borders( { attributes, setAttributes } ) {
 									manualSync();
 								}
 							} }
-							isSmall
 						>
 							{ !! sync ? link : linkOff }
 						</Button>


### PR DESCRIPTION
This fixes a sizing issue with the buttons when using the latest Gutenberg plugin.