### PR TITLE
Tweak: Remove simple shortcuts

### DIFF
--- a/src/blocks/element/components/BlockSettings.jsx
+++ b/src/blocks/element/components/BlockSettings.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Button, BaseControl, Notice } from '@wordpress/components';
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { createBlock, cloneBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -9,13 +9,8 @@ import {
 	ApplyFilters,
 	OpenPanel,
 	URLControls,
-	ColorPickerControls,
-	moreDesignOptions,
-	UnitControl,
 	TagNameControl,
 	HtmlAttributes,
-	DimensionsControl,
-	ImageUpload,
 	GridColumnSelector,
 	gridColumnLayouts as layouts,
 	DividerModal,
@@ -119,17 +114,6 @@ export function BlockSettings( {
 	} = useDispatch( blockEditorStore );
 	const { getBlock } = useSelect( ( select ) => select( blockEditorStore ), [] );
 
-	const backgroundImageUrl = useMemo( () => {
-		const url = getStyleValue( 'backgroundImage', currentAtRule );
-
-		const regex = /url\((['"]?)(.*?)\1\)/;
-		const match = url.match( regex );
-
-		if ( match && match[ 2 ] ) {
-			return match[ 2 ];
-		}
-	}, [ getStyleValue( 'backgroundImage' ), currentAtRule ] );
-
 	return (
 		<ApplyFilters
 			name="generateblocks.editor.blockControls"
@@ -202,57 +186,40 @@ export function BlockSettings( {
 						} }
 					/>
 				</BaseControl>
-
-				<UnitControl
-					id="columnGap"
-					label={ __( 'Horizontal Gap', 'generateblocks' ) }
-					value={ getStyleValue( 'columnGap', currentAtRule ) }
-					onChange={ ( value ) => onStyleChange( 'columnGap', value, currentAtRule ) }
-				/>
-
-				<UnitControl
-					id="rowGap"
-					label={ __( 'Vertical Gap', 'generateblocks' ) }
-					value={ getStyleValue( 'rowGap', currentAtRule ) }
-					onChange={ ( value ) => onStyleChange( 'rowGap', value, currentAtRule ) }
-				/>
 			</OpenPanel>
 
 			<OpenPanel
-				title={ __( 'Design', 'generateblocks' ) }
-				dropdownOptions={ [
-					moreDesignOptions,
-				] }
+				title={ __( 'Settings', 'generateblocks' ) }
+				shouldRender={ '' === currentAtRule }
 			>
-				<ColorPickerControls
-					items={ 'a' === tagName ? linkElementColorControls : containerColorControls }
-					getStyleValue={ getStyleValue }
-					onStyleChange={ onStyleChange }
-					currentAtRule={ currentAtRule }
-				/>
+				<TagNameControl
+					blockName="generateblocks/element"
+					value={ tagName }
+					onChange={ ( value ) => {
+						setAttributes( { tagName: value } );
 
-				<DimensionsControl
-					label={ __( 'Padding', 'generateblocks-pro' ) }
-					attributeNames={ [ 'paddingTop', 'paddingLeft', 'paddingRight', 'paddingBottom' ] }
-					values={ {
-						paddingTop: getStyleValue( 'paddingTop', currentAtRule ),
-						paddingRight: getStyleValue( 'paddingRight', currentAtRule ),
-						paddingBottom: getStyleValue( 'paddingBottom', currentAtRule ),
-						paddingLeft: getStyleValue( 'paddingLeft', currentAtRule ),
+						if ( 'a' === value && ! styles?.display ) {
+							onStyleChange( 'display', 'block' );
+						}
 					} }
-					onChange={ ( values ) => Object.keys( values ).forEach( ( property ) => (
-						onStyleChange( property, values[ property ], currentAtRule )
-					) ) }
-					placeholders={ {} }
 				/>
 
-				<ImageUpload
-					label={ __( 'Background Image', 'generateblocks' ) }
-					value={ getStyleValue( 'backgroundImage', currentAtRule ) }
-					onInsert={ ( value ) => onStyleChange( 'backgroundImage', `url(${ value })`, currentAtRule ) }
-					onSelectImage={ ( media ) => onStyleChange( 'backgroundImage', `url(${ media.url })`, currentAtRule ) }
-					showInput={ false }
-					previewUrl={ backgroundImageUrl }
+				{ 'a' === tagName && (
+					<BaseControl>
+						<Notice
+							status="warning"
+							isDismissible={ false }
+						>
+							{ __( 'This container is now a link element. Be sure not to add any interactive elements inside of it, like buttons or other links.', 'generateblocks' ) }
+						</Notice>
+					</BaseControl>
+				) }
+
+				<HtmlAttributes
+					items={ htmlAttributes }
+					onAdd={ ( value ) => setAttributes( { htmlAttributes: value } ) }
+					onRemove={ ( value ) => setAttributes( { htmlAttributes: value } ) }
+					onChange={ ( value ) => setAttributes( { htmlAttributes: value } ) }
 				/>
 			</OpenPanel>
 
@@ -311,41 +278,6 @@ export function BlockSettings( {
 						} }
 					/>
 				) }
-			</OpenPanel>
-
-			<OpenPanel
-				title={ __( 'Settings', 'generateblocks' ) }
-				shouldRender={ '' === currentAtRule }
-			>
-				<TagNameControl
-					blockName="generateblocks/element"
-					value={ tagName }
-					onChange={ ( value ) => {
-						setAttributes( { tagName: value } );
-
-						if ( 'a' === value && ! styles?.display ) {
-							onStyleChange( 'display', 'block' );
-						}
-					} }
-				/>
-
-				{ 'a' === tagName && (
-					<BaseControl>
-						<Notice
-							status="warning"
-							isDismissible={ false }
-						>
-							{ __( 'This container is now a link element. Be sure not to add any interactive elements inside of it, like buttons or other links.', 'generateblocks' ) }
-						</Notice>
-					</BaseControl>
-				) }
-
-				<HtmlAttributes
-					items={ htmlAttributes }
-					onAdd={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-					onRemove={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-					onChange={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-				/>
 			</OpenPanel>
 		</ApplyFilters>
 	);

--- a/src/blocks/loop-item/components/BlockSettings.jsx
+++ b/src/blocks/loop-item/components/BlockSettings.jsx
@@ -1,19 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import { BaseControl, Notice } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
 
 import {
 	ApplyFilters,
 	OpenPanel,
 	URLControls,
-	ColorPickerControls,
-	moreDesignOptions,
 	TagNameControl,
 	HtmlAttributes,
-	DimensionsControl,
-	ImageUpload,
 } from '@components/index.js';
-import { containerColorControls, linkElementColorControls } from '../../element/components/BlockSettings';
 
 export function BlockSettings( {
 	getStyleValue,
@@ -28,17 +22,6 @@ export function BlockSettings( {
 		htmlAttributes,
 		styles,
 	} = attributes;
-
-	const backgroundImageUrl = useMemo( () => {
-		const url = getStyleValue( 'backgroundImage', currentAtRule );
-
-		const regex = /url\((['"]?)(.*?)\1\)/;
-		const match = url.match( regex );
-
-		if ( match && match[ 2 ] ) {
-			return match[ 2 ];
-		}
-	}, [ getStyleValue( 'backgroundImage' ), currentAtRule ] );
 
 	return (
 		<ApplyFilters
@@ -57,44 +40,6 @@ export function BlockSettings( {
 				<URLControls
 					setAttributes={ setAttributes }
 					htmlAttributes={ htmlAttributes }
-				/>
-			</OpenPanel>
-
-			<OpenPanel
-				title={ __( 'Design', 'generateblocks' ) }
-				dropdownOptions={ [
-					moreDesignOptions,
-				] }
-			>
-				<ColorPickerControls
-					items={ 'a' === tagName ? linkElementColorControls : containerColorControls }
-					getStyleValue={ getStyleValue }
-					onStyleChange={ onStyleChange }
-					currentAtRule={ currentAtRule }
-				/>
-
-				<DimensionsControl
-					label={ __( 'Padding', 'generateblocks-pro' ) }
-					attributeNames={ [ 'paddingTop', 'paddingLeft', 'paddingRight', 'paddingBottom' ] }
-					values={ {
-						paddingTop: getStyleValue( 'paddingTop', currentAtRule ),
-						paddingRight: getStyleValue( 'paddingRight', currentAtRule ),
-						paddingBottom: getStyleValue( 'paddingBottom', currentAtRule ),
-						paddingLeft: getStyleValue( 'paddingLeft', currentAtRule ),
-					} }
-					onChange={ ( values ) => Object.keys( values ).forEach( ( property ) => (
-						onStyleChange( property, values[ property ], currentAtRule )
-					) ) }
-					placeholders={ {} }
-				/>
-
-				<ImageUpload
-					label={ __( 'Background Image', 'generateblocks' ) }
-					value={ getStyleValue( 'backgroundImage', currentAtRule ) }
-					onInsert={ ( value ) => onStyleChange( 'backgroundImage', `url(${ value })`, currentAtRule ) }
-					onSelectImage={ ( media ) => onStyleChange( 'backgroundImage', `url(${ media.url })`, currentAtRule ) }
-					showInput={ false }
-					previewUrl={ backgroundImageUrl }
 				/>
 			</OpenPanel>
 

--- a/src/blocks/media/components/BlockSettings.jsx
+++ b/src/blocks/media/components/BlockSettings.jsx
@@ -2,10 +2,8 @@ import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 
 import {
-	moreDesignOptions,
 	ApplyFilters,
 	OpenPanel,
-	UnitControl,
 	HtmlAttributes,
 	ImageUpload,
 } from '@components/index.js';
@@ -120,27 +118,6 @@ export function BlockSettings( {
 					onAdd={ ( value ) => setAttributes( { htmlAttributes: value } ) }
 					onRemove={ ( value ) => setAttributes( { htmlAttributes: value } ) }
 					onChange={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-				/>
-			</OpenPanel>
-
-			<OpenPanel
-				title={ __( 'Design', 'generateblocks' ) }
-				dropdownOptions={ [
-					moreDesignOptions,
-				] }
-			>
-				<UnitControl
-					id="width"
-					label={ __( 'Width', 'generateblocks' ) }
-					value={ getStyleValue( 'width', currentAtRule ) }
-					onChange={ ( value ) => onStyleChange( 'width', value, currentAtRule ) }
-				/>
-
-				<UnitControl
-					id="height"
-					label={ __( 'Height', 'generateblocks' ) }
-					value={ getStyleValue( 'height', currentAtRule ) }
-					onChange={ ( value ) => onStyleChange( 'height', value, currentAtRule ) }
 				/>
 			</OpenPanel>
 		</ApplyFilters>

--- a/src/blocks/text/components/BlockSettings.jsx
+++ b/src/blocks/text/components/BlockSettings.jsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 
 import {
@@ -7,12 +6,8 @@ import {
 	OpenPanel,
 	URLControls,
 	IconControl,
-	ColorPickerControls,
-	moreDesignOptions,
-	UnitControl,
 	TagNameControl,
 	HtmlAttributes,
-	DimensionsControl,
 } from '@components/index.js';
 
 export const buttonColorControls = [
@@ -106,22 +101,6 @@ export function BlockSettings( {
 		iconLocation,
 	} = attributes;
 
-	const colorControls = useMemo( () => {
-		let controls = textColorControls;
-
-		if ( 'a' === tagName || 'button' === tagName ) {
-			controls = buttonColorControls;
-		}
-
-		if ( ! icon ) {
-			controls = controls.filter( ( control ) => (
-				'icon-color' !== control.id
-			) );
-		}
-
-		return controls;
-	}, [ tagName, icon ] );
-
 	return (
 		<ApplyFilters
 			name="generateblocks.editor.blockControls"
@@ -143,66 +122,27 @@ export function BlockSettings( {
 			</OpenPanel>
 
 			<OpenPanel
-				title={ __( 'Design', 'generateblocks' ) }
-				dropdownOptions={ [
-					moreDesignOptions,
-				] }
+				title={ __( 'Settings', 'generateblocks' ) }
+				shouldRender={ '' === currentAtRule }
 			>
-				<ColorPickerControls
-					items={ colorControls }
-					getStyleValue={ getStyleValue }
-					onStyleChange={ onStyleChange }
-					currentAtRule={ currentAtRule }
+				<TagNameControl
+					blockName="generateblocks/text"
+					value={ tagName }
+					onChange={ ( value ) => {
+						setAttributes( { tagName: value } );
+
+						if ( 'a' === value && ! getStyleValue( 'display', currentAtRule ) ) {
+							onStyleChange( 'display', 'block' );
+						}
+					} }
 				/>
 
-				<UnitControl
-					id="fontSize"
-					label={ __( 'Text size', 'generateblocks' ) }
-					value={ getStyleValue( 'fontSize', currentAtRule ) }
-					onChange={ ( value ) => onStyleChange( 'fontSize', value, currentAtRule ) }
+				<HtmlAttributes
+					items={ htmlAttributes }
+					onAdd={ ( value ) => setAttributes( { htmlAttributes: value } ) }
+					onRemove={ ( value ) => setAttributes( { htmlAttributes: value } ) }
+					onChange={ ( value ) => setAttributes( { htmlAttributes: value } ) }
 				/>
-
-				<SelectControl
-					label={ __( 'Appearance', 'generateblocks' ) }
-					value={ getStyleValue( 'fontWeight', currentAtRule ) }
-					options={ [
-						{ label: __( 'Default', 'generateblocks' ), value: '' },
-						{ label: __( 'Thin', 'generateblocks' ), value: '100' },
-						{ label: __( 'Extra Light', 'generateblocks' ), value: '200' },
-						{ label: __( 'Light', 'generateblocks' ), value: '300' },
-						{ label: __( 'Normal', 'generateblocks' ), value: '400' },
-						{ label: __( 'Medium', 'generateblocks' ), value: '500' },
-						{ label: __( 'Semi Bold', 'generateblocks' ), value: '600' },
-						{ label: __( 'Bold', 'generateblocks' ), value: '700' },
-						{ label: __( 'Extra Bold', 'generateblocks' ), value: '800' },
-						{ label: __( 'Black', 'generateblocks' ), value: '900' },
-					] }
-					onChange={ ( value ) => onStyleChange( 'fontWeight', value, currentAtRule ) }
-				/>
-
-				{ 'a' === tagName || 'button' === tagName ? (
-					<DimensionsControl
-						label={ __( 'Padding', 'generateblocks-pro' ) }
-						attributeNames={ [ 'paddingTop', 'paddingLeft', 'paddingRight', 'paddingBottom' ] }
-						values={ {
-							paddingTop: getStyleValue( 'paddingTop', currentAtRule ),
-							paddingRight: getStyleValue( 'paddingRight', currentAtRule ),
-							paddingBottom: getStyleValue( 'paddingBottom', currentAtRule ),
-							paddingLeft: getStyleValue( 'paddingLeft', currentAtRule ),
-						} }
-						onChange={ ( values ) => Object.keys( values ).forEach( ( property ) => (
-							onStyleChange( property, values[ property ], currentAtRule )
-						) ) }
-						placeholders={ {} }
-					/>
-				) : (
-					<UnitControl
-						id="marginBottom"
-						label={ __( 'Bottom spacing', 'generateblocks' ) }
-						value={ getStyleValue( 'marginBottom', currentAtRule ) }
-						onChange={ ( value ) => onStyleChange( 'marginBottom', value, currentAtRule ) }
-					/>
-				) }
 			</OpenPanel>
 
 			<OpenPanel
@@ -238,30 +178,6 @@ export function BlockSettings( {
 						onChange={ ( value ) => setAttributes( { iconLocation: value } ) }
 					/>
 				) }
-			</OpenPanel>
-
-			<OpenPanel
-				title={ __( 'Settings', 'generateblocks' ) }
-				shouldRender={ '' === currentAtRule }
-			>
-				<TagNameControl
-					blockName="generateblocks/text"
-					value={ tagName }
-					onChange={ ( value ) => {
-						setAttributes( { tagName: value } );
-
-						if ( 'a' === value && ! getStyleValue( 'display', currentAtRule ) ) {
-							onStyleChange( 'display', 'block' );
-						}
-					} }
-				/>
-
-				<HtmlAttributes
-					items={ htmlAttributes }
-					onAdd={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-					onRemove={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-					onChange={ ( value ) => setAttributes( { htmlAttributes: value } ) }
-				/>
 			</OpenPanel>
 		</ApplyFilters>
 	);


### PR DESCRIPTION
After some discussion, we've decided it's best to remove simple shortcuts from the new blocks, as they add another layer of UI that doesn't add a ton of value.

A shortcut is acceptable when it:

* Targets a non-default selector, saving the user from multiple clicks and knowing which selector to target
* Does something as well as adjust the styles object (add/remove blocks, etc...)