### PR TITLE
Tweak: Use consistent `withUniqueId`

### DIFF
--- a/src/blocks/loop-item/edit.js
+++ b/src/blocks/loop-item/edit.js
@@ -2,8 +2,9 @@ import { useBlockProps, InspectorControls, useInnerBlocksProps } from '@wordpres
 import { useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import { BlockSettings } from './components/BlockSettings';
 import BlockAppender from '../element/components/BlockAppender';

--- a/src/blocks/looper/edit.js
+++ b/src/blocks/looper/edit.js
@@ -2,17 +2,18 @@ import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import { LoopInnerBlocksRenderer } from './components/LoopInnerBlocksRenderer';
 import { BlockSettings } from './components/BlockSettings';
 import { selectorShortcuts as defaultSelectorShortcuts } from '@utils/selectorShortcuts.js';
-
-import './editor.scss';
 import { withEmptyObjectFix } from '@hoc/withEmptyObjectFix';
 import { withStyles } from '@hoc/withStyles';
 import { BlockStylesBuilder } from '@components/index';
+
+import './editor.scss';
 
 function EditBlock( props ) {
 	const {

--- a/src/blocks/query-page-numbers/edit.js
+++ b/src/blocks/query-page-numbers/edit.js
@@ -1,9 +1,10 @@
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
 import { __ } from '@wordpress/i18n';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import { BlockSettings } from './components/BlockSettings';
 import { withEmptyObjectFix } from '@hoc/withEmptyObjectFix';

--- a/src/blocks/query-terms-list/edit.js
+++ b/src/blocks/query-terms-list/edit.js
@@ -1,10 +1,10 @@
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
-import { getCss } from '@edge22/styles-builder';
 import { __ } from '@wordpress/i18n';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import { BlockSettings } from './components/BlockSettings';
 import { withEmptyObjectFix } from '@hoc/withEmptyObjectFix';
@@ -66,17 +66,6 @@ function EditBlock( props ) {
 			setAttributes( { tagName: 'div' } );
 		}
 	}, [ tagName ] );
-
-	useEffect( () => {
-		if ( ! selector ) {
-			return;
-		}
-
-		( async function() {
-			const generateCss = await getCss( selector, styles );
-			setAttributes( { css: generateCss } );
-		}() );
-	}, [ JSON.stringify( styles ), selector ] );
 
 	const { style = '', ...otherAttributes } = htmlAttributes;
 	const inlineStyleObject = convertInlineStyleStringToObject( style );

--- a/src/blocks/query/edit.js
+++ b/src/blocks/query/edit.js
@@ -2,8 +2,9 @@ import { useBlockProps, InspectorControls, useInnerBlocksProps } from '@wordpres
 import { useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import RootElement from '../../components/root-element/index.js';
 import { TemplateSelector } from '@components/template-selector';

--- a/src/blocks/shape/edit.js
+++ b/src/blocks/shape/edit.js
@@ -1,8 +1,9 @@
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withUniqueId } from '../../hoc';
-import { BlockStyles } from '@edge22/block-styles';
+
+import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import sanitizeSVG from '../../utils/sanitize-svg/index.js';
 import RootElement from '../../components/root-element/index.js';

--- a/src/blocks/text/edit.js
+++ b/src/blocks/text/edit.js
@@ -2,8 +2,10 @@ import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { withDynamicTag } from '../../hoc/withDynamicTag';
+
 import { BlockStyles, withUniqueId } from '@edge22/block-styles';
+
+import { withDynamicTag } from '../../hoc/withDynamicTag';
 import { LinkBlockToolbar } from '../../components/link-block-toolbar/LinkBlockToolbar.jsx';
 import { convertInlineStyleStringToObject } from '../element/utils.js';
 import { Icon } from './components/Icon.jsx';


### PR DESCRIPTION
This uses the `withUniqueId` hoc provided in the Block Styles package across all of our new blocks.