### PR TITLE
`wp_img_tag_add_loading_attr` deprecated in 6.3

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -908,7 +908,7 @@ function generateblocks_filter_images( $content, $attributes ) {
 
 	// Add 'loading' attribute if applicable.
 	if ( wp_lazy_loading_enabled( 'img', '' ) && false === strpos( $content, ' loading=' ) ) {
-		$content = wp_img_tag_add_loading_attr( $content, '' );
+		$content = wp_img_tag_add_loading_optimization_attrs( $content, '' );
 	}
 
 	return $content;


### PR DESCRIPTION
`wp_img_tag_add_loading_attr` has been deprecated in WordPress 6.3. updated with `wp_img_tag_add_loading_optimization_attrs` https://developer.wordpress.org/reference/functions/wp_img_tag_add_loading_optimization_attrs/