### PR TITLE
Fix: Global styles overwriting local attributes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 == Changelog ==
 
 = 1.8.1 =
+* Fix: Global styles overwriting local attributes
 
 = 1.8.0 =
 * Feature: Add flexbox alignment matrix component to Container toolbar

--- a/src/hoc/migrations/migrateGlobalStyleAttrs.js
+++ b/src/hoc/migrations/migrateGlobalStyleAttrs.js
@@ -5,6 +5,7 @@ import { migrateContainerAttributes } from '../withContainerLegacyMigration';
 import { migrateHeadlineAttributes } from '../withHeadlineLegacyMigration';
 import { migrateGridAttributes } from '../withGridLegacyMigration';
 import { migrateImageAttributes } from '../withImageLegacyMigration';
+import { isEmpty, isObject } from 'lodash';
 
 /**
  * This ensures that Global Styles pass the correct attributes
@@ -62,7 +63,26 @@ addFilter(
 				mode: 'css',
 			} );
 
-			return { ...attributes, ...migratedAttributes };
+			const newAttributes = {};
+
+			// We only need these migrated attributes if a local attribute doesn't exist.
+			Object.entries( migratedAttributes ).forEach( ( [ attributeName, attributeValue ] ) => {
+				if ( isObject( attributeValue ) ) {
+					Object.entries( attributeValue ).forEach( ( [ objectProperty, objectValue ] ) => {
+						if ( isEmpty( attributes[ attributeName ]?.[ objectProperty ] ) ) {
+							newAttributes[ attributeName ] = {
+								...attributes[ attributeName ],
+								...newAttributes[ attributeName ],
+								[ objectProperty ]: objectValue,
+							};
+						}
+					} );
+				} else if ( isEmpty( attributes[ attributeName ] ) ) {
+					newAttributes[ attributeName ] = attributeValue;
+				}
+			} );
+
+			return { ...attributes, ...newAttributes };
 		}
 
 		return attributes;


### PR DESCRIPTION
This fixes a bug where our migrated Global Style attributes were overriding local attributes in the editor.

Reference: https://generate.support/topic/gb-v-1-8-0-headline-icon-sizing-bug

To reproduce:

1. Create a Global Style in GB 1.7.3.
2. Add a Headline with some padding, icon padding and icon size.
3. Update to 1.8.0 and use this Global Style in the editor.
4. Try changing the local padding, icon padding or icon size.