### PR TITLE
Tweak: Add block version filter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
 		"generateBlocksSettings": "readonly",
 		"generateBlocksLegacyDefaults": "readonly",
 		"generateBlocksPatternLibrary": "readonly",
-		"generateblocksBlockMedia": "readonly"
+		"generateblocksBlockMedia": "readonly",
+		"generateBlocksEditor": "readonly"
 	},
 	"env": {
 	  "browser": true,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2001,19 +2001,25 @@ function generateblocks_str_starts_with( $string, $prefix ) {
  * @since 2.0.0
  * @return bool
  */
-function generateblocks_should_show_legacy_blocks() {
-	$show_legacy_blocks = false;
+function generateblocks_get_active_block_version() {
+	$block_version = 2;
 
 	if (
 		defined( 'GENERATEBLOCKS_PRO_VERSION' )
 		&& version_compare( GENERATEBLOCKS_PRO_VERSION, '1.8.0-alpha.1', '<' )
 	) {
-		$show_legacy_blocks = true;
+		$block_version = 1;
+	}
+
+	$legacy_global_styles = get_option( 'generateblocks_global_styles', [] );
+
+	if ( ! empty( $legacy_global_styles ) ) {
+		$block_version = 1;
 	}
 
 	return apply_filters(
-		'generateblocks_show_legacy_blocks',
-		$show_legacy_blocks
+		'generateblocks_active_block_version',
+		(int) $block_version
 	);
 }
 

--- a/includes/general.php
+++ b/includes/general.php
@@ -277,14 +277,6 @@ function generateblocks_do_category( $categories ) {
 	array_unshift(
 		$categories,
 		[
-			'slug'  => 'generateblocks-legacy',
-			'title' => __( 'GenerateBlocks Legacy', 'generateblocks' ),
-		]
-	);
-
-	array_unshift(
-		$categories,
-		[
 			'slug'  => 'generateblocks',
 			'title' => __( 'GenerateBlocks', 'generateblocks' ),
 		]

--- a/includes/general.php
+++ b/includes/general.php
@@ -91,7 +91,6 @@ function generateblocks_do_block_editor_assets() {
 			'queryLoopEditorPostsCap' => apply_filters( 'generateblocks_query_loop_editor_posts_cap', 50 ),
 			'disableGoogleFonts' => generateblocks_get_option( 'disable_google_fonts' ),
 			'typographyFontFamilyList' => generateblocks_get_font_family_list(),
-			'shouldShowLegacyBlocks' => generateblocks_should_show_legacy_blocks(),
 		)
 	);
 
@@ -249,6 +248,14 @@ function generateblocks_do_block_editor_assets() {
 		$editor_assets['dependencies'],
 		$editor_assets['version'],
 		true
+	);
+
+	wp_localize_script(
+		'generateblocks-editor',
+		'generateBlocksEditor',
+		[
+			'activeBlockVersion' => generateblocks_get_active_block_version(),
+		]
 	);
 
 	wp_enqueue_style(

--- a/src/blocks/button-container/block.js
+++ b/src/blocks/button-container/block.js
@@ -33,7 +33,7 @@ registerBlockType( 'generateblocks/button-container', {
 	title: __( 'Buttons', 'generateblocks' ),
 	description: __( 'Drive conversions with beautiful buttons.', 'generateblocks' ),
 	icon: getIcon( 'button-container' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'button' ),
 		__( 'buttons' ),

--- a/src/blocks/button/block.js
+++ b/src/blocks/button/block.js
@@ -41,7 +41,7 @@ registerBlockType( 'generateblocks/button', {
 	title: __( 'Button', 'generateblocks' ),
 	description: __( 'Drive conversions with beautiful buttons.', 'generateblocks' ),
 	icon: getIcon( 'button' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'button' ),
 		__( 'buttons' ),
@@ -50,7 +50,6 @@ registerBlockType( 'generateblocks/button', {
 	attributes,
 	supports: {
 		className: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 	edit: editButton,
 	save: saveButton,

--- a/src/blocks/container/block.js
+++ b/src/blocks/container/block.js
@@ -36,7 +36,7 @@ registerBlockType( 'generateblocks/container', {
 	title: __( 'Container', 'generateblocks' ),
 	description: __( 'Organize your content into rows and sections.', 'generateblocks' ),
 	icon: getIcon( 'container' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'section' ),
 		__( 'container' ),
@@ -47,7 +47,6 @@ registerBlockType( 'generateblocks/container', {
 		align: false,
 		className: false,
 		html: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 	usesContext: [ 'postId', 'postType', 'generateblocks/queryId' ],
 	edit: containerEdit,

--- a/src/blocks/grid/block.js
+++ b/src/blocks/grid/block.js
@@ -32,7 +32,7 @@ registerBlockType( 'generateblocks/grid', {
 	title: __( 'Grid', 'generateblocks' ),
 	description: __( 'Create advanced layouts with flexible grids.', 'generateblocks' ),
 	icon: getIcon( 'grid' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'grid' ),
 		__( 'column' ),
@@ -42,7 +42,6 @@ registerBlockType( 'generateblocks/grid', {
 	supports: {
 		className: false,
 		html: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 	edit: editGridContainer,
 	save: () => {

--- a/src/blocks/headline/block.js
+++ b/src/blocks/headline/block.js
@@ -42,7 +42,7 @@ registerBlockType( 'generateblocks/headline', {
 	title: __( 'Headline', 'generateblocks' ),
 	description: __( 'Craft text-rich content with advanced typography.', 'generateblocks' ),
 	icon: getIcon( 'headline' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'heading' ),
 		__( 'headline' ),
@@ -52,7 +52,6 @@ registerBlockType( 'generateblocks/headline', {
 	attributes,
 	supports: {
 		className: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 	edit: editHeadline,
 	save: saveHeadline,

--- a/src/blocks/image/index.js
+++ b/src/blocks/image/index.js
@@ -25,7 +25,7 @@ const attributes = Object.assign(
 registerBlockType( 'generateblocks/image', {
 	apiVersion: 2,
 	title: __( 'Image', 'generateblocks' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	description: __( 'Add images to your content to make a visual statement.', 'generateblocks' ),
 	icon: getIcon( 'image' ),
 	attributes,
@@ -54,6 +54,5 @@ registerBlockType( 'generateblocks/image', {
 		className: false,
 		customClassName: true,
 		html: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 } );

--- a/src/blocks/query-loop/block.js
+++ b/src/blocks/query-loop/block.js
@@ -12,7 +12,7 @@ registerBlockType( 'generateblocks/query-loop', {
 	title: __( 'Query Loop', 'generateblocks' ),
 	description: __( 'Build a list of posts from any post type using advanced query parameters.', 'generateblocks' ),
 	icon: getIcon( 'query-loop' ),
-	category: 'generateblocks-legacy',
+	category: 'generateblocks',
 	keywords: [
 		__( 'query' ),
 		__( 'loop' ),
@@ -22,7 +22,6 @@ registerBlockType( 'generateblocks/query-loop', {
 	supports: {
 		className: false,
 		customClassName: false,
-		inserter: generateBlocksInfo.shouldShowLegacyBlocks,
 	},
 	providesContext: {
 		'generateblocks/query': 'query',

--- a/src/blocks/text/index.js
+++ b/src/blocks/text/index.js
@@ -28,6 +28,20 @@ registerBlockType( metadata, {
 registerBlockVariation(
 	'generateblocks/text',
 	{
+		name: 'generateblocks/heading',
+		title: 'Headline',
+		description: __( 'A heading text element.', 'generateblocks' ),
+		icon: headingIcon,
+		attributes: {
+			tagName: 'h2',
+		},
+		isActive: ( blockAttributes ) => 'heading' === getElementType( blockAttributes.tagName ),
+	},
+);
+
+registerBlockVariation(
+	'generateblocks/text',
+	{
 		name: 'generateblocks/button',
 		title: 'Button',
 		description: __( 'An interactive button element.', 'generateblocks' ),
@@ -51,21 +65,6 @@ registerBlockVariation(
 			},
 		},
 		isActive: ( blockAttributes ) => 'button' === getElementType( blockAttributes.tagName ),
-	},
-);
-
-registerBlockVariation(
-	'generateblocks/text',
-	{
-		name: 'generateblocks/heading',
-		title: 'Heading',
-		description: __( 'A heading text element.', 'generateblocks' ),
-		icon: headingIcon,
-		attributes: {
-			tagName: 'h2',
-		},
-		isActive: ( blockAttributes ) => 'heading' === getElementType( blockAttributes.tagName ),
-		scope: [ 'block' ],
 	},
 );
 

--- a/src/editor/disable-blocks.js
+++ b/src/editor/disable-blocks.js
@@ -9,7 +9,7 @@ const v1Blocks = [
 	'generateblocks/query-loop',
 ];
 
-function disableLegacyBlocks( settings, name ) {
+function disableBlocks( settings, name ) {
 	const activeBlockVersion = parseInt( generateBlocksEditor.activeBlockVersion );
 
 	// Disable our version 1 blocks.
@@ -46,6 +46,6 @@ function disableLegacyBlocks( settings, name ) {
 
 addFilter(
 	'blocks.registerBlockType',
-	'generateblocks/disableLegacyBlocks',
-	disableLegacyBlocks,
+	'generateblocks/disableBlocks',
+	disableBlocks,
 );

--- a/src/editor/disable-legacy-blocks.js
+++ b/src/editor/disable-legacy-blocks.js
@@ -1,0 +1,51 @@
+import { addFilter } from '@wordpress/hooks';
+
+const v1Blocks = [
+	'generateblocks/button',
+	'generateblocks/headline',
+	'generateblocks/container',
+	'generateblocks/grid',
+	'generateblocks/image',
+	'generateblocks/query-loop',
+];
+
+function disableLegacyBlocks( settings, name ) {
+	const activeBlockVersion = parseInt( generateBlocksEditor.activeBlockVersion );
+
+	// Disable our version 1 blocks.
+	if (
+		v1Blocks.includes( name ) &&
+		1 !== activeBlockVersion
+	) {
+		return {
+			...settings,
+			supports: {
+				...settings.supports,
+				inserter: false,
+			},
+		};
+	}
+
+	// Disable our new blocks if legacy blocks are enabled.
+	if (
+		! v1Blocks.includes( name ) &&
+		name.startsWith( 'generateblocks' ) &&
+		1 === activeBlockVersion
+	) {
+		return {
+			...settings,
+			supports: {
+				...settings.supports,
+				inserter: false,
+			},
+		};
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'generateblocks/disableLegacyBlocks',
+	disableLegacyBlocks,
+);

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,2 +1,3 @@
 import './stores.js';
+import './disable-legacy-blocks.js';
 import './editor.scss';

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,3 +1,3 @@
 import './stores.js';
-import './disable-legacy-blocks.js';
+import './disable-blocks.js';
 import './editor.scss';


### PR DESCRIPTION
This PR does a handful of things.

1. Version 1 and version 2 blocks will never appear in the editor together. It's a one or the other kind of thing.
2. If you're using GBP and it has a version less than 1.8, version 1 blocks will show.
3. If you're using legacy Global Styles, version 1 blocks will show.
4. You can choose the version to use with a simple filter:

```
add_filter( 'generateblocks_active_block_version', function() {
    return 1; // or 2.
} );
```

Using a number for the above filter gives us flexibility in the future if we want to do a version 3.

It also allows users to opt-in to using version 1 for certain projects, which will make sure the v1 blocks continue to display in the inserter, and v2 blocks don't.