### PR TITLE
Tweak: Add active panel ID to sidebar header

### DIFF
--- a/src/editor-sidebar/index.js
+++ b/src/editor-sidebar/index.js
@@ -7,6 +7,7 @@ import './editor.scss';
 import { Button } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
+import classnames from 'classnames';
 
 function SidebarItems( props ) {
 	const { name, children } = props;
@@ -51,7 +52,9 @@ function EditorSidebar() {
 			className="gblocks-editor-sidebar"
 			title={ __( 'GenerateBlocks', 'generateblocks-pro' ) }
 			icon={ <Icon /> }
-			headerClassName="gblocks-editor-sidebar-header"
+			headerClassName={ classnames( 'gblocks-editor-sidebar-header', {
+				[ `gblocks-editor-sidebar-header--${ activePanel }` ]: activePanel,
+			} ) }
 			header={
 				<SidebarHeader
 					activePanel={ activePanel }


### PR DESCRIPTION
This adds the sidebar panel ID to the sidebar header so it can be easily styled.