### PR TITLE
Fix: Update effects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"lodash": "4.17.21",
 				"react-colorful": "^5.5.1",
 				"react-select": "^5.7.3",
+				"react-use": "^17.5.1",
 				"request": "^2.88.2",
 				"use-debounce": "^7.0.1",
 				"use-local-storage-state": "^16.0.0",
@@ -3031,7 +3032,6 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
@@ -4557,6 +4557,11 @@
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
+		},
+		"node_modules/@types/js-cookie": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+			"integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
 		},
 		"node_modules/@types/jsdom": {
 			"version": "20.0.1",
@@ -6274,6 +6279,11 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/@xobotyi/scrollbar-width": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+			"integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
 		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -8057,6 +8067,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/copy-to-clipboard": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+			"integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+			"dependencies": {
+				"toggle-selection": "^1.0.6"
+			}
+		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "10.2.4",
 			"dev": true,
@@ -8357,6 +8375,14 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12 || >=16"
+			}
+		},
+		"node_modules/css-in-js-utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+			"integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+			"dependencies": {
+				"hyphenate-style-name": "^1.0.3"
 			}
 		},
 		"node_modules/css-loader": {
@@ -9306,7 +9332,6 @@
 		},
 		"node_modules/error-stack-parser": {
 			"version": "2.1.4",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"stackframe": "^1.3.4"
@@ -10628,6 +10653,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-shallow-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+			"integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"dev": true,
@@ -10635,6 +10665,11 @@
 			"engines": {
 				"node": ">= 4.9.1"
 			}
+		},
+		"node_modules/fastest-stable-stringify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+			"integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -12110,6 +12145,11 @@
 				"node": ">=10.17.0"
 			}
 		},
+		"node_modules/hyphenate-style-name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+			"integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"license": "MIT",
@@ -12265,6 +12305,14 @@
 			"version": "1.3.8",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/inline-style-prefixer": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+			"integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+			"dependencies": {
+				"css-in-js-utils": "^3.1.0"
+			}
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.7",
@@ -13634,6 +13682,11 @@
 			"version": "0.4.4",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/js-cookie": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
 		},
 		"node_modules/js-library-detector": {
 			"version": "6.7.0",
@@ -15050,6 +15103,55 @@
 			"bin": {
 				"multicast-dns": "cli.js"
 			}
+		},
+		"node_modules/nano-css": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+			"integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"css-tree": "^1.1.2",
+				"csstype": "^3.1.2",
+				"fastest-stable-stringify": "^2.0.2",
+				"inline-style-prefixer": "^7.0.1",
+				"rtl-css-js": "^1.16.1",
+				"stacktrace-js": "^2.0.2",
+				"stylis": "^4.3.0"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/nano-css/node_modules/css-tree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+			"dependencies": {
+				"mdn-data": "2.0.14",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/nano-css/node_modules/mdn-data": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+		},
+		"node_modules/nano-css/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nano-css/node_modules/stylis": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
+			"integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.6",
@@ -17286,6 +17388,40 @@
 				"react-dom": ">=16.6.0"
 			}
 		},
+		"node_modules/react-universal-interface": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+			"integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+			"peerDependencies": {
+				"react": "*",
+				"tslib": "*"
+			}
+		},
+		"node_modules/react-use": {
+			"version": "17.5.1",
+			"resolved": "https://registry.npmjs.org/react-use/-/react-use-17.5.1.tgz",
+			"integrity": "sha512-LG/uPEVRflLWMwi3j/sZqR00nF6JGqTTDblkXK2nzXsIvij06hXl1V/MZIlwj1OKIQUtlh1l9jK8gLsRyCQxMg==",
+			"dependencies": {
+				"@types/js-cookie": "^2.2.6",
+				"@xobotyi/scrollbar-width": "^1.9.5",
+				"copy-to-clipboard": "^3.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-shallow-equal": "^1.0.0",
+				"js-cookie": "^2.2.1",
+				"nano-css": "^5.6.2",
+				"react-universal-interface": "^0.6.2",
+				"resize-observer-polyfill": "^1.5.1",
+				"screenfull": "^5.1.0",
+				"set-harmonic-interval": "^1.0.1",
+				"throttle-debounce": "^3.0.1",
+				"ts-easing": "^0.2.0",
+				"tslib": "^2.1.0"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
 		"node_modules/read-pkg": {
 			"version": "5.2.0",
 			"dev": true,
@@ -17734,6 +17870,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
 			"license": "MIT",
@@ -17841,6 +17982,14 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/rtl-css-js": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+			"integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+			"dependencies": {
+				"@babel/runtime": "^7.1.2"
 			}
 		},
 		"node_modules/run-con": {
@@ -18040,6 +18189,17 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/screenfull": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+			"integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/select": {
@@ -18255,6 +18415,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-harmonic-interval": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+			"integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+			"engines": {
+				"node": ">=6.9"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -18868,6 +19036,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stack-generator": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+			"integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+			"dependencies": {
+				"stackframe": "^1.3.4"
+			}
+		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"dev": true,
@@ -18889,8 +19065,34 @@
 		},
 		"node_modules/stackframe": {
 			"version": "1.3.4",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/stacktrace-gps": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+			"integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+			"dependencies": {
+				"source-map": "0.5.6",
+				"stackframe": "^1.3.4"
+			}
+		},
+		"node_modules/stacktrace-gps/node_modules/source-map": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+			"integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stacktrace-js": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+			"integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+			"dependencies": {
+				"error-stack-parser": "^2.0.6",
+				"stack-generator": "^2.0.5",
+				"stacktrace-gps": "^3.0.4"
+			}
 		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
@@ -19564,6 +19766,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/throttle-debounce": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+			"integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"dev": true,
@@ -19600,6 +19810,11 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/toggle-selection": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+			"integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
@@ -19694,6 +19909,11 @@
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
 			}
+		},
+		"node_modules/ts-easing": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+			"integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
 		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"lodash": "4.17.21",
 		"react-colorful": "^5.5.1",
 		"react-select": "^5.7.3",
+		"react-use": "^17.5.1",
 		"request": "^2.88.2",
 		"use-debounce": "^7.0.1",
 		"use-local-storage-state": "^16.0.0",

--- a/src/components/unit-control/index.js
+++ b/src/components/unit-control/index.js
@@ -4,6 +4,7 @@
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { TextControl, BaseControl } from '@wordpress/components';
 import classnames from 'classnames';
+import { useUpdateEffect } from 'react-use';
 
 /**
  * Internal dependencies
@@ -38,7 +39,6 @@ export default function UnitControl( props ) {
 	const [ unitValue, setUnitValue ] = useState( '' );
 	const [ numericValue, setNumericValue ] = useState( '' );
 	const [ placeholderValue, setPlaceholderValue ] = useState( '' );
-	const isMounted = useRef( false );
 	const wrapperRef = useRef( false );
 	const inputRef = useRef( false );
 
@@ -87,13 +87,7 @@ export default function UnitControl( props ) {
 		setPlaceholders();
 	}, [ value, overrideValue ] );
 
-	useEffect( () => {
-		// Don't run this on first render.
-		if ( ! isMounted.current ) {
-			isMounted.current = true;
-			return;
-		}
-
+	useUpdateEffect( () => {
 		const hasOverride = !! overrideValue && !! disabled;
 
 		const fullValue = startsWithNumber( numericValue )


### PR DESCRIPTION
Gutenberg will soon be enforcing `StrictMode`, which breaks out `firstMount` ref pattern.

Using the `useUpdateEffect()` package fixes this issue, and cleans up the codebase/makes the effect more clear as to what it does.