### PR TITLE
Add support for numerical cursor input

### DIFF
--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 import './editor.scss';
 import UnitDropdown from './unit-dropdown';
 import unitList from './unit-list';
+import { key } from '@wordpress/icons';
 
 export default function UnitControl( props ) {
 	const {
@@ -141,6 +142,20 @@ export default function UnitControl( props ) {
 					step={ step }
 					autoComplete="off"
 					disabled={ disabled }
+					onKeyDown={ ( event ) => {
+						const keyPressed = event.key;
+						const newValue = event.target.value;
+
+						if ( keyPressed === 'ArrowUp' ) {
+							if ( ! isNaN( newValue ) ) {
+								setNumericValue( +newValue + 1 );
+							}
+						} else if ( keyPressed === 'ArrowDown' ) {
+							if ( ! isNaN( newValue ) ) {
+								setNumericValue( +newValue - 1 );
+							}
+						}
+					} }
 					onChange={ ( newValue ) => setNumericValue( newValue ) }
 					onFocus={ () => {
 						onFocus();

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -12,7 +12,6 @@ import classnames from 'classnames';
 import './editor.scss';
 import UnitDropdown from './unit-dropdown';
 import unitList from './unit-list';
-import { key } from '@wordpress/icons';
 
 export default function UnitControl( props ) {
 	const {


### PR DESCRIPTION
Fixes #1135.

Allows the use of up/down cursor keys to nudge values in the `UnitControl` component. If text is present (e.g. `calc()`) then it doesn't attempt to alter the input value.

I like how the combination of using tab and the up/down cursor input enables fast iteration of editing values (see video for demo).

If accepted, should this be merged into the release branch, or the pattern library branch?

https://github.com/tomusborne/generateblocks/assets/1482075/fb164f5e-22a7-48aa-a7d6-90a1da6ce358
