### PR TITLE
Feature/pattern library requests

### DIFF
--- a/src/blocks/pattern-library/components/category-list.js
+++ b/src/blocks/pattern-library/components/category-list.js
@@ -8,6 +8,7 @@ export default function CategoryList() {
 	return (
 		<div className="pattern-category-list">
 			<Button
+				id="pattern-category-all"
 				isPressed={ '' === activeCategory }
 				onClick={ () => setActiveCategory( '' ) }
 			>
@@ -15,6 +16,7 @@ export default function CategoryList() {
 			</Button>
 			{ categories && categories.map( ( category ) => (
 				<Button
+					id={ `pattern-category-${ category.id }` }
 					key={ category.id }
 					isPressed={ category.id === activeCategory }
 					onClick={ () => setActiveCategory( category.id ) }

--- a/src/blocks/pattern-library/components/library-provider.js
+++ b/src/blocks/pattern-library/components/library-provider.js
@@ -104,7 +104,7 @@ export function LibraryProvider( { clientId, children } ) {
 	const [ loading, setLoading ] = useState( false );
 	const [ previewIframeWidth, setPreviewIframeWidth ] = useState( '100%' );
 	const [ requiredClasses, setRequiredClasses ] = useState( [] );
-	const itemsPerPage = 12;
+	const itemsPerPage = 15;
 	const [ itemCount, setItemCount ] = useState( itemsPerPage );
 	const [ scrollPosition, setScrollPosition ] = useState( 0 );
 

--- a/src/blocks/pattern-library/components/library-provider.js
+++ b/src/blocks/pattern-library/components/library-provider.js
@@ -159,10 +159,9 @@ export function LibraryProvider( { clientId, children } ) {
 
 	async function setLibraryCategories() {
 		const { data } = await fetchLibraryCategories( activeLibrary?.id, isLocal, publicKey );
-		const { data: allPatterns } = await fetchLibraryPatterns( activeLibrary?.id, '', '', isLocal, publicKey );
 
 		// We only want to show categories that have patterns in this current library of collections.
-		const categoriesInPatterns = new Set( allPatterns.flatMap( ( obj ) => obj.categories ) );
+		const categoriesInPatterns = new Set( patterns.flatMap( ( obj ) => obj.categories ) );
 		const categoriesWithPatterns = data.filter( ( category ) => categoriesInPatterns.has( category.id ) );
 
 		setCategories( categoriesWithPatterns ?? [] );
@@ -180,8 +179,8 @@ export function LibraryProvider( { clientId, children } ) {
 			setRequiredClasses( [] );
 		}
 
-		// Fetch patterns for the active library.
-		const { data: fetchedPatterns } = await fetchLibraryPatterns( activeLibrary?.id, activeCategory, search, isLocal, publicKey );
+		// Fetch all patterns for the active library.
+		const { data: fetchedPatterns } = await fetchLibraryPatterns( activeLibrary?.id, '', '', isLocal, publicKey );
 		setPatterns( fetchedPatterns ?? [] );
 
 		// Reset.
@@ -212,7 +211,7 @@ export function LibraryProvider( { clientId, children } ) {
 		} else {
 			setCategories( [] );
 		}
-	}, [ activeLibrary?.id ] );
+	}, [ activeLibrary?.id, patterns ] );
 
 	useEffect( () => {
 		if ( activeLibrary.id ) {
@@ -220,7 +219,7 @@ export function LibraryProvider( { clientId, children } ) {
 		} else {
 			setPatterns( [] );
 		}
-	}, [ activeLibrary?.id, activeCategory, search, publicKey ] );
+	}, [ activeLibrary?.id, publicKey ] );
 
 	return (
 		<LibraryContext.Provider value={ defaultContext }>

--- a/src/blocks/pattern-library/components/pattern-list.js
+++ b/src/blocks/pattern-library/components/pattern-list.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 import { PatternDetails } from './pattern-details';
 import classnames from 'classnames';
 
-export default function PatternList( { bulkInsertEnabled = false } ) {
+export default function PatternList( { bulkInsertEnabled = false, patterns } ) {
 	const ref = useRef();
 	const loadMoreRef = useRef();
 	const {
-		patterns,
 		activePatternId,
 		setActivePatternId,
 		loading,

--- a/src/blocks/pattern-library/components/pattern-list.js
+++ b/src/blocks/pattern-library/components/pattern-list.js
@@ -6,12 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { PatternDetails } from './pattern-details';
 import classnames from 'classnames';
 
-export default function PatternList( { bulkInsertEnabled = false, patterns } ) {
+export default function PatternList( { bulkInsertEnabled = false, patterns = [] } ) {
 	const ref = useRef();
 	const loadMoreRef = useRef();
 	const {
 		activePatternId,
-		setActivePatternId,
 		loading,
 		itemsPerPage,
 		itemCount,
@@ -114,8 +113,8 @@ export default function PatternList( { bulkInsertEnabled = false, patterns } ) {
 			{ !! activePattern &&
 				<Pattern
 					isLoading={ loading }
-					activePatternId={ activePatternId }
-					{ ...activePattern }
+					isActive={ true }
+					pattern={ activePattern }
 				/>
 			}
 
@@ -127,7 +126,7 @@ export default function PatternList( { bulkInsertEnabled = false, patterns } ) {
 					display: !! activePattern ? 'none' : '',
 				} }
 			>
-				{ visiblePatterns && visiblePatterns.map( ( pattern ) => {
+				{ visiblePatterns.map( ( pattern ) => {
 					const isSelected = selectedPatterns.some( ( { id } ) => id === pattern.id ) ?? false;
 
 					return (
@@ -167,8 +166,7 @@ export default function PatternList( { bulkInsertEnabled = false, patterns } ) {
 							) }
 							<Pattern
 								isLoading={ loading }
-								setActivePattern={ setActivePatternId }
-								{ ...pattern }
+								pattern={ pattern }
 							/>
 
 							<PatternDetailsMemo

--- a/src/blocks/pattern-library/components/pattern-search.js
+++ b/src/blocks/pattern-library/components/pattern-search.js
@@ -1,21 +1,16 @@
 import { SearchControl } from '@wordpress/components';
-import { useDebounce } from '@wordpress/compose';
-import { useLibrary } from './library-provider';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
-export default function PatternSearch() {
-	const { search, setSearch } = useLibrary();
-	const [ searchInput, setSearchInput ] = useState( search );
-	const setDebouncedInput = useDebounce( setSearch, 500 );
-
-	useEffect( () => {
-		setDebouncedInput( searchInput );
-	}, [ searchInput ] );
+export default function PatternSearch( { onChange } ) {
+	const [ searchInput, setSearchInput ] = useState( '' );
 
 	return (
 		<SearchControl
 			value={ searchInput }
-			onChange={ setSearchInput }
+			onChange={ ( value ) => {
+				onChange( value );
+				setSearchInput( value );
+			} }
 		/>
 	);
 }

--- a/src/blocks/pattern-library/components/pattern-search.js
+++ b/src/blocks/pattern-library/components/pattern-search.js
@@ -1,8 +1,16 @@
 import { SearchControl } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+import { useLibrary } from './library-provider';
 
 export default function PatternSearch( { onChange } ) {
+	const { setSearch } = useLibrary();
 	const [ searchInput, setSearchInput ] = useState( '' );
+	const setDebouncedInput = useDebounce( setSearch, 500 );
+
+	useEffect( () => {
+		setDebouncedInput( searchInput );
+	}, [ searchInput ] );
 
 	return (
 		<SearchControl

--- a/src/blocks/pattern-library/components/pattern.js
+++ b/src/blocks/pattern-library/components/pattern.js
@@ -3,20 +3,19 @@ import { useEffect, useRef, useState, useLayoutEffect } from '@wordpress/element
 import imagesLoaded from 'imagesloaded';
 import { useLibrary } from './library-provider';
 
-export default function Pattern( props ) {
+export default function Pattern( { pattern, isLoading, isActive = false } ) {
 	const {
 		id,
 		preview,
-		isLoading,
-		activePatternId,
 		label,
-	} = props;
+		scripts = [],
+	} = pattern;
 	const iframeRef = useRef();
 	const elementRef = useRef();
 	const [ height, setHeight ] = useState( 0 );
 	const [ injectContent, setInjectContent ] = useState( false );
 	const [ editorColors, setEditorColors ] = useState( {} );
-	const [ isVisible, setIsVisible ] = useState( !! activePatternId );
+	const [ isVisible, setIsVisible ] = useState( !! isActive );
 	const [ isLoaded, setIsLoaded ] = useState( false );
 	const [ patternWidth, setPatternWidth ] = useState( 0 );
 	const [ isResizing, setIsResizing ] = useState( false );
@@ -98,7 +97,6 @@ export default function Pattern( props ) {
 		}
 
 		const document = iframeRef.current.contentWindow.document;
-		const scripts = props?.scripts ?? [];
 
 		scripts.forEach( ( script ) => {
 			const scriptElement = document.createElement( 'script' );
@@ -148,7 +146,7 @@ export default function Pattern( props ) {
 	 * Set the height of the preview iframe.
 	 */
 	useEffect( () => {
-		if ( ! activePatternId ) {
+		if ( ! isActive ) {
 			return;
 		}
 
@@ -165,6 +163,11 @@ export default function Pattern( props ) {
 	useEffect( () => {
 		const iframeDocument = iframeRef.current.contentWindow.document;
 		const iframeBody = iframeDocument.body;
+
+		if ( ! iframeBody ) {
+			return;
+		}
+
 		const elements = Array.from( iframeBody.querySelectorAll( '*' ) );
 
 		const firstVisibleElement = elements?.find( ( element ) => {
@@ -197,7 +200,7 @@ export default function Pattern( props ) {
 	return (
 		<div
 			className="gb-pattern-frame"
-			style={ activePatternId ? {
+			style={ isActive ? {
 				backgroundColor: 'none',
 				padding: 0,
 			} : {} }
@@ -205,17 +208,17 @@ export default function Pattern( props ) {
 			<div
 				ref={ elementRef }
 				className="gb-pattern"
-				style={ ! activePatternId ? wrapperStyle : { minHeight: '200px' } }
+				style={ ! isActive ? wrapperStyle : { minHeight: '200px' } }
 			>
 				{ !! isVisible && ! isLoaded && <Spinner /> }
 				<div
-					style={ ! activePatternId ? {
+					style={ ! isActive ? {
 						width: `${ viewport }px`,
 						height: `${ viewportHeight }px`,
 					} : {} }
 				>
 					<div
-						style={ ! activePatternId ? {
+						style={ ! isActive ? {
 							height: height + 'px',
 							width: `${ ( ( iframe / viewport ) * 100 ) }%`,
 							transformOrigin: '0 0',
@@ -245,24 +248,25 @@ export default function Pattern( props ) {
 
 									// Reset our height when we click anything in our preview.
 									// This accounts for height changes from accordions etc...
-									if ( activePatternId ) {
+									if ( isActive ) {
 										setHeight( iframeDoc.body.scrollHeight );
 									}
 								} );
 							} }
 							title={ label }
-							src={ isVisible ? generateBlocksInfo.patternPreviewUrl : '' }
+							src={ generateBlocksInfo.patternPreviewUrl }
 							ref={ iframeRef }
 							style={ {
 								height: height + 'px',
 								border: '0',
-								pointerEvents: ! activePatternId ? 'none' : '',
-								width: activePatternId ? previewIframeWidth : `${ iframe }px`,
+								pointerEvents: ! isActive ? 'none' : '',
+								width: isActive ? previewIframeWidth : `${ iframe }px`,
 								opacity: ! isLoaded ? 0 : 1,
-								display: activePatternId && '100%' !== previewIframeWidth ? 'block' : '',
-								margin: activePatternId && '100%' !== previewIframeWidth ? '0 auto' : '',
+								display: isVisible || ( isActive && '100%' !== previewIframeWidth ) ? 'block' : '',
+								margin: isActive && '100%' !== previewIframeWidth ? '0 auto' : '',
 							} }
 							tabIndex="-1"
+							loading="lazy"
 						/>
 					</div>
 				</div>

--- a/src/blocks/pattern-library/editor.scss
+++ b/src/blocks/pattern-library/editor.scss
@@ -85,7 +85,7 @@
 		background: #f0f0f0;
 		display: grid;
 		gap: 32px;
-		grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+		grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
 		margin-top: 0;
 		padding: 30px;
 


### PR DESCRIPTION
Fixes #1153

**Changes**
- Updated iframe attributes to help ensure smoother loading
- Eliminated extra fetch when setting library categories. All patterns for the library are loaded up front and then they are filtered client side. 
- Updated items_per_page to 15 to match new max row count
- Memoized category list to prevent extra re-rendering
- Added client side filtering logic and a local search cache. This will help the search feel snappier as it gets used (while the modal is open). 
- Various tweaks and minor style bugfixes

**Notes**
- I think that we should look towards a list virtualization solution. This would be a larger project of its own but it would allow the pattern library to handle a larger amount of patterns even better than it does now. 
- At 187 patterns, the performance is definitely not poor, but I think it could be better with optimizations such as list virtualization (as noted above). 
- Many pro patterns have large images (> 100kb) which should be optimized (noted in discord)
- I think we should consider moving toward using React query to clean up the useEffect soup in some of this (and other) code. I didn't think that made sense to try here as the life would've exceeded the value with our team's priorities. 