### PR TITLE
Bug - Resolve runtime errors in editor

### DIFF
--- a/src/blocks/headline/components/HeadlineContentRenderer.js
+++ b/src/blocks/headline/components/HeadlineContentRenderer.js
@@ -74,6 +74,20 @@ export default function HeadlineContentRenderer( props ) {
 
 	doAction( 'generateblocks.editor.renderBlock', { ...props, ref: headlineRef } );
 
+	const innerContentProps = {
+		name,
+		tagName,
+		value: content,
+		onChange: ( newContent ) => setAttributes( { content: newContent } ),
+		placeholder: __( 'Headline', 'generateblocks' ),
+	};
+
+	if ( RichText === InnerContent ) {
+		innerContentProps.onReplace = onReplace;
+		innerContentProps.onSplit = onSplit( attributes, clientId );
+		innerContentProps.allowedFormats = textFormats;
+	}
+
 	return (
 		<RootElement name={ name } clientId={ clientId }>
 			<Element tagName={ element } htmlAttrs={ blockProps }>
@@ -85,16 +99,7 @@ export default function HeadlineContentRenderer( props ) {
 					wrapperClassname={ 'gb-headline-text' }
 					ariaLabel={ ( !! removeText && !! ariaLabel ? ariaLabel : undefined ) }
 				>
-					<InnerContent
-						name={ name }
-						tagName={ tagName }
-						value={ content }
-						onChange={ ( newContent ) => setAttributes( { content: newContent } ) }
-						onSplit={ onSplit( attributes, clientId ) }
-						onReplace={ onReplace }
-						placeholder={ __( 'Headline', 'generateblocks' ) }
-						allowedFormats={ textFormats }
-					/>
+					<InnerContent { ...innerContentProps } />
 				</IconWrapper>
 			</Element>
 		</RootElement>

--- a/src/utils/get-attribute/index.js
+++ b/src/utils/get-attribute/index.js
@@ -11,5 +11,5 @@ export default function getAttribute( name, props, getName = false ) {
 		return attributeName;
 	}
 
-	return attributes[ attributeName ];
+	return attributes[ attributeName ] ?? '';
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,6 @@ const config = {
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
 		new DependencyExtractionWebpackPlugin( {
-			injectPolyfill: true, // Required, from default config.
 			useDefaults: true,
 			requestToExternal( request ) {
 				// Only externalize edge22 package imports.


### PR DESCRIPTION
This fixes a number of existing runtime errors and removes wp-polyfill from the webpack output.