### PR TITLE
Fix: Pattern previews not loading

### DIFF
--- a/src/blocks/pattern-library/components/pattern.js
+++ b/src/blocks/pattern-library/components/pattern.js
@@ -254,7 +254,7 @@ export default function Pattern( { pattern, isLoading, isActive = false } ) {
 								} );
 							} }
 							title={ label }
-							src={ isVisible ? generateBlocksInfo.patternPreviewUrl : '' }
+							src={ generateBlocksInfo.patternPreviewUrl }
 							ref={ iframeRef }
 							style={ {
 								height: height + 'px',


### PR DESCRIPTION
The conditional `src` loading was causing previews not to load once we switched to loading core patterns.