### PR TITLE
Tweak: Remove Button resets

### DIFF
--- a/src/blocks/button/editor.scss
+++ b/src/blocks/button/editor.scss
@@ -3,11 +3,8 @@
  */
 .editor-styles-wrapper {
 	.gb-button {
-		padding: unset;
 		line-height: unset;
 		text-decoration: none !important;
-		border: none;
-		margin: 0;
 		box-sizing: border-box;
 
 		.editor-rich-text__tinymce {


### PR DESCRIPTION
These properties can be set by the block and don't need to be reset.