### PR TITLE
Fix/border color not showing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 == Changelog ==
 
 = 1.8.2 =
+* Fix: Border colors not showing when old attributes are set.
 
 = 1.8.1 =
 * Fix: Icon padding controls order

--- a/src/extend/inspector-control/controls/borders/index.js
+++ b/src/extend/inspector-control/controls/borders/index.js
@@ -189,7 +189,7 @@ export default function Borders( { attributes, setAttributes } ) {
 									} }
 								/>
 
-								{ !! bordersPanel.borderColors.length && 'Desktop' === device && ! attributes.borderColor && ! attributes.borderColorHover && ! attributes.borderColorCurrent &&
+								{ !! bordersPanel.borderColors.length && 'Desktop' === device &&
 									<div className="gblocks-border-colors">
 										{ bordersPanel.borderColors.map( ( borderColor, index ) => {
 											return (


### PR DESCRIPTION
Reference: https://generate.support/topic/button-border-colours-missing-in-block-settings/