### PR TITLE
Fix: Pattern search mixing up active libraries

### DIFF
--- a/src/pattern-library/components/library-layout.js
+++ b/src/pattern-library/components/library-layout.js
@@ -62,16 +62,19 @@ export default function LibraryLayout( { closeModal } ) {
 
 	function maybeGetCachedSearchResult( value ) {
 		const category = activeCategory === '' ? 'all' : activeCategory;
+		const library = activeLibrary?.id || '';
 
-		if ( ! searchCache[ category ] ) {
-			searchCache[ category ] = {};
+		if ( ! searchCache[ library ] || ! searchCache[ library ][ category ] ) {
+			searchCache[ library ] = searchCache[ library ] || {};
+			searchCache[ library ][ category ] = searchCache[ library ][ category ] || {};
 		}
 
-		if ( ! searchCache[ category ][ value ] ) {
+		// Check if the value exists in the cache
+		if ( ! searchCache[ library ][ category ][ value ] ) {
 			return false;
 		}
 
-		return searchCache[ category ][ value ];
+		return searchCache[ library ][ category ][ value ];
 	}
 
 	const contentStyles = {};
@@ -147,6 +150,7 @@ export default function LibraryLayout( { closeModal } ) {
 						setSearch( value );
 
 						const category = activeCategory === '' ? 'all' : activeCategory;
+
 						// Check if result has been cached already
 						const cachedResult = maybeGetCachedSearchResult( value );
 
@@ -157,7 +161,11 @@ export default function LibraryLayout( { closeModal } ) {
 
 						const newPatternList = filterPatterns( value );
 
-						searchCache[ category ][ value ] = newPatternList;
+						const library = activeLibrary?.id;
+
+						if ( library ) {
+							searchCache[ library ][ category ][ value ] = newPatternList;
+						}
 
 						setFilteredPatterns( newPatternList );
 					} } />

--- a/src/pattern-library/components/pattern-search.js
+++ b/src/pattern-library/components/pattern-search.js
@@ -4,13 +4,17 @@ import { useDebounce } from '@wordpress/compose';
 import { useLibrary } from './library-provider';
 
 export default function PatternSearch( { onChange } ) {
-	const { setSearch } = useLibrary();
+	const { setSearch, activeLibrary } = useLibrary();
 	const [ searchInput, setSearchInput ] = useState( '' );
 	const setDebouncedInput = useDebounce( setSearch, 500 );
 
 	useEffect( () => {
 		setDebouncedInput( searchInput );
 	}, [ searchInput ] );
+
+	useEffect( () => {
+		setSearchInput( '' );
+	}, [ activeLibrary?.id ] );
 
 	return (
 		<SearchControl


### PR DESCRIPTION
This fixes a bug where using the search bar in the Patterns modal displays patterns from libraries other than the active one.

To replicate, switch between libraries and use the search.