### PR TITLE
Fix: Text block editor margins

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -548,7 +548,7 @@ function generateblocks_do_block_css_reset( $editor_settings ) {
 	$editor_settings['styles'][] = [ 'css' => $css ];
 
 	$blocks_to_reset = [
-		'.wp-block-generateblocks-text',
+		':where(.wp-block-generateblocks-text:not(h1, h2, h3, h4, h5, h6))',
 		'.wp-block-generateblocks-element',
 		'.wp-block-generateblocks-shape',
 		'.wp-block-generateblocks-media',
@@ -560,7 +560,12 @@ function generateblocks_do_block_css_reset( $editor_settings ) {
 		'.wp-block-generateblocks-query-terms-list',
 	];
 
-	$css = implode( ',', $blocks_to_reset ) . '{max-width:unset;margin:0;}';
+	$heading_blocks_to_reset = [
+		':where(.wp-block-generateblocks-text:is(h1, h2, h3, h4, h5, h6))',
+	];
+
+	$css  = implode( ',', $blocks_to_reset ) . '{max-width:unset;margin:0;}';
+	$css .= implode( ',', $heading_blocks_to_reset ) . '{max-width:unset;margin-left:0;margin-right:0;}';
 	$editor_settings['styles'][] = [ 'css' => $css ];
 
 	return $editor_settings;

--- a/includes/general.php
+++ b/includes/general.php
@@ -548,7 +548,7 @@ function generateblocks_do_block_css_reset( $editor_settings ) {
 	$editor_settings['styles'][] = [ 'css' => $css ];
 
 	$blocks_to_reset = [
-		':where(.wp-block-generateblocks-text:not(h1, h2, h3, h4, h5, h6))',
+		'.wp-block-generateblocks-text:not(h1, h2, h3, h4, h5, h6)',
 		'.wp-block-generateblocks-element',
 		'.wp-block-generateblocks-shape',
 		'.wp-block-generateblocks-media',
@@ -561,7 +561,7 @@ function generateblocks_do_block_css_reset( $editor_settings ) {
 	];
 
 	$heading_blocks_to_reset = [
-		':where(.wp-block-generateblocks-text:is(h1, h2, h3, h4, h5, h6))',
+		'.wp-block-generateblocks-text:is(h1, h2, h3, h4, h5, h6)',
 	];
 
 	$css  = implode( ',', $blocks_to_reset ) . '{max-width:unset;margin:0;}';


### PR DESCRIPTION
This fixes an issue where the Text block when being used as a heading was losing all margins in the editor.