### PR TITLE
Fix: `.gb-highlight` class background

### DIFF
--- a/includes/blocks/class-headline.php
+++ b/includes/blocks/class-headline.php
@@ -252,7 +252,6 @@ class GenerateBlocks_Block_Headline {
 			if ( $settings['highlightTextColor'] ) {
 				$css->set_selector( $selector . ' .gb-highlight' );
 				$css->add_property( 'color', $settings['highlightTextColor'] );
-				$css->add_property( 'background', 'none' );
 			}
 
 			$tablet_css->set_selector( $selector );
@@ -513,7 +512,6 @@ class GenerateBlocks_Block_Headline {
 			if ( $settings['highlightTextColor'] ) {
 				$css->set_selector( '.gb-headline-' . $id . ' .gb-highlight' );
 				$css->add_property( 'color', $settings['highlightTextColor'] );
-				$css->add_property( 'background', 'none' );
 			}
 
 			$tablet_css->set_selector( '.gb-headline-' . $id );

--- a/includes/general.php
+++ b/includes/general.php
@@ -474,6 +474,7 @@ add_filter( 'generateblocks_css_output', 'generateblocks_add_general_css' );
 function generateblocks_add_general_css( $css ) {
 	$css .= '.gb-container .wp-block-image img{vertical-align:middle;}';
 	$css .= '.gb-grid-wrapper .wp-block-image{margin-bottom:0;}';
+	$css .= '.gb-highlight{background:none;}';
 
 	return $css;
 }


### PR DESCRIPTION
This fixes a bug where the `.gb-highlight` element was getting the default browser yellow background if the user didn't set a text color in the controls.