### PR TITLE
Fix: Headline editor margin when set to `div`

### DIFF
--- a/src/blocks/headline/editor.scss
+++ b/src/blocks/headline/editor.scss
@@ -9,6 +9,11 @@
 			display: inline-block;
 		}
 	}
+
+	:where(div.gb-headline) {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 }
 
 .gb-image-replace-url {


### PR DESCRIPTION
This fixes a bug in the editor where Headline blocks set to `div` show the default top/bottom editor margin.