### PR TITLE
Fix: Inserted pattern styles

### DIFF
--- a/src/pattern-library/components/pattern-details.js
+++ b/src/pattern-library/components/pattern-details.js
@@ -41,13 +41,6 @@ export function PatternDetails( {
 
 							const blockInsertionPoint = getBlockInsertionPoint();
 							const renderedPattern = parse( pattern.pattern );
-
-							await insertBlocks(
-								renderedPattern,
-								blockInsertionPoint?.index ?? 0,
-								blockInsertionPoint.rootClientId ?? ''
-							);
-
 							const updatedBlocks = updateUniqueIds( renderedPattern );
 
 							updatedBlocks.forEach( ( block ) => {
@@ -55,6 +48,12 @@ export function PatternDetails( {
 									updateBlockAttributes( block.clientId, block.attributes );
 								}
 							} );
+
+							await insertBlocks(
+								updatedBlocks,
+								blockInsertionPoint?.index ?? 0,
+								blockInsertionPoint.rootClientId ?? ''
+							);
 
 							closeModal();
 						} }

--- a/src/pattern-library/components/selected-patterns.js
+++ b/src/pattern-library/components/selected-patterns.js
@@ -95,12 +95,6 @@ export function SelectedPatterns( { closeModal, globalStyleData, setBulkInsertEn
 						const blockInsertionPoint = getBlockInsertionPoint();
 						const renderedPatterns = parse( blockReplacements );
 
-						await insertBlocks(
-							renderedPatterns,
-							blockInsertionPoint?.index ?? 0,
-							blockInsertionPoint.rootClientId ?? ''
-						);
-
 						const updatedBlocks = updateUniqueIds( renderedPatterns );
 
 						updatedBlocks.forEach( ( block ) => {
@@ -108,6 +102,12 @@ export function SelectedPatterns( { closeModal, globalStyleData, setBulkInsertEn
 								updateBlockAttributes( block.clientId, block.attributes );
 							}
 						} );
+
+						await insertBlocks(
+							updatedBlocks,
+							blockInsertionPoint?.index ?? 0,
+							blockInsertionPoint.rootClientId ?? ''
+						);
 
 						closeModal();
 					} }


### PR DESCRIPTION
I noticed a bug introduced in #1180 where the `uniqueId` would change after insertion, but the local block styles wouldn't update, as they're memoized.

This PR updates the `uniqueId` attributes before the block is inserted, so things can remain memoized. 