### PR TITLE
Fix: Patterns inserting after selected empty paragraph

### DIFF
--- a/src/pattern-library/utils.js
+++ b/src/pattern-library/utils.js
@@ -15,3 +15,17 @@ export function updateUniqueIds( blocks ) {
 		return block;
 	} );
 }
+
+export function isEmptyContentBlock( selectedBlock ) {
+	if ( 'core/paragraph' === selectedBlock?.name ) {
+		const currentContent = selectedBlock?.attributes?.content;
+
+		if ( 'string' === typeof currentContent ) {
+			return ! currentContent.trim();
+		} else if ( 'object' === typeof currentContent ) {
+			return ! currentContent?.text.trim();
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
During testing I noticed that if I add a new paragraph (and have it selected), then open the Pattern Library and insert a pattern, it inserts the pattern after the empty paragraph.

I think it makes more sense to replace the empty paragraph with the inserted pattern.