### PR TITLE
Feature: Add pattern library to plugin sidebar

### DIFF
--- a/src/pattern-library/components/library-layout.js
+++ b/src/pattern-library/components/library-layout.js
@@ -16,7 +16,7 @@ import { doAction } from '@wordpress/hooks';
 
 const searchCache = {};
 
-export default function LibraryLayout( { setIsOpen } ) {
+export default function LibraryLayout( { closeModal } ) {
 	const {
 		activePatternId,
 		setActivePatternId,
@@ -127,7 +127,7 @@ export default function LibraryLayout( { setIsOpen } ) {
 									icon={ close }
 									label={ __( 'Close Pattern Library', 'generateblocks' ) }
 									showTooltip={ true }
-									onClick={ () => setIsOpen( false ) }
+									onClick={ closeModal }
 								/>
 							</>
 						) : (
@@ -167,7 +167,7 @@ export default function LibraryLayout( { setIsOpen } ) {
 					} } />
 					<MemoizedCategoryList />
 					<SelectedPatterns
-						setIsOpen={ setIsOpen }
+						closeModal={ closeModal }
 						globalStyleCSS={ globalStyleCSS }
 						globalStyleData={ globalStyleData }
 					/>
@@ -182,7 +182,7 @@ export default function LibraryLayout( { setIsOpen } ) {
 				<PatternList
 					patterns={ filteredPatterns }
 					bulkInsertEnabled={ bulkInsertEnabled }
-					setIsOpen={ setIsOpen }
+					closeModal={ closeModal }
 					globalStyleCSS={ globalStyleCSS }
 					globalStyleData={ globalStyleData }
 				/>

--- a/src/pattern-library/components/pattern-details.js
+++ b/src/pattern-library/components/pattern-details.js
@@ -15,7 +15,7 @@ export function PatternDetails( {
 	bulkInsertEnabled,
 	showTitle = true,
 	globalStyleData,
-	setIsOpen,
+	closeModal,
 } ) {
 	const {
 		setActivePatternId,
@@ -45,7 +45,7 @@ export function PatternDetails( {
 								blockInsertionPoint.rootClientId ?? ''
 							);
 
-							setIsOpen( false );
+							closeModal();
 						} }
 						patterns={ [ pattern ] }
 						globalStyleData={ globalStyleData }

--- a/src/pattern-library/components/pattern-list.js
+++ b/src/pattern-library/components/pattern-list.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 export default function PatternList( {
 	bulkInsertEnabled = false,
 	patterns = [],
-	setIsOpen,
+	closeModal,
 	globalStyleCSS,
 	globalStyleData,
 } ) {
@@ -182,7 +182,7 @@ export default function PatternList( {
 								patternRef={ ref }
 								bulkInsertEnabled={ bulkInsertEnabled }
 								globalStyleData={ globalStyleData }
-								setIsOpen={ setIsOpen }
+								closeModal={ closeModal }
 							/>
 						</li>
 					);

--- a/src/pattern-library/components/selected-patterns.js
+++ b/src/pattern-library/components/selected-patterns.js
@@ -9,7 +9,7 @@ import { SortableList } from '../../components/dnd';
 import { useLibrary } from './library-provider';
 import { InsertPattern } from './insert-pattern';
 
-export function SelectedPatterns( { setIsOpen, globalStyleData } ) {
+export function SelectedPatterns( { closeModal, globalStyleData } ) {
 	const { insertBlocks } = useDispatch( blockEditorStore );
 	const {
 		selectedPatterns = [],
@@ -96,7 +96,7 @@ export function SelectedPatterns( { setIsOpen, globalStyleData } ) {
 						blockInsertionPoint.rootClientId ?? ''
 					);
 
-					setIsOpen( false );
+					closeModal();
 				} }
 			/>
 		</aside>

--- a/src/pattern-library/index.js
+++ b/src/pattern-library/index.js
@@ -1,50 +1,79 @@
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, PanelBody } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { createPortal, useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { LibraryProvider } from './components/library-provider';
 import LibraryLayout from './components/library-layout';
 import { __ } from '@wordpress/i18n';
+import { PluginSidebar, store as editPostStore } from '@wordpress/edit-post';
 import './editor.scss';
 import getIcon from '../utils/get-icon';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 function PatternLibrary() {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const toolbar = document.querySelector( '.interface-pinned-items' );
+	const [ currentPanel, setCurrentPanel ] = useState( '' );
+	const button = document.querySelector( 'button[aria-controls="gblocks-pattern-library-sidebar:gblocks-pattern-library"]' );
+	const { getActiveGeneralSidebarName } = useSelect( ( select ) => select( editPostStore ), [] );
+	const { openGeneralSidebar } = useDispatch( editPostStore );
+
+	function triggerModal() {
+		setIsOpen( true );
+
+		const activePanel = getActiveGeneralSidebarName();
+		setCurrentPanel( activePanel ?? '' );
+	}
+
+	function closeModal() {
+		setIsOpen( false );
+		openGeneralSidebar( currentPanel ?? '' );
+	}
+
+	useEffect( () => {
+		if ( ! button ) {
+			return;
+		}
+
+		button.addEventListener( 'click', triggerModal );
+
+		return () => {
+			button.removeEventListener( 'click', triggerModal );
+		};
+	}, [ button ] );
 
 	return (
-		<>
-			{ !! toolbar && createPortal(
+		<PluginSidebar
+			name="gblocks-pattern-library"
+			title={ __( 'Pattern Library', 'generateblocks-pro' ) }
+			icon={ getIcon( 'pattern-library' ) }
+		>
+			<PanelBody>
 				<Button
 					className="gblocks-pattern-library-button"
+					variant="secondary"
 					onClick={ () => setIsOpen( true ) }
-					icon={ getIcon( 'generateblocks' ) }
 					label={ __( 'Open Pattern Library', 'generateblocks' ) }
 					showTooltip
 					isPressed={ isOpen }
 				>
-					{ __( 'Patterns', 'generateblocks' ) }
-				</Button>,
-				toolbar
-			) }
+					{ __( 'Launch Pattern Library', 'generateblocks' ) }
+				</Button>
+			</PanelBody>
 
 			{ !! isOpen && (
 				<Modal
 					className="gblocks-pattern-library-modal"
 					isFullScreen
-					onRequestClose={ () => setIsOpen( false ) }
+					onRequestClose={ closeModal }
 				>
 					<LibraryProvider>
-						<LibraryLayout setIsOpen={ setIsOpen } />
+						<LibraryLayout closeModal={ closeModal } />
 					</LibraryProvider>
 				</Modal>
 			) }
-		</>
+		</PluginSidebar>
 	);
 }
 
-registerPlugin(
-	'gb-pattern-library',
-	{
-		render: PatternLibrary,
-	}
-);
+registerPlugin( 'gblocks-pattern-library-sidebar', {
+	render: PatternLibrary,
+} );


### PR DESCRIPTION
Alternative to #1175 

https://github.com/tomusborne/generateblocks/assets/20714883/d37d2a4f-3f03-471e-8cc5-c64a875c25be

Did this as a quick alternative to using a portal to insert the Pattern Library block.

This has the advantage of using core features to add the toggle (no portal needed).

However, it has the disadvantage of not being as obvious/visible.

Nice thing here is that if markup changes, the button will remain there and it will open a regular plugin sidebar with a button to open the library.