### PR TITLE
Tweak: Add `useStyleIndicator` hook

### DIFF
--- a/src/extend/inspector-control/controls/layout/index.js
+++ b/src/extend/inspector-control/controls/layout/index.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useContext, useRef, useState, useMemo, useEffect } from '@wordpress/element';
+import { useContext, useRef } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -20,15 +20,14 @@ import { positionOptions, overflowOptions } from './options';
 import FlexControl from '../../../../components/flex-control';
 import getDeviceType from '../../../../utils/get-device-type';
 import ThemeWidth from './components/ThemeWidth';
+import { useStyleIndicator } from '../../../../hooks/useStyleIndicator';
+import { getContentAttribute } from '../../../../utils/get-content-attribute';
 
 export default function Layout( { attributes, setAttributes, computedStyles } ) {
 	const device = getDeviceType();
-	const { supports: { layout, flexChildPanel } } = useContext( ControlsContext );
-	const panelRef = useRef( null );
-	const prevContentLength = useRef( 0 );
-	const currentContentLength = attributes.content ? attributes.content.length : 0;
-	const contentWasUpdated = prevContentLength.current !== currentContentLength;
-	const [ controlGlobalStyle, setControlGlobalStyle ] = useState( {
+	const { blockName, supports: { layout, flexChildPanel } } = useContext( ControlsContext );
+	const contentValue = getContentAttribute( attributes, blockName );
+	const panelControls = {
 		alignItems: false,
 		columnGap: false,
 		display: false,
@@ -40,20 +39,14 @@ export default function Layout( { attributes, setAttributes, computedStyles } ) 
 		position: false,
 		rowGap: false,
 		zIndex: false,
-	} );
-	const styleSources = applyFilters(
-		'generateblocks.editor.panel.computedStyleSources',
-		{},
-		computedStyles,
-		Object.keys( controlGlobalStyle ),
-	);
-	const hasGlobalStyle = useMemo( () => {
-		return Object.values( controlGlobalStyle ).some( ( control ) => control === true );
-	}, [ controlGlobalStyle ] );
-
-	useEffect( () => {
-		prevContentLength.current = currentContentLength;
-	}, [ attributes.content ] );
+	};
+	const [
+		setControlGlobalStyle,
+		styleSources,
+		hasGlobalStyle,
+		contentWasUpdated,
+	] = useStyleIndicator( computedStyles, panelControls, contentValue );
+	const panelRef = useRef( null );
 
 	const componentProps = {
 		attributes,

--- a/src/hooks/useStyleIndicator.js
+++ b/src/hooks/useStyleIndicator.js
@@ -1,0 +1,26 @@
+import { useState, useMemo, useRef, useEffect } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+
+export function useStyleIndicator( computedStyles, panelControls, content = '' ) {
+	const [ controlGlobalStyle, setControlGlobalStyle ] = useState( panelControls );
+
+	const styleSources = applyFilters(
+		'generateblocks.editor.panel.computedStyleSources',
+		{},
+		computedStyles,
+		Object.keys( controlGlobalStyle ),
+	);
+	const hasGlobalStyle = useMemo( () => {
+		return Object.values( controlGlobalStyle ).some( ( control ) => control === true );
+	}, [ controlGlobalStyle ] );
+
+	const prevContentLength = useRef( 0 );
+	const currentContentLength = content ? content.length : 0;
+	const contentWasUpdated = prevContentLength.current !== currentContentLength;
+
+	useEffect( () => {
+		prevContentLength.current = currentContentLength;
+	}, [ content ] );
+
+	return [ setControlGlobalStyle, styleSources, hasGlobalStyle, contentWasUpdated ];
+}

--- a/src/utils/get-content-attribute/index.js
+++ b/src/utils/get-content-attribute/index.js
@@ -1,0 +1,13 @@
+export function getContentAttribute( attributes, blockName ) {
+	let contentValue = '';
+
+	if ( 'generateblocks/button' === blockName ) {
+		contentValue = attributes.text;
+	}
+
+	if ( 'generateblocks/headline' === blockName ) {
+		contentValue = attributes.content;
+	}
+
+	return contentValue;
+}


### PR DESCRIPTION
@iansvo Was looking at what it would take to extend this to the other panels and saw an opportunity to reduce duplication.

Should allow us to keep this part of the code in one place in case we need to bug fix/improve.