### PR TITLE
Fix: Broken pattern preview in bulk select mode

### DIFF
--- a/src/pattern-library/components/library-layout.js
+++ b/src/pattern-library/components/library-layout.js
@@ -187,6 +187,7 @@ export default function LibraryLayout( { closeModal } ) {
 							closeModal={ closeModal }
 							globalStyleData={ globalStyleData }
 							setBulkInsertEnabled={ setBulkInsertEnabled }
+							filteredPatterns={ filteredPatterns }
 						/>
 					) }
 				</>

--- a/src/pattern-library/components/selected-patterns.js
+++ b/src/pattern-library/components/selected-patterns.js
@@ -10,7 +10,7 @@ import { useLibrary } from './library-provider';
 import { InsertPattern } from './insert-pattern';
 import { isEmptyContentBlock, updateUniqueIds } from '../utils';
 
-export function SelectedPatterns( { closeModal, globalStyleData, setBulkInsertEnabled } ) {
+export function SelectedPatterns( { closeModal, globalStyleData, setBulkInsertEnabled, filteredPatterns } ) {
 	const { insertBlocks, replaceBlock } = useDispatch( blockEditorStore );
 	const {
 		selectedPatterns = [],
@@ -49,6 +49,7 @@ export function SelectedPatterns( { closeModal, globalStyleData, setBulkInsertEn
 						icon={ seen }
 						label={ __( 'Preview Pattern', 'generateblocks' ) }
 						showTooltip
+						disabled={ ! filteredPatterns.find( ( { id } ) => id === pattern.id ) }
 						onClick={ () => {
 							setActivePatternId( pattern.id );
 							const patternContent = ref.current.closest( '.gb-pattern-library__content' );


### PR DESCRIPTION
This fixes a bug where the preview pattern feature doesn't work if the pattern isn't in the current list of patterns being displayed.

https://github.com/tomusborne/generateblocks/assets/20714883/374898c7-e56f-4b88-8092-12caf563e82f

This PR disables the button if the preview isn't available. A better solution would be to have the patterns always be available, but I believe this would require a refactor of how we filter the pattern list.