### PR TITLE
Bug: Missing script deps for packages

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1942,13 +1942,14 @@ function generateblocks_get_enqueue_assets(
 	$fallback_assets = [
 		'dependencies' => [],
 		'version' => '',
-	]
+	],
+	$base_path = GENERATEBLOCKS_DIR . 'dist/'
 ) {
 	if ( ! $filename ) {
 		return $fallback_assets;
 	}
 
-	$assets_file = GENERATEBLOCKS_DIR . 'dist/' . $filename . '.asset.php';
+	$assets_file = $base_path . $filename . '.asset.php';
 	$compiled_assets = file_exists( $assets_file )
 		? require $assets_file
 		: false;

--- a/includes/general.php
+++ b/includes/general.php
@@ -213,7 +213,14 @@ function generateblocks_do_block_editor_assets() {
 		);
 
 		foreach ( $edge22_packages as $name => $version ) {
-			$package_info = generateblocks_get_enqueue_assets( $name );
+			$package_info = generateblocks_get_enqueue_assets(
+				'index',
+				[
+					'dependencies' => [],
+					'version' => '',
+				],
+				GENERATEBLOCKS_DIR . "node_modules/{$name}/dist"
+			);
 
 			$name = str_replace( '@edge22/', '', $name );
 
@@ -233,16 +240,6 @@ function generateblocks_do_block_editor_assets() {
 			);
 		}
 	}
-
-	$styles_builder_assets = generateblocks_get_enqueue_assets( 'styles-builder' );
-
-	wp_enqueue_script(
-		'generateblocks-styles-builder',
-		GENERATEBLOCKS_DIR_URL . 'dist/styles-builder.js',
-		$styles_builder_assets['dependencies'],
-		$styles_builder_assets['version'],
-		true
-	);
 
 	$editor_assets = generateblocks_get_enqueue_assets( 'editor' );
 


### PR DESCRIPTION
The new package entries were missing the proper deps list. This retrieves the deps from the package itself to ensure they’re correct. 