### PR TITLE
Tweak: Load block margin/max-width resets before block CSS

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -426,3 +426,20 @@ function generateblocks_register_user_meta() {
 		)
 	);
 }
+
+add_filter( 'block_editor_settings_all', 'generateblocks_do_block_css_reset', 15 );
+/**
+ * This resets the `max-width`, `margin-left`, and `margin-right` properties for our blocks in the editor.
+ * We have to do this as most themes use `.wp-block` to set a `max-width` and auto margins.
+ *
+ * We used to do this directly in the block CSS if those block attributes didn't exist, but this allows us
+ * to overwrite the reset in the `block_editor_settings_all` filter with a later priority.
+ *
+ * @param array $editor_settings The existing editor settings.
+ */
+function generateblocks_do_block_css_reset( $editor_settings ) {
+	$css = '.gb-container, .gb-headline, .gb-button, .gb-image, .gb-grid-wrapper, .gb-button-wrapper {max-width:unset;margin-left:0;margin-right:0;}';
+	$editor_settings['styles'][] = [ 'css' => $css ];
+
+	return $editor_settings;
+}

--- a/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
+++ b/src/extend/inspector-control/controls/sizing/components/SizingCSS.js
@@ -27,10 +27,6 @@ export default function SizingCSS( css, selector, attributes, device = '' ) {
 		delete styles[ 'max-width' ];
 	}
 
-	if ( ! styles[ 'max-width' ] ) {
-		styles[ 'max-width' ] = 'unset';
-	}
-
 	return (
 		addToCSS( css, selector, styles )
 	);

--- a/src/extend/inspector-control/controls/spacing/components/SpacingCSS.js
+++ b/src/extend/inspector-control/controls/spacing/components/SpacingCSS.js
@@ -1,13 +1,11 @@
 import addToCSS from '../../../../../utils/add-to-css';
 
 export default function SpacingCSS( css, selector, attributes, device = '' ) {
-	const fallback = '' === device ? '0' : '';
-
 	const styles = {
 		'margin-top': attributes[ 'marginTop' + device ],
-		'margin-right': attributes[ 'marginRight' + device ] || fallback,
+		'margin-right': attributes[ 'marginRight' + device ],
 		'margin-bottom': attributes[ 'marginBottom' + device ],
-		'margin-left': attributes[ 'marginLeft' + device ] || fallback,
+		'margin-left': attributes[ 'marginLeft' + device ],
 		'padding-top': attributes[ 'paddingTop' + device ],
 		'padding-right': attributes[ 'paddingRight' + device ],
 		'padding-bottom': attributes[ 'paddingBottom' + device ],


### PR DESCRIPTION
Right now we set the `margin` and `max-width` of our blocks if values for those attributes don't exist.

Loading these resets directly in the block CSS makes them very difficult/impossible to overwrite.

This removes the resets from the individual block CSS and loads them in the `block_editor_settings_all` filter so we can overwrite them with other styles if necessary.