### PR TITLE
Fix: Button margin in the editor

### DIFF
--- a/src/blocks/button/editor.scss
+++ b/src/blocks/button/editor.scss
@@ -1,21 +1,17 @@
 /**
  * Editor Styles
  */
-.editor-styles-wrapper {
-	.gb-button {
-		line-height: unset;
-		text-decoration: none !important;
-		box-sizing: border-box;
+.gb-button {
+	line-height: unset;
+	text-decoration: none;
+	box-sizing: border-box;
+	margin: 0;
+	border: none;
 
-		.editor-rich-text__tinymce {
-			line-height: 1em;
-		}
-
-		&.button {
-			font-size: inherit;
-			min-height: auto;
-			border-radius: unset;
-		}
+	&.button {
+		font-size: inherit;
+		min-height: auto;
+		border-radius: unset;
 	}
 }
 


### PR DESCRIPTION
The Button block now has core-added margin in the editor due to my changes here: https://github.com/tomusborne/generateblocks/pull/1152

This PR fixes that issue, but removes the `.editor-styles-wrapper` class which should fix the original issue.