### PR TITLE
Chore: Ignore `.nvmrc` from dist

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@ tests
 .eslintrc.json
 .gitattributes
 .gitignore
+.nvmrc
 package-lock.json
 package.json
 composer.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,7 @@ module.exports = function( grunt ) {
 					'!.eslintignore',
 					'!.eslintrc.json',
 					'!*.zip',
+					'!.nvmrc',
 				],
 				dest: 'package/generateblocks/',
 			},


### PR DESCRIPTION
Ignores the `.nvmrc` file when packaging up our .zip (`Gruntfile.js`) and sending the files to WP.org (`.distignore`).