### PR TITLE
Fix: Panel IDs

### DIFF
--- a/src/components/panel-area/index.js
+++ b/src/components/panel-area/index.js
@@ -36,10 +36,6 @@ const PanelArea = forwardRef( function PanelArea( props, ref ) {
 		return null;
 	}
 
-	function capitalizeFirstLetter( string ) {
-		return string.charAt( 0 ).toUpperCase() + string.slice( 1 );
-	}
-
 	return (
 		<ApplyFilters
 			name="generateblocks.editor.panel"
@@ -49,7 +45,7 @@ const PanelArea = forwardRef( function PanelArea( props, ref ) {
 			{ ...props }
 		>
 			<ApplyFilters
-				name={ `generateblocks.editor.panel.${ blockName }${ capitalizeFirstLetter( id ) }` }
+				name={ 'generateblocks.panel.' + id }
 				props={ props }
 				state={ state }
 			>

--- a/src/extend/inspector-control/controls/background-panel/index.js
+++ b/src/extend/inspector-control/controls/background-panel/index.js
@@ -30,7 +30,7 @@ export default function BackgroundPanel( { attributes, setAttributes } ) {
 			initialOpen={ false }
 			icon={ getIcon( 'gradients' ) }
 			className={ 'gblocks-panel-label' }
-			id="background"
+			id={ `${ id }Background` }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 		>

--- a/src/extend/inspector-control/controls/borders/index.js
+++ b/src/extend/inspector-control/controls/borders/index.js
@@ -19,7 +19,7 @@ import { isEqual, isEmpty } from 'lodash';
 
 export default function Borders( { attributes, setAttributes } ) {
 	const device = getDeviceType();
-	const { supports: { borders: bordersPanel } } = useContext( ControlsContext );
+	const { id, supports: { borders: bordersPanel } } = useContext( ControlsContext );
 	const [ deviceAttributes, setDeviceAttributes ] = useDeviceAttributes( attributes, setAttributes );
 	const borderRadiusAttributes = [ 'borderTopLeftRadius', 'borderTopRightRadius', 'borderBottomLeftRadius', 'borderBottomRightRadius' ];
 	const borderAreas = [ 'borderTop', 'borderRight', 'borderBottom', 'borderLeft' ];
@@ -90,7 +90,7 @@ export default function Borders( { attributes, setAttributes } ) {
 			initialOpen={ false }
 			icon={ getIcon( 'borders' ) }
 			className="gblocks-panel-label"
-			id="borders"
+			id={ `${ id }Borders` }
 		>
 			{ ( bordersPanel.borderTop || bordersPanel.borderRight || bordersPanel.borderBottom || bordersPanel.borderLeft ) &&
 				<BaseControl

--- a/src/extend/inspector-control/controls/colors/index.js
+++ b/src/extend/inspector-control/controls/colors/index.js
@@ -6,7 +6,7 @@ import { useContext } from '@wordpress/element';
 import ControlsContext from '../../../../block-context';
 
 export default function Colors( { attributes, setAttributes } ) {
-	const { blockName, supports: { colors } } = useContext( ControlsContext );
+	const { id, blockName, supports: { colors } } = useContext( ControlsContext );
 
 	return (
 		<PanelArea
@@ -14,7 +14,7 @@ export default function Colors( { attributes, setAttributes } ) {
 			initialOpen={ false }
 			icon={ getIcon( 'colors' ) }
 			className="gblocks-panel-label"
-			id="colors"
+			id={ `${ id }Colors` }
 		>
 			<ColorGroup
 				attributes={ attributes }

--- a/src/extend/inspector-control/controls/flex-child-panel/index.js
+++ b/src/extend/inspector-control/controls/flex-child-panel/index.js
@@ -11,7 +11,7 @@ import getDeviceType from '../../../../utils/get-device-type';
 
 export default function FlexChild( { attributes, setAttributes } ) {
 	const device = getDeviceType();
-	const { supports: { flexChildPanel } } = useContext( ControlsContext );
+	const { id, supports: { flexChildPanel } } = useContext( ControlsContext );
 
 	const componentProps = {
 		attributes,
@@ -28,7 +28,7 @@ export default function FlexChild( { attributes, setAttributes } ) {
 			title={ __( 'Flex Child', 'generateblocks' ) }
 			initialOpen={ false }
 			className="gblocks-panel-label"
-			id="flexChild"
+			id={ `${ id }FlexChild` }
 		>
 			{ flexChildPanel.flex && ( ! useInnerContainer || ( useInnerContainer && isGrid ) ) &&
 				<FlexControls

--- a/src/extend/inspector-control/controls/icon/index.js
+++ b/src/extend/inspector-control/controls/icon/index.js
@@ -29,7 +29,7 @@ export default function IconControls( { attributes, setAttributes } ) {
 			initialOpen={ false }
 			icon={ getIcon( 'icons' ) }
 			className="gblocks-panel-label"
-			id="icon"
+			id={ `${ id }Icon` }
 		>
 			{ 'Desktop' === device &&
 				<>

--- a/src/extend/inspector-control/controls/layout/index.js
+++ b/src/extend/inspector-control/controls/layout/index.js
@@ -25,7 +25,7 @@ import { getContentAttribute } from '../../../../utils/get-content-attribute';
 
 export default function Layout( { attributes, setAttributes, computedStyles } ) {
 	const device = getDeviceType();
-	const { blockName, supports: { layout, flexChildPanel } } = useContext( ControlsContext );
+	const { id, blockName, supports: { layout, flexChildPanel } } = useContext( ControlsContext );
 	const contentValue = getContentAttribute( attributes, blockName );
 	const [ deviceAttributes ] = useDeviceAttributes( attributes, setAttributes );
 	const panelControls = {
@@ -152,7 +152,7 @@ export default function Layout( { attributes, setAttributes, computedStyles } ) 
 			initialOpen={ false }
 			icon={ getIcon( 'layout' ) }
 			className="gblocks-panel-label"
-			id="layout"
+			id={ `${ id }Layout` }
 			ref={ panelRef }
 			hasGlobalStyle={ hasGlobalStyle }
 		>

--- a/src/extend/inspector-control/controls/settings-panel/index.js
+++ b/src/extend/inspector-control/controls/settings-panel/index.js
@@ -4,7 +4,7 @@ import { useContext } from '@wordpress/element';
 import ControlsContext from '../../../../block-context';
 
 export default function SettingsPanel( { children } ) {
-	const { supports: { settingsPanel } } = useContext( ControlsContext );
+	const { id, supports: { settingsPanel } } = useContext( ControlsContext );
 
 	return (
 		<PanelArea
@@ -12,7 +12,7 @@ export default function SettingsPanel( { children } ) {
 			initialOpen={ false }
 			icon={ getIcon( settingsPanel.icon ) }
 			className="gblocks-panel-label"
-			id="settings"
+			id={ `${ id }Settings` }
 		>
 			{ children }
 		</PanelArea>

--- a/src/extend/inspector-control/controls/shapes-panel/index.js
+++ b/src/extend/inspector-control/controls/shapes-panel/index.js
@@ -1,7 +1,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import PanelArea from '../../../../components/panel-area';
 import getIcon from '../../../../utils/get-icon';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useContext } from '@wordpress/element';
+import ControlsContext from '../../../../block-context';
 import classnames from 'classnames';
 import sanitizeSVG from '../../../../utils/sanitize-svg';
 import {
@@ -19,6 +20,7 @@ import UnitPicker from '../../../../components/unit-picker';
 import getDeviceType from '../../../../utils/get-device-type';
 
 export default function ShapesPanel( { attributes, setAttributes } ) {
+	const { id } = useContext( ControlsContext );
 	const deviceType = getDeviceType();
 	const {
 		backgroundColor,
@@ -76,7 +78,7 @@ export default function ShapesPanel( { attributes, setAttributes } ) {
 			initialOpen={ false }
 			icon={ getIcon( 'shapes' ) }
 			className={ 'gblocks-panel-label' }
-			id="shapes"
+			id={ `${ id }Shapes` }
 		>
 			<BaseControl className="gb-icon-chooser gb-shape-chooser">
 				{

--- a/src/extend/inspector-control/controls/sizing/index.js
+++ b/src/extend/inspector-control/controls/sizing/index.js
@@ -20,7 +20,7 @@ import { useStyleIndicator, useDeviceAttributes } from '../../../../hooks';
 import { getContentAttribute } from '../../../../utils/get-content-attribute';
 
 export default function Sizing( { attributes, setAttributes, computedStyles } ) {
-	const { blockName, supports: { sizingPanel } } = useContext( ControlsContext );
+	const { id, blockName, supports: { sizingPanel } } = useContext( ControlsContext );
 	const device = getDeviceType();
 	const panelRef = useRef( null );
 	const contentValue = getContentAttribute( attributes, blockName );
@@ -109,7 +109,7 @@ export default function Sizing( { attributes, setAttributes, computedStyles } ) 
 			initialOpen={ false }
 			icon={ getIcon( 'sizing' ) }
 			className="gblocks-panel-label"
-			id="sizing"
+			id={ `${ id }Sizing` }
 			ref={ panelRef }
 			hasGlobalStyle={ hasGlobalStyle }
 		>

--- a/src/extend/inspector-control/controls/spacing/index.js
+++ b/src/extend/inspector-control/controls/spacing/index.js
@@ -15,7 +15,7 @@ import { getContentAttribute } from '../../../../utils/get-content-attribute';
 
 export default function Spacing( { attributes, setAttributes, computedStyles } ) {
 	const device = getDeviceType();
-	const { blockName, supports: { spacing } } = useContext( ControlsContext );
+	const { id, blockName, supports: { spacing } } = useContext( ControlsContext );
 	const contentValue = getContentAttribute( attributes, blockName );
 	const [ deviceAttributes, setDeviceAttributes ] = useDeviceAttributes( attributes, setAttributes );
 	const panelRef = useRef( null );
@@ -124,7 +124,7 @@ export default function Spacing( { attributes, setAttributes, computedStyles } )
 			initialOpen={ false }
 			icon={ getIcon( 'spacing' ) }
 			className="gblocks-panel-label"
-			id="spacing"
+			id={ `${ id }Spacing` }
 			ref={ panelRef }
 			hasGlobalStyle={ hasGlobalStyle }
 		>

--- a/src/extend/inspector-control/controls/typography/index.js
+++ b/src/extend/inspector-control/controls/typography/index.js
@@ -18,7 +18,7 @@ import './editor.scss';
 
 export default function Typography( { attributes, setAttributes, computedStyles } ) {
 	const device = getDeviceType();
-	const { supports: { typography: typographySupports } } = useContext( ControlsContext );
+	const { id, supports: { typography: typographySupports } } = useContext( ControlsContext );
 	const { typography } = attributes;
 	const isDesktop = 'Desktop' === device;
 
@@ -28,7 +28,7 @@ export default function Typography( { attributes, setAttributes, computedStyles 
 			initialOpen={ false }
 			icon={ getIcon( 'typography' ) }
 			className="gblocks-panel-label"
-			id="typography"
+			id={ `${ id }Typography` }
 		>
 			{ typographySupports.alignment &&
 				<Alignment


### PR DESCRIPTION
While testing #1156, I noticed that the "Advanced Backgrounds" feature in GB Pro no longer appear in the "Container" block.

This is due to the re-naming of the panel area filters.

@iansvo Do you see any issues with the following changes? This should maintain backward compatibility, and it doesn't seem to break the indicators at all.

If we need a more generic name for the panels, maybe we should introduce a new `name` prop with the generic name?