### PR TITLE
Feature: Import pattern styles as needed

### DIFF
--- a/src/pattern-library/components/insert-pattern.js
+++ b/src/pattern-library/components/insert-pattern.js
@@ -15,6 +15,6 @@ export function InsertPattern( { label, onClick, patterns, globalStyleData, clas
 				{ label }
 			</Button>
 		),
-		{ label, onClick, patterns, globalStyleData }
+		{ label, onClick, patterns, globalStyleData, className }
 	);
 }

--- a/src/pattern-library/components/insert-pattern.js
+++ b/src/pattern-library/components/insert-pattern.js
@@ -1,0 +1,20 @@
+import { Button } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
+
+export function InsertPattern( { label, onClick, patterns, globalStyleData, className } ) {
+	return applyFilters(
+		'generateblocks.patterns.insertPatternButton',
+		(
+			<Button
+				className={ className }
+				variant="primary"
+				icon={ plus }
+				onClick={ onClick }
+			>
+				{ label }
+			</Button>
+		),
+		{ label, onClick, patterns, globalStyleData }
+	);
+}

--- a/src/pattern-library/components/library-cache.js
+++ b/src/pattern-library/components/library-cache.js
@@ -7,10 +7,9 @@ import { Button, Icon, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { backup } from '@wordpress/icons';
 
-export default function LibraryCache() {
+export default function LibraryCache( { setCacheIsClearing, cacheIsClearing } ) {
 	const { activeLibrary, setLibraryCategories, setLibraryPatterns, isLocal } = useLibrary();
 	const [ cacheData, setCacheData ] = useState( false );
-	const [ cacheIsClearing, setCacheIsClearing ] = useState( false );
 
 	async function checkCacheData() {
 		if ( isLocal ) {

--- a/src/pattern-library/components/pattern-details.js
+++ b/src/pattern-library/components/pattern-details.js
@@ -1,12 +1,22 @@
 import { Button } from '@wordpress/components';
-import { plus, seen } from '@wordpress/icons';
+import { seen } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { parse } from '@wordpress/blocks';
 import { useLibrary } from './library-provider';
+import { InsertPattern } from './insert-pattern';
 
-export function PatternDetails( { pattern, patternRef = null, children, showPreview = true, bulkInsertEnabled, showTitle = true } ) {
+export function PatternDetails( {
+	pattern,
+	patternRef = null,
+	children,
+	showPreview = true,
+	bulkInsertEnabled,
+	showTitle = true,
+	globalStyleData,
+	setIsOpen,
+} ) {
 	const {
 		setActivePatternId,
 		setScrollPosition,
@@ -22,11 +32,11 @@ export function PatternDetails( { pattern, patternRef = null, children, showPrev
 
 			<div className="gb-pattern-details__actions">
 				{ ! bulkInsertEnabled && (
-					<Button
-						variant="primary"
-						icon={ plus }
-						onClick={ ( e ) => {
+					<InsertPattern
+						label={ __( 'Insert', 'generateblocks' ) }
+						onClick={ async( e ) => {
 							e.stopPropagation();
+
 							const blockInsertionPoint = getBlockInsertionPoint();
 
 							insertBlocks(
@@ -34,10 +44,12 @@ export function PatternDetails( { pattern, patternRef = null, children, showPrev
 								blockInsertionPoint?.index ?? 0,
 								blockInsertionPoint.rootClientId ?? ''
 							);
+
+							setIsOpen( false );
 						} }
-					>
-						{ __( 'Insert', 'generateblocks' ) }
-					</Button>
+						patterns={ [ pattern ] }
+						globalStyleData={ globalStyleData }
+					/>
 				) }
 
 				{ ( showPreview && ! bulkInsertEnabled ) && (

--- a/src/pattern-library/components/pattern-list.js
+++ b/src/pattern-library/components/pattern-list.js
@@ -6,7 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { PatternDetails } from './pattern-details';
 import classnames from 'classnames';
 
-export default function PatternList( { bulkInsertEnabled = false, patterns = [] } ) {
+export default function PatternList( {
+	bulkInsertEnabled = false,
+	patterns = [],
+	setIsOpen,
+	globalStyleCSS,
+	globalStyleData,
+} ) {
 	const ref = useRef();
 	const loadMoreRef = useRef();
 	const {
@@ -115,6 +121,7 @@ export default function PatternList( { bulkInsertEnabled = false, patterns = [] 
 					isLoading={ loading }
 					isActive={ true }
 					pattern={ activePattern }
+					globalStyleCSS={ globalStyleCSS }
 				/>
 			}
 
@@ -167,12 +174,15 @@ export default function PatternList( { bulkInsertEnabled = false, patterns = [] 
 							<Pattern
 								isLoading={ loading }
 								pattern={ pattern }
+								globalStyleCSS={ globalStyleCSS }
 							/>
 
 							<PatternDetailsMemo
 								pattern={ pattern }
 								patternRef={ ref }
 								bulkInsertEnabled={ bulkInsertEnabled }
+								globalStyleData={ globalStyleData }
+								setIsOpen={ setIsOpen }
 							/>
 						</li>
 					);

--- a/src/pattern-library/components/pattern.js
+++ b/src/pattern-library/components/pattern.js
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState, useLayoutEffect } from '@wordpress/element
 import imagesLoaded from 'imagesloaded';
 import { useLibrary } from './library-provider';
 
-export default function Pattern( { pattern, isLoading, isActive = false } ) {
+export default function Pattern( { pattern, isLoading, isActive = false, globalStyleCSS } ) {
 	const {
 		id,
 		preview,
@@ -108,6 +108,12 @@ export default function Pattern( { pattern, isLoading, isActive = false } ) {
 		document.body.innerHTML = preview;
 		document.head.innerHTML += '<style id="block-active"></style>';
 		document.head.innerHTML += '<style id="pattern-styles"></style>';
+
+		const globalStyleElement = document.createElement( 'style' );
+		globalStyleElement.innerHTML = globalStyleCSS;
+
+		const firstStyleElement = document.querySelector( 'head style' );
+		document.head.insertBefore( globalStyleElement, firstStyleElement );
 
 		imagesLoaded( document.body, () => {
 			setHeight( document.body.scrollHeight );

--- a/src/pattern-library/components/required-components.js
+++ b/src/pattern-library/components/required-components.js
@@ -1,5 +1,0 @@
-import { applyFilters } from '@wordpress/hooks';
-
-export default function RequiredComponents( { activeLibrary, requiredClasses, setRequiredClasses, children } ) {
-	return applyFilters( 'generateblocks.pattern-library.collection.content', children, { activeLibrary, requiredClasses, setRequiredClasses } );
-}

--- a/src/pattern-library/components/selected-patterns.js
+++ b/src/pattern-library/components/selected-patterns.js
@@ -7,8 +7,9 @@ import { lineSolid, seen } from '@wordpress/icons';
 import { useRef } from '@wordpress/element';
 import { SortableList } from '../../components/dnd';
 import { useLibrary } from './library-provider';
+import { InsertPattern } from './insert-pattern';
 
-export function SelectedPatterns() {
+export function SelectedPatterns( { setIsOpen, globalStyleData } ) {
 	const { insertBlocks } = useDispatch( blockEditorStore );
 	const {
 		selectedPatterns = [],
@@ -80,9 +81,11 @@ export function SelectedPatterns() {
 				itemComponent={ SelectedPattern }
 				dragHandle={ true }
 			/>
-			<Button
+			<InsertPattern
 				className="gb-selected-patterns__insert"
-				variant="primary"
+				label={ __( 'Insert All', 'generateblocks' ) }
+				patterns={ selectedPatterns }
+				globalStyleData={ globalStyleData }
 				onClick={ () => {
 					const blockReplacements = selectedPatterns.reduce( ( prev, current ) => prev + current.pattern, '' );
 					const blockInsertionPoint = getBlockInsertionPoint();
@@ -92,10 +95,10 @@ export function SelectedPatterns() {
 						blockInsertionPoint?.index ?? 0,
 						blockInsertionPoint.rootClientId ?? ''
 					);
+
+					setIsOpen( false );
 				} }
-			>
-				{ __( 'Insert All', 'generateblocks' ) }
-			</Button>
+			/>
 		</aside>
 	);
 }


### PR DESCRIPTION
This PR sets the table to allow Global Style imports on an individual basis.

This means if a pattern uses a Global Style, the library will try to import that style as you insert it onto your page.

This is better than the current method, as you only need to import the styles you're going to use. Currently, we require the import of ALL global styles required in a library before you can even start browsing.