### PR TITLE
Security: Add user capability check to Query Loop post status

### DIFF
--- a/includes/class-query-loop.php
+++ b/includes/class-query-loop.php
@@ -129,6 +129,15 @@ class GenerateBlocks_Query_Loop {
 			$query_args['posts_per_page'] = $per_page;
 		}
 
+		if (
+			isset( $query_args['post_status'] ) &&
+			'publish' !== $query_args['post_status'] &&
+			! current_user_can( 'read_private_posts' )
+		) {
+			// If the user can't read private posts, we'll force the post status to be public.
+			$query_args['post_status'] = 'publish';
+		}
+
 		return $query_args;
 	}
 

--- a/src/blocks/query-loop/components/QueryLoopRenderer.js
+++ b/src/blocks/query-loop/components/QueryLoopRenderer.js
@@ -17,9 +17,20 @@ export default function QueryLoopRenderer( props ) {
 			getEntityRecords,
 			isResolving,
 			hasFinishedResolution,
+			canUser,
 		} = select( coreStore );
 
-		const queryParams = [ 'postType', query.post_type || 'post', normalizedQuery ];
+		let queryData = normalizedQuery;
+
+		// If the user can't update settings, we'll only show published posts.
+		if ( ! canUser( 'update', 'settings' ) ) {
+			queryData = {
+				...queryData,
+				status: 'publish',
+			};
+		}
+
+		const queryParams = [ 'postType', query.post_type || 'post', queryData ];
 
 		return {
 			data: getEntityRecords( ...queryParams ),


### PR DESCRIPTION
closes https://github.com/tomusborne/generateblocks-pro/issues/485

This prevents users without the proper capability from seeing posts with any status other than `publish` in the Query Loop in the editor and frontend.