### PR TITLE
Tweak - Adjust legacy blocks check to use version

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2002,10 +2002,8 @@ function generateblocks_str_starts_with( $string, $prefix ) {
 function generateblocks_should_show_legacy_blocks() {
 	$show_legacy_blocks = false;
 
-	if ( defined( 'GENERATEBLOCKS_PRO_VERSION' ) ) {
-		if ( ! class_exists( 'GenerateBlocks_Block_Accordion_Item' ) ) {
-			$show_legacy_blocks = true;
-		}
+	if ( defined( 'GENERATEBLOCKS_VERSION' ) && GENERATEBLOCKS_VERSION < 2.0 ) {
+		$show_legacy_blocks = true;
 	}
 
 	return apply_filters(


### PR DESCRIPTION
Simple change to use the free plugin’s version to determine if legacy blocks should be shown in the inserter. The previously added hook remains in place. 