### PR TITLE
Bug - Fix webpack dep extraction order

### DIFF
--- a/config/webpack-dependency-extraction.js
+++ b/config/webpack-dependency-extraction.js
@@ -1,8 +1,9 @@
 const WPDependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-const json2php = require( 'json2php' );
 
 class DependencyExtractionWebpackPlugin extends WPDependencyExtractionWebpackPlugin {
 	/**
+	 * Extend the default stringify behavior to sort dependencies by name before returning them.
+	 *
 	 * @param {any} asset Asset Data
 	 * @return {string} Stringified asset data suitable for output
 	 */
@@ -24,13 +25,8 @@ class DependencyExtractionWebpackPlugin extends WPDependencyExtractionWebpackPlu
 
 		const updatedAsset = { ...asset, dependencies: sortedDeps };
 
-		if ( this.options.outputFormat === 'php' ) {
-			return `<?php return ${ json2php(
-				JSON.parse( JSON.stringify( updatedAsset ) )
-			) };\n`;
-		}
-
-		return JSON.stringify( updatedAsset );
+		// Fallback to the original method with the updated asset.
+		return super.stringify( updatedAsset );
 	}
 }
 

--- a/config/webpack-dependency-extraction.js
+++ b/config/webpack-dependency-extraction.js
@@ -1,0 +1,37 @@
+const WPDependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const json2php = require( 'json2php' );
+
+class DependencyExtractionWebpackPlugin extends WPDependencyExtractionWebpackPlugin {
+	/**
+	 * @param {any} asset Asset Data
+	 * @return {string} Stringified asset data suitable for output
+	 */
+	stringify( asset ) {
+		const prefix = 'generateblocks-';
+		const sortedDeps = asset.dependencies.sort( ( a, b ) => {
+			const aMatches = a.startsWith( prefix );
+			const bMatches = b.startsWith( prefix );
+
+			if ( aMatches && ! bMatches ) {
+				return 1;
+			}
+			if ( bMatches && ! aMatches ) {
+				return -1;
+			}
+
+			return a.localeCompare( b );
+		} );
+
+		const updatedAsset = { ...asset, dependencies: sortedDeps };
+
+		if ( this.options.outputFormat === 'php' ) {
+			return `<?php return ${ json2php(
+				JSON.parse( JSON.stringify( updatedAsset ) )
+			) };\n`;
+		}
+
+		return JSON.stringify( updatedAsset );
+	}
+}
+
+module.exports = DependencyExtractionWebpackPlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
 				"grunt-contrib-clean": "^2.0.1",
 				"grunt-contrib-compress": "^2.0.0",
 				"grunt-contrib-copy": "^1.0.0",
-				"json2php": "^0.0.9",
 				"webpack-remove-empty-scripts": "^1.0.4"
 			}
 		},
@@ -15608,12 +15607,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-		},
-		"node_modules/json2php": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
-			"integrity": "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw==",
-			"dev": true
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@dnd-kit/utilities": "^3.2.2",
 				"@edge22/block-styles": "^1.1.18",
 				"@edge22/components": "^1.1.3",
-				"@edge22/styles-builder": "^1.1.32",
+				"@edge22/styles-builder": "^1.1.33",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
 				"@wordpress/components": "^25.10.0",
@@ -45,6 +45,7 @@
 				"grunt-contrib-clean": "^2.0.1",
 				"grunt-contrib-compress": "^2.0.0",
 				"grunt-contrib-copy": "^1.0.0",
+				"json2php": "^0.0.9",
 				"webpack-remove-empty-scripts": "^1.0.4"
 			}
 		},
@@ -2223,9 +2224,9 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.1.32",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.1.32.tgz",
-			"integrity": "sha512-+sKszv4h+dnWjJJmqjJ+E/Yg9nyXAOrLYsopTTW4lekZ9ifr8BZedlIv4HFPPa8Fs0NaNlhATzgFGM7u6AIQFQ==",
+			"version": "1.1.33",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.1.33.tgz",
+			"integrity": "sha512-UXQYF5fBxUDLFVfZvfjvq6OPkm9aF1lLwLuNAf4YTpcyA/80SbM7EyS435hMkSXmlgeVeacgY8vWJ5XGT8HHeQ==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",
@@ -5941,6 +5942,12 @@
 			"peerDependencies": {
 				"webpack": "^5.0.0"
 			}
+		},
+		"node_modules/@wordpress/dependency-extraction-webpack-plugin/node_modules/json2php": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.7.tgz",
+			"integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
+			"dev": true
 		},
 		"node_modules/@wordpress/deprecated": {
 			"version": "3.58.0",
@@ -15603,9 +15610,9 @@
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
 		"node_modules/json2php": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.7.tgz",
-			"integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
+			"integrity": "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw==",
 			"dev": true
 		},
 		"node_modules/json5": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@dnd-kit/utilities": "^3.2.2",
 		"@edge22/block-styles": "^1.1.18",
 		"@edge22/components": "^1.1.3",
-		"@edge22/styles-builder": "^1.1.32",
+		"@edge22/styles-builder": "^1.1.33",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",
 		"@wordpress/components": "^25.10.0",
@@ -54,6 +54,7 @@
 		"grunt-contrib-clean": "^2.0.1",
 		"grunt-contrib-compress": "^2.0.0",
 		"grunt-contrib-copy": "^1.0.0",
+		"json2php": "^0.0.9",
 		"webpack-remove-empty-scripts": "^1.0.4"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"grunt-contrib-clean": "^2.0.1",
 		"grunt-contrib-compress": "^2.0.0",
 		"grunt-contrib-copy": "^1.0.0",
-		"json2php": "^0.0.9",
 		"webpack-remove-empty-scripts": "^1.0.4"
 	},
 	"scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const {
 	camelCaseDash,
 } = require( '@wordpress/dependency-extraction-webpack-plugin/lib/util' );
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const DependencyExtractionWebpackPlugin = require( './config/webpack-dependency-extraction' );
 
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const ESLintPlugin = require( 'eslint-webpack-plugin' );


### PR DESCRIPTION
This PR adds a customized version of the DependencyExtractionWebpackPlugin that has a sorted assets array that places all of our plugin specific deps last to ensure they load as expected. 

Includes a bump for the styles-builder to fix an issue with border values