### PR TITLE
Fix text-decoration for headings

### DIFF
--- a/src/blocks/headline/editor.scss
+++ b/src/blocks/headline/editor.scss
@@ -4,12 +4,6 @@
 		color: unset;
 	}
 
-	.gb-headline {
-		span.rich-text {
-			display: inline-block;
-		}
-	}
-
 	:where(div.gb-headline) {
 		margin-top: 0;
 		margin-bottom: 0;


### PR DESCRIPTION
Removes extra style that caused the rich-text span to not display inline styles correctly