### PR TITLE
Feature: Add `linkTo` feature to dynamic tags

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -41,7 +41,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		if ( $link ) {
 			$output = sprintf(
 				'<a href="%s">%s</a>',
-				$link,
+				esc_url( $link ),
 				$output
 			);
 		}

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -21,7 +21,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @param string $output The output.
 	 * @param array  $options The options.
 	 */
-	private static function withLink( $output, $options ) {
+	private static function with_link( $output, $options ) {
 		if ( empty( $options['linkTo'] ) ) {
 			return $output;
 		}
@@ -56,7 +56,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @param array  $options The options.
 	 */
 	private static function output( $output, $options ) {
-		$output = self::withLink( $output, $options );
+		$output = self::with_link( $output, $options );
 		$output = apply_filters( 'generateblocks_dynamic_tag_output', $output, $options );
 
 		return $output;

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -16,15 +16,63 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	/**
+	 * Wrap a link around the output.
+	 *
+	 * @param string $output The output.
+	 * @param array  $options The options.
+	 */
+	private static function withLink( $output, $options ) {
+		if ( empty( $options['linkTo'] ) ) {
+			return $output;
+		}
+
+		$id      = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$link_to = $options['linkTo'];
+		$link    = '';
+
+		if ( 'post' === $link_to ) {
+			$link = get_permalink( $id );
+		}
+
+		if ( 'comments' === $link_to ) {
+			$link = get_comments_link( $id );
+		}
+
+		if ( $link ) {
+			$output = sprintf(
+				'<a href="%s">%s</a>',
+				$link,
+				$output
+			);
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Output the dynamic tag.
+	 *
+	 * @param string $output The output.
+	 * @param array  $options The options.
+	 */
+	private static function output( $output, $options ) {
+		$output = self::withLink( $output, $options );
+		$output = apply_filters( 'generateblocks_dynamic_tag_output', $output, $options );
+
+		return $output;
+	}
+
+	/**
 	 * Get the title.
 	 *
 	 * @param array $options The options.
 	 * @return string
 	 */
 	public static function get_the_title( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$output = get_the_title( $id );
 
-		return get_the_title( $id );
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -34,9 +82,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_the_permalink( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$output = get_permalink( $id );
 
-		return get_permalink( $id );
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -46,8 +95,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_published_date( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
-		return get_the_date( '', $id );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$output = get_the_date( '', $id );
+
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -57,8 +108,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_modified_date( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
-		return get_the_modified_date( '', $id );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$output = get_the_modified_date( '', $id );
+
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -68,20 +121,23 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return int
 	 */
 	public static function get_featured_image_url( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id       = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$image_id = get_post_thumbnail_id( $id );
+		$output   = '';
 
 		if ( ! $image_id ) {
-			return '';
+			return self::output( $output, $options );
 		}
 
 		$image = wp_get_attachment_image_src( $image_id, 'full' );
 
 		if ( ! $image ) {
-			return '';
+			return self::output( $output, $options );
 		}
 
-		return $image[0];
+		$output = $image[0];
+
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -91,14 +147,15 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return int
 	 */
 	public static function get_featured_image_id( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id       = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$image_id = get_post_thumbnail_id( $id );
+		$output   = 0;
 
 		if ( ! $image_id ) {
-			return 0;
+			return self::output( $output, $options );
 		}
 
-		return $image_id;
+		return self::output( $image_id, $options );
 	}
 
 	/**
@@ -108,18 +165,19 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_post_meta( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
-		$meta = get_post_meta( $id, $options['metaKey'], true );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$meta   = get_post_meta( $id, $options['metaKey'], true );
+		$output = '';
 
 		if ( ! $meta ) {
-			return '';
+			return self::output( $output, $options );
 		}
 
 		add_filter( 'wp_kses_allowed_html', [ 'GenerateBlocks_Dynamic_Tags', 'expand_allowed_html' ], 10, 2 );
-		$meta = wp_kses_post( $meta );
+		$output = wp_kses_post( $meta );
 		remove_filter( 'wp_kses_allowed_html', [ 'GenerateBlocks_Dynamic_Tags', 'expand_allowed_html' ], 10, 2 );
 
-		return $meta;
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -133,18 +191,19 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_previous_posts_page_url( $options, $block, $instance ) {
 		$page_key = isset( $instance->context['generateblocks/queryId'] ) ? 'query-' . $instance->context['generateblocks/queryId'] . '-page' : 'query-page';
 		$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
+		$output   = '';
 
 		if ( isset( $instance->context['generateblocks/inheritQuery'] ) && $instance->context['generateblocks/inheritQuery'] ) {
 			global $paged;
 
 			if ( $paged > 1 ) {
-				$url = previous_posts( false );
+				$output = previous_posts( false );
 			}
 		} elseif ( 1 !== $page ) {
-			$url = esc_url( add_query_arg( $page_key, $page - 1 ) );
+			$output = esc_url( add_query_arg( $page_key, $page - 1 ) );
 		}
 
-		return $url ?? '';
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -159,6 +218,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		$page_key = isset( $instance->context['generateblocks/queryId'] ) ? 'query-' . $instance->context['generateblocks/queryId'] . '-page' : 'query-page';
 		$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
 		$max_page = isset( $instance->context['generateblocks/query']['pages'] ) ? (int) $instance->context['generateblocks/query']['pages'] : 0;
+		$output   = '';
 
 		if ( isset( $instance->context['generateblocks/inheritQuery'] ) && $instance->context['generateblocks/inheritQuery'] ) {
 			global $wp_query, $paged;
@@ -174,25 +234,25 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			$nextpage = (int) $paged + 1;
 
 			if ( $nextpage <= $max_page ) {
-				$url = next_posts( $max_page, false );
+				$output = next_posts( $max_page, false );
 			}
 		} elseif ( ! $max_page || $max_page > $page ) {
 			$custom_query = $instance->context['generateblocks/queryData'] ?? null;
 
 			if ( ! $custom_query ) {
-				return '';
+				return self::output( $output, $options );
 			}
 
 			$custom_query_max_pages = (int) $custom_query->max_num_pages;
 
 			if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
-				$url = esc_url( add_query_arg( $page_key, $page + 1 ) );
+				$output = esc_url( add_query_arg( $page_key, $page + 1 ) );
 			}
 
 			wp_reset_postdata(); // Restore original Post Data.
 		}
 
-		return $url ?? '';
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -206,20 +266,23 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		$none   = $options['none'] ?? __( 'No comments', 'generateblocks' );
 		$single = $options['single'] ?? __( '1 comment', 'generateblocks' );
 		$multi  = $options['multi'] ?? __( '% comments', 'generateblocks' );
+		$output = '';
 
 		if ( ! post_password_required( $id ) && ( comments_open( $id ) || get_comments_number( $id ) ) ) {
 			if ( '' === $none && get_comments_number( $id ) < 1 ) {
-				return $none;
+				return self::output( $none, $options );
 			}
 
-			return get_comments_number_text(
+			$output = get_comments_number_text(
 				$none,
 				$single,
 				$multi
 			);
 		} else {
-			return $none;
+			$output = $none;
 		}
+
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -229,9 +292,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_the_comments_url( $options ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$output = get_comments_link( $id );
 
-		return get_comments_link( $id );
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -244,9 +308,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		$id      = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$user_id = get_post_field( 'post_author', $id );
 		$key     = $options['metaKey'] ?? '';
+		$output  = '';
 
 		if ( ! $user_id || ! $key ) {
-			return '';
+			return self::output( $output, $options );
 		}
 
 		$meta = get_user_meta( $user_id, $key, true );
@@ -280,10 +345,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		}
 
 		add_filter( 'wp_kses_allowed_html', [ 'GenerateBlocks_Dynamic_Tags', 'expand_allowed_html' ], 10, 2 );
-		$meta = wp_kses_post( $meta );
+		$output = wp_kses_post( $meta );
 		remove_filter( 'wp_kses_allowed_html', [ 'GenerateBlocks_Dynamic_Tags', 'expand_allowed_html' ], 10, 2 );
 
-		return $meta;
+		return self::output( $output, $options );
 	}
 
 	/**
@@ -295,11 +360,14 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_author_archive_url( $options ) {
 		$id      = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$user_id = get_post_field( 'post_author', $id );
+		$output  = '';
 
 		if ( ! $user_id ) {
-			return '';
+			return self::output( $output, $options );
 		}
 
-		return get_author_posts_url( $user_id );
+		$output = get_author_posts_url( $user_id );
+
+		return self::output( $output, $options );
 	}
 }

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -43,11 +43,14 @@ class GenerateBlocks_Register_Dynamic_Tag {
 	 * Parse options.
 	 *
 	 * @param string $options_string The options string.
+	 * @param string $tag_name The tag name.
 	 * @return array
 	 */
-	private static function parse_options( $options_string ) {
+	private static function parse_options( $options_string, $tag_name ) {
 		$pairs = explode( '|', $options_string );
-		$result = [];
+		$result = [
+			'tag_name' => $tag_name, // Make it so the tag name is available to us in $options.
+		];
 
 		if ( empty( $pairs ) ) {
 			return $result;
@@ -171,7 +174,7 @@ class GenerateBlocks_Register_Dynamic_Tag {
 					$full_tag = $match[0];
 					$full_tag = self::maybe_prepend_protocol( $content, $full_tag );
 					$options_string = $match[2] ?? '';
-					$options = self::parse_options( $options_string );
+					$options = self::parse_options( $options_string, $tag_name );
 					$replacement = $data['return']( $options, $block, $instance );
 
 					if ( self::should_remove_block( $content, $full_tag, $replacement ) ) {

--- a/src/blocks/query/templates.js
+++ b/src/blocks/query/templates.js
@@ -116,7 +116,7 @@ export const templates = [
 						[
 							[ 'generateblocks/text', {
 								tagName: 'h2',
-								content: '{post_title}',
+								content: '{post_title linkTo=post}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',
@@ -157,7 +157,7 @@ export const templates = [
 									fontSize: '20px',
 									marginBottom: '5px',
 								},
-								content: '<a href="{post_permalink}">{post_title}</a>',
+								content: '{post_title linkTo=post}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',
@@ -207,7 +207,7 @@ export const templates = [
 									fontSize: '30px',
 									marginBottom: '5px',
 								},
-								content: '<a href="{post_permalink}">{post_title}</a>',
+								content: '{post_title linkTo=post}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',
@@ -269,7 +269,7 @@ export const templates = [
 									fontSize: '30px',
 									marginBottom: '5px',
 								},
-								content: '<a href="{post_permalink}">{post_title}</a>',
+								content: '{post_title linkTo=post}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -173,7 +173,8 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 
 	const interactiveTagNames = [ 'a', 'button' ];
 	const canBeLinked = [ 'post_title', 'comments_count', 'published_date', 'modified_date' ];
-	const showLinkTo = canBeLinked.includes( dynamicTag );
+	const showLinkTo = canBeLinked.includes( dynamicTag ) && ! interactiveTagNames.includes( tagName );
+	const showInsertAsLink = hasSelection && ! interactiveTagNames.includes( tagName ) && ! linkTo;
 
 	return (
 		<>
@@ -248,7 +249,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 						</>
 					) }
 
-					{ showLinkTo && ! interactiveTagNames.includes( tagName ) && (
+					{ showLinkTo && (
 						<SelectControl
 							label={ __( 'Link to', 'generateblocks' ) }
 							value={ linkTo }
@@ -267,7 +268,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 						onChange={ ( value ) => setDynamicTagToInsert( value ) }
 					/>
 
-					{ !! hasSelection && ! interactiveTagNames.includes( tagName ) && ! linkTo && (
+					{ !! showInsertAsLink && (
 						<CheckboxControl
 							label={ __( 'Insert as link', 'generateblocks' ) }
 							checked={ insertAsLink }

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -135,30 +135,30 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 			return;
 		}
 
-		const tags = [];
+		const options = [];
 
 		if ( postIdSource ) {
-			tags.push( `postId=${ postIdSource }` );
+			options.push( `postId=${ postIdSource }` );
 		}
 
 		const isMetaTag = dynamicTag.startsWith( 'post_meta' ) ||
             dynamicTag.startsWith( 'author_meta' );
 
 		if ( isMetaTag && metaKey ) {
-			tags.push( `metaKey=${ metaKey }` );
+			options.push( `metaKey=${ metaKey }` );
 		}
 
 		if ( dynamicTag.startsWith( 'comments_count' ) ) {
-			tags.push( `none=${ commentsCountText.none }` );
-			tags.push( `one=${ commentsCountText.one }` );
-			tags.push( `multiple=${ commentsCountText.multiple }` );
+			options.push( `none=${ commentsCountText.none }` );
+			options.push( `one=${ commentsCountText.one }` );
+			options.push( `multiple=${ commentsCountText.multiple }` );
 		}
 
 		if ( linkTo ) {
-			tags.push( `linkTo=${ linkTo }` );
+			options.push( `linkTo=${ linkTo }` );
 		}
 
-		const tagOptions = tags.join( '|' );
+		const tagOptions = options.join( '|' );
 
 		let tagToInsert = dynamicTag;
 


### PR DESCRIPTION
Blocked by #1278 

This PR adds a `linkTo` param to the dynamic tags. This allows you to choose whether to automatically link the dynamic text or not.

It also runs all dynamic tag output through a single filter, so users can filter their output based on the tag/options.