### PR TITLE
Refactor: Dynamic tags

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -22,12 +22,12 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @param array  $options The options.
 	 */
 	private static function with_link( $output, $options ) {
-		if ( empty( $options['linkTo'] ) ) {
+		if ( empty( $options['link'] ) ) {
 			return $output;
 		}
 
 		$id      = GenerateBlocks_Dynamic_Tags::get_id( $options );
-		$link_to = $options['linkTo'];
+		$link_to = $options['link'];
 		$link    = '';
 
 		if ( 'post' === $link_to ) {
@@ -166,7 +166,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 */
 	public static function get_post_meta( $options ) {
 		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
-		$meta   = get_post_meta( $id, $options['metaKey'], true );
+		$meta   = get_post_meta( $id, $options['key'], true );
 		$output = '';
 
 		if ( ! $meta ) {
@@ -307,7 +307,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_author_meta( $options ) {
 		$id      = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$user_id = get_post_field( 'post_author', $id );
-		$key     = $options['metaKey'] ?? '';
+		$key     = $options['key'] ?? '';
 		$output  = '';
 
 		if ( ! $user_id || ! $key ) {

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -211,6 +211,13 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 		$post_id      = $request->get_param( 'id' );
 		$replacements = [];
 
+		$all_tags  = GenerateBlocks_Register_Dynamic_Tag::get_tags();
+		$tags_list = [];
+
+		foreach ( $all_tags as $tag => $data ) {
+			$tags_list[] = $data['tag'];
+		}
+
 		// Match the content inside the curly brackets.
 		preg_match_all( '/\{(.*?)\}/', $content, $matches );
 
@@ -220,6 +227,13 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 			// Loop through our tags and add the `id` option if it doesn't exist.
 			// We need to do this to ensure the dynamic tag is replaced correctly.
 			foreach ( (array) $inside_brackets as $tag ) {
+				$split_tag = preg_split( '/[\s|]/', $tag, 2 );
+				$tag_name  = $split_tag[0];
+
+				if ( ! in_array( $tag_name, $tags_list, true ) ) {
+					continue;
+				}
+
 				if ( ! generateblocks_str_contains( $tag, ' ' ) ) {
 					// There are no spaces in the tag, so there are no options.
 					$content = str_replace( $tag, "{$tag} id:{$post_id}", $tag );

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -159,8 +159,8 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 	public static function get_id( $options ) {
 		$id = get_the_ID();
 
-		if ( isset( $options['postId'] ) ) {
-			$id = absint( $options['postId'] );
+		if ( isset( $options['id'] ) ) {
+			$id = absint( $options['id'] );
 		}
 
 		return apply_filters(
@@ -208,7 +208,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 	 */
 	public function get_dynamic_tag_replacements( $request ) {
 		$content      = urldecode( $request->get_param( 'content' ) );
-		$post_id      = $request->get_param( 'postId' );
+		$post_id      = $request->get_param( 'id' );
 		$replacements = [];
 
 		// Match the content inside the curly brackets.
@@ -217,20 +217,20 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 		if ( ! empty( $matches ) ) {
 			$inside_brackets = $matches[1];
 
-			// Loop through our tags and add the `postId` option if it doesn't exist.
+			// Loop through our tags and add the `id` option if it doesn't exist.
 			// We need to do this to ensure the dynamic tag is replaced correctly.
 			foreach ( (array) $inside_brackets as $tag ) {
 				if ( ! generateblocks_str_contains( $tag, ' ' ) ) {
 					// There are no spaces in the tag, so there are no options.
-					$content = str_replace( $tag, "{$tag} postId={$post_id}", $tag );
+					$content = str_replace( $tag, "{$tag} id:{$post_id}", $tag );
 
 					$replacements[] = [
 						'original' => "{{$tag}}",
 						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{$content}}", [], new stdClass() ),
 					];
-				} elseif ( ! generateblocks_str_contains( $tag, 'postId' ) ) {
-					// There are spaces in the tag, but no `postId` option.
-					$content = str_replace( $tag, "{$tag}|postId={$post_id}", $tag );
+				} elseif ( ! generateblocks_str_contains( $tag, 'id' ) ) {
+					// There are spaces in the tag, but no `id` option.
+					$content = str_replace( $tag, "{$tag}|id:{$post_id}", $tag );
 
 					$replacements[] = [
 						'original' => "{{$tag}}",
@@ -287,7 +287,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 
 				if ( $p->next_tag(
 					[
-						'tag_name'   => 'a',
+						'tag_name' => 'a',
 					]
 				) ) {
 					$p->set_attribute( 'data-gb-router-target', 'query-' . $query_id );

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -57,7 +57,12 @@ class GenerateBlocks_Register_Dynamic_Tag {
 		}
 
 		foreach ( $pairs as $pair ) {
-			list( $key, $value ) = explode( '=', $pair );
+			if ( generateblocks_str_contains( $pair, ':' ) ) {
+				list( $key, $value ) = explode( ':', $pair, 2 );
+			} else {
+				$key = $pair;
+				$value = true; // Default value if no colon is present.
+			}
 
 			$result[ $key ] = $value;
 		}

--- a/src/dynamic-tags/components/DynamicTagModal.jsx
+++ b/src/dynamic-tags/components/DynamicTagModal.jsx
@@ -44,7 +44,7 @@ export function DynamicTagModal( { onInsert, renderToggle, tooltip, tagName, val
 					title={ __( 'Dynamic Tags', 'generateblocks' ) }
 					onRequestClose={ onToggle }
 					className="gb-dynamic-tag-modal"
-					size="medium"
+					size="large"
 				>
 					<div className="gb-dynamic-tag-modal__content">
 						<DynamicTagSelect

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -8,7 +8,7 @@ import { SelectPostType } from './SelectPostType';
 import { SelectPost } from './SelectPost';
 
 function parseTag( tagString ) {
-	const regex = /\{([\w_]+)(?:\s+(\w+(?:=(?:[^|]+))?(?:\|[\w_]+(?:=(?:[^|]+))?)*))?\}/;
+	const regex = /\{([\w_]+)(?:\s+(\w+(?::(?:[^|]+))?(?:\|[\w_]+(?::(?:[^|]+))?)*)?)?\}/;
 	const match = tagString.match( regex );
 
 	if ( ! match ) {
@@ -20,7 +20,7 @@ function parseTag( tagString ) {
 
 	if ( paramsString ) {
 		paramsString.split( '|' ).forEach( ( param ) => {
-			const [ key, value ] = param.split( '=' );
+			const [ key, value ] = param.split( ':' );
 			params[ key ] = value || true;
 		} );
 	}
@@ -74,13 +74,13 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 
 		const params = parsedTag?.params;
 
-		if ( params?.postId ) {
+		if ( params?.id ) {
 			setDynamicSource( 'post' );
-			setPostIdSource( parseInt( params.postId ) );
+			setPostIdSource( parseInt( params.id ) );
 		}
 
-		if ( params?.metaKey ) {
-			setMetaKey( params.metaKey );
+		if ( params?.key ) {
+			setMetaKey( params.key );
 		}
 
 		if ( 'comments_count' === tag ) {
@@ -101,8 +101,8 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 			setCommentsCountText( existingCommentsCountText );
 		}
 
-		if ( params?.linkTo ) {
-			setLinkTo( params.linkTo );
+		if ( params?.link ) {
+			setLinkTo( params.link );
 		}
 
 		if ( params?.renderIfEmpty ) {
@@ -143,28 +143,28 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 		const options = [];
 
 		if ( postIdSource ) {
-			options.push( `postId=${ postIdSource }` );
+			options.push( `id:${ postIdSource }` );
 		}
 
 		const isMetaTag = dynamicTag.startsWith( 'post_meta' ) ||
             dynamicTag.startsWith( 'author_meta' );
 
 		if ( isMetaTag && metaKey ) {
-			options.push( `metaKey=${ metaKey }` );
+			options.push( `key:${ metaKey }` );
 		}
 
 		if ( dynamicTag.startsWith( 'comments_count' ) ) {
-			options.push( `none=${ commentsCountText.none }` );
-			options.push( `one=${ commentsCountText.one }` );
-			options.push( `multiple=${ commentsCountText.multiple }` );
+			options.push( `none:${ commentsCountText.none }` );
+			options.push( `one:${ commentsCountText.one }` );
+			options.push( `multiple:${ commentsCountText.multiple }` );
 		}
 
 		if ( linkTo ) {
-			options.push( `linkTo=${ linkTo }` );
+			options.push( `link:${ linkTo }` );
 		}
 
 		if ( renderIfEmpty ) {
-			options.push( 'renderIfEmpty=true' );
+			options.push( 'renderIfEmpty' );
 		}
 
 		const tagOptions = options.join( '|' );
@@ -192,6 +192,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 				value={ dynamicTag }
 				options={ dynamicTagOptions }
 				onChange={ ( value ) => setDynamicTag( value ) }
+				className="gb-dynamic-tag-select"
 			/>
 
 			{ !! dynamicTag && (
@@ -273,6 +274,7 @@ export function DynamicTagSelect( { onInsert, tagName, value: selectedValue } ) 
 
 					<CheckboxControl
 						label={ __( 'Render block if empty', 'generateblocks' ) }
+						className="gb-dynamic-tag-select__render-if-empty"
 						checked={ !! renderIfEmpty }
 						onChange={ ( value ) => setRenderIfEmpty( value ) }
 						help={ __( 'Render the block even if this dynamic tag has no value.', 'generateblocks' ) }

--- a/src/dynamic-tags/editor.scss
+++ b/src/dynamic-tags/editor.scss
@@ -1,15 +1,4 @@
-.gb-dynamic-tag-content {
-	.components-popover__content {
-		width: 300px;
-	}
-}
-
 .gb-dynamic-tag-modal {
-	.components-modal__content {
-		width: 400px;
-		height: 400px;
-	}
-
 	&__content {
 		display: flex;
 		flex-direction: column;
@@ -17,6 +6,29 @@
 
 		.components-button {
 			align-self: flex-start;
+		}
+	}
+
+	.components-base-control__help {
+		margin-bottom: 0;
+	}
+
+	.gb-dynamic-tag-select__render-if-empty > * {
+		margin: 0;
+	}
+
+	.components-combobox-control__suggestions-container {
+		position: relative;
+
+		.components-form-token-field__suggestions-list {
+			position: absolute;
+			max-height: 300px;
+			background: #fff;
+			top: calc(100% + 5px);
+			border: 1px solid currentColor;
+			z-index: 1;
+			box-shadow: 0 0 0;
+			border-radius: 3px;
 		}
 	}
 }

--- a/src/hoc/withDynamicTag.js
+++ b/src/hoc/withDynamicTag.js
@@ -49,7 +49,7 @@ export function withDynamicTag( WrappedComponent ) {
 							'/generateblocks/v1/dynamic-tag-replacements?content=',
 							{
 								content: encodeURIComponent( contentValue ),
-								postId: context?.postId,
+								id: context?.postId,
 							},
 						),
 						method: 'GET',


### PR DESCRIPTION
This PR changes how dynamic tags are formatted.

Before:
`{post_title postId=123|linkTo=post|renderIfEmpty=true}`

Now:
`{post_title id:123|link:post|renderIfEmpty}`

Main differences:

1. We now use a `:` to separate keys and values.
2. We shortened the keys where possible.
3. Keys can have no value when `true` is assumed.
4. Tags that are not registered will not try to replace themselves in the editor.