### PR TITLE
Tweak: Remove one-time CSS

### DIFF
--- a/includes/blocks/class-button.php
+++ b/includes/blocks/class-button.php
@@ -171,12 +171,7 @@ class GenerateBlocks_Block_Button {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-button' );
-			$css->add_property( 'text-decoration', 'none' );
-
-			$css->set_selector( '.gb-icon svg' );
-			$css->add_property( 'fill', 'currentColor' );
-
+			// Singular CSS is no longer supported since 1.9.0.
 			do_action(
 				'generateblocks_block_one_time_css_data',
 				'button',
@@ -200,6 +195,7 @@ class GenerateBlocks_Block_Button {
 		generateblocks_add_border_css( $css, $settings );
 		$css->add_property( 'background-color', generateblocks_hex2rgba( $settings['backgroundColor'], $settings['backgroundColorOpacity'] ) );
 		$css->add_property( 'color', $settings['textColor'] );
+		$css->add_property( 'text-decoration', 'none' );
 
 		if ( $settings['gradient'] ) {
 			$css->add_property( 'background-image', 'linear-gradient(' . $settings['gradientDirection'] . 'deg, ' . generateblocks_hex2rgba( $settings['gradientColorOne'], $settings['gradientColorOneOpacity'] ) . $gradientColorStopOneValue . ', ' . generateblocks_hex2rgba( $settings['gradientColorTwo'], $settings['gradientColorTwoOpacity'] ) . $gradientColorStopTwoValue . ')' );
@@ -271,6 +267,7 @@ class GenerateBlocks_Block_Button {
 
 			$css->add_property( 'width', generateblocks_get_array_attribute_value( 'width', $settings['iconStyles'] ) );
 			$css->add_property( 'height', generateblocks_get_array_attribute_value( 'height', $settings['iconStyles'] ) );
+			$css->add_property( 'fill', 'currentColor' );
 		}
 
 		$tablet_css->set_selector( $selector );

--- a/includes/blocks/class-container.php
+++ b/includes/blocks/class-container.php
@@ -182,18 +182,6 @@ class GenerateBlocks_Block_Container {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-container .wp-block-image img' );
-			$css->add_property( 'vertical-align', 'middle' );
-
-			$css->set_selector( '.gb-container .gb-shape' );
-			$css->add_property( 'position', 'absolute' );
-			$css->add_property( 'overflow', 'hidden' );
-			$css->add_property( 'pointer-events', 'none' );
-			$css->add_property( 'line-height', '0' );
-
-			$css->set_selector( '.gb-container .gb-shape svg' );
-			$css->add_property( 'fill', 'currentColor' );
-
 			do_action(
 				'generateblocks_block_one_time_css_data',
 				'container',
@@ -512,6 +500,10 @@ class GenerateBlocks_Block_Container {
 				$css->set_selector( $selector . ' > .gb-shapes .gb-shape-' . $shapeNumber );
 				$css->add_property( 'color', generateblocks_hex2rgba( $shapeOptions['color'], $shapeOptions['colorOpacity'] ) );
 				$css->add_property( 'z-index', $shapeOptions['zindex'] );
+				$css->add_property( 'position', 'absolute' );
+				$css->add_property( 'overflow', 'hidden' );
+				$css->add_property( 'pointer-events', 'none' );
+				$css->add_property( 'line-height', '0' );
 
 				if ( 'top' === $shapeOptions['location'] || 'bottom' === $shapeOptions['location'] ) {
 					$css->add_property( 'left', '0' );
@@ -539,6 +531,7 @@ class GenerateBlocks_Block_Container {
 				$css->set_selector( $selector . ' > .gb-shapes .gb-shape-' . $shapeNumber . ' svg' );
 				$css->add_property( 'height', $shapeOptions['height'], 'px' );
 				$css->add_property( 'width', $shapeWidth );
+				$css->add_property( 'fill', 'currentColor' );
 
 				if ( 'top' === $shapeOptions['location'] || 'bottom' === $shapeOptions['location'] ) {
 					$css->add_property( 'position', 'relative' );

--- a/includes/blocks/class-grid.php
+++ b/includes/blocks/class-grid.php
@@ -109,16 +109,6 @@ class GenerateBlocks_Block_Grid {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-grid-wrapper' );
-			$css->add_property( 'display', 'flex' );
-			$css->add_property( 'flex-wrap', 'wrap' );
-
-			$css->set_selector( '.gb-grid-column' );
-			$css->add_property( 'box-sizing', 'border-box' );
-
-			$css->set_selector( '.gb-grid-wrapper .wp-block-image' );
-			$css->add_property( 'margin-bottom', '0' );
-
 			do_action(
 				'generateblocks_block_one_time_css_data',
 				'grid',
@@ -130,6 +120,8 @@ class GenerateBlocks_Block_Grid {
 		}
 
 		$css->set_selector( '.gb-grid-wrapper-' . $id );
+		$css->add_property( 'display', 'flex' );
+		$css->add_property( 'flex-wrap', 'wrap' );
 		$css->add_property( 'align-items', $settings['verticalAlignment'] );
 		$css->add_property( 'justify-content', $settings['horizontalAlignment'] );
 
@@ -142,6 +134,7 @@ class GenerateBlocks_Block_Grid {
 		}
 
 		$css->set_selector( '.gb-grid-wrapper-' . $id . ' > .gb-grid-column' );
+		$css->add_property( 'box-sizing', 'border-box' );
 		$css->add_property( 'padding-' . $gap_direction, $settings['horizontalGap'], 'px' );
 
 		if ( $blockVersion < 3 || $settings['useLegacyRowGap'] ) {

--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -151,13 +151,7 @@ class GenerateBlocks_Block_Headline {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-icon svg' );
-			$css->add_property( 'fill', 'currentColor' );
-
-			$css->set_selector( '.gb-highlight' );
-			$css->add_property( 'background', 'none' );
-			$css->add_property( 'color', 'unset' );
-
+			// Singular CSS is no longer supported since 1.9.0.
 			do_action(
 				'generateblocks_block_one_time_css_data',
 				'headline',
@@ -252,11 +246,13 @@ class GenerateBlocks_Block_Headline {
 
 				$css->add_property( 'width', generateblocks_get_array_attribute_value( 'width', $settings['iconStyles'] ) );
 				$css->add_property( 'height', generateblocks_get_array_attribute_value( 'height', $settings['iconStyles'] ) );
+				$css->add_property( 'fill', 'currentColor' );
 			}
 
 			if ( $settings['highlightTextColor'] ) {
 				$css->set_selector( $selector . ' .gb-highlight' );
 				$css->add_property( 'color', $settings['highlightTextColor'] );
+				$css->add_property( 'background', 'none' );
 			}
 
 			$tablet_css->set_selector( $selector );
@@ -461,6 +457,7 @@ class GenerateBlocks_Block_Headline {
 				$css->set_selector( '.gb-headline-wrapper-' . $id . ' .gb-icon svg' );
 				$css->add_property( 'width', $settings['iconSize'], $settings['iconSizeUnit'] );
 				$css->add_property( 'height', $settings['iconSize'], $settings['iconSizeUnit'] );
+				$css->add_property( 'fill', 'currentColor' );
 
 				$css->set_selector( '.gb-headline-wrapper-' . $id );
 				$css->add_property( 'padding', array( $settings['paddingTop'], $settings['paddingRight'], $settings['paddingBottom'], $settings['paddingLeft'] ), $settings['paddingUnit'] );
@@ -505,6 +502,7 @@ class GenerateBlocks_Block_Headline {
 			if ( $settings['highlightTextColor'] ) {
 				$css->set_selector( '.gb-headline-' . $id . ' .gb-highlight' );
 				$css->add_property( 'color', $settings['highlightTextColor'] );
+				$css->add_property( 'background', 'none' );
 			}
 
 			$tablet_css->set_selector( '.gb-headline-' . $id );

--- a/includes/blocks/class-image.php
+++ b/includes/blocks/class-image.php
@@ -93,9 +93,6 @@ class GenerateBlocks_Block_Image {
 
 		// Only add this CSS once.
 		if ( ! self::$singular_css_added ) {
-			$css->set_selector( '.gb-block-image img' );
-			$css->add_property( 'vertical-align', 'middle' );
-
 			do_action(
 				'generateblocks_block_one_time_css_data',
 				'image',
@@ -128,6 +125,7 @@ class GenerateBlocks_Block_Image {
 		$css->add_property( 'width', $settings['width'] );
 		$css->add_property( 'height', $settings['height'] );
 		$css->add_property( 'object-fit', $settings['objectFit'] );
+		$css->add_property( 'vertical-align', 'middle' );
 
 		$tablet_css->set_selector( '.gb-block-image-' . $id );
 		generateblocks_add_spacing_css( $tablet_css, $settings, 'Tablet' );

--- a/includes/general.php
+++ b/includes/general.php
@@ -443,3 +443,16 @@ function generateblocks_do_block_css_reset( $editor_settings ) {
 
 	return $editor_settings;
 }
+
+add_filter( 'generateblocks_css_output', 'generateblocks_add_general_css' );
+/**
+ * Add general CSS that doesn't apply to our own blocks.
+ *
+ * @param string $css Existing CSS.
+ */
+function generateblocks_add_general_css( $css ) {
+	$css .= '.gb-container .wp-block-image img{vertical-align:middle;}';
+	$css .= '.gb-grid-wrapper .wp-block-image{margin-bottom:0;}';
+
+	return $css;
+}


### PR DESCRIPTION
CSS generated by blocks should be specific to the individual block being rendered.

This PR removes all "one-time" CSS from the individual block output.

This means we could revert the `generateblocks_skip_singular_css` filter we had to add to integrate with Global Classes in GB Pro: https://github.com/tomusborne/generateblocks/blob/feature/pattern-library/includes/blocks/class-button.php#L173