### PR TITLE
Feature: Add option to render block if no dynamic tag value

### DIFF
--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -47,6 +47,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 		multiple: __( '%s comments', 'generateblocks' ),
 	} );
 	const [ linkTo, setLinkTo ] = useState( '' );
+	const [ renderIfEmpty, setRenderIfEmpty ] = useState( false );
 
 	const { getSelectionStart, getSelectionEnd } = useSelect( blockEditorStore, [] );
 	const selectionStart = getSelectionStart();
@@ -103,6 +104,10 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 		if ( params?.linkTo ) {
 			setLinkTo( params.linkTo );
 		}
+
+		if ( params?.renderIfEmpty ) {
+			setRenderIfEmpty( true );
+		}
 	}, [ selectedValue ] );
 
 	/**
@@ -158,6 +163,10 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 			options.push( `linkTo=${ linkTo }` );
 		}
 
+		if ( renderIfEmpty ) {
+			options.push( 'renderIfEmpty=true' );
+		}
+
 		const tagOptions = options.join( '|' );
 
 		let tagToInsert = dynamicTag;
@@ -169,7 +178,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 		tagToInsert = `{${ tagToInsert }}`;
 
 		setDynamicTagToInsert( tagToInsert );
-	}, [ postIdSource, dynamicTag, metaKey, commentsCountText, linkTo ] );
+	}, [ postIdSource, dynamicTag, metaKey, commentsCountText, linkTo, renderIfEmpty ] );
 
 	const interactiveTagNames = [ 'a', 'button' ];
 	const canBeLinked = [ 'post_title', 'comments_count', 'published_date', 'modified_date' ];
@@ -261,6 +270,13 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 							onChange={ ( value ) => setLinkTo( value ) }
 						/>
 					) }
+
+					<CheckboxControl
+						label={ __( 'Render block if empty', 'generateblocks' ) }
+						checked={ !! renderIfEmpty }
+						onChange={ ( value ) => setRenderIfEmpty( value ) }
+						help={ __( 'Render the block even if this dynamic tag has no value.', 'generateblocks' ) }
+					/>
 
 					<TextControl
 						label={ __( 'Dynamic tag to insert', 'generateblocks' ) }


### PR DESCRIPTION
By default, a block will not render if the dynamic tag within it returns no value. This is to prevent things like empty `<img>` elements, or text elements.

However, there might be reason to output the block even if a dynamic tag returns empty. For example, if you've added a dynamic tag to the `title` attribute of a block and it returns nothing, you likely still want that block to render.

This PR adds an option when building the dynamic tag to render the block even if the tag returns empty.