### PR TITLE
Tweak: Handle dynamic IDs as image src

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -25,6 +25,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 		add_filter( 'render_block', [ $this, 'replace_tags' ], 10, 3 );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		add_filter( 'generateblocks_before_dynamic_tag_replace', [ $this, 'before_tag_replace' ], 10, 2 );
+		add_filter( 'generateblocks_dynamic_tag_replacement', [ $this, 'alter_replacement' ], 10, 2 );
 	}
 
 	/**
@@ -524,6 +525,29 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Alter replacement.
+	 *
+	 * @param string $replacement The replacement.
+	 * @param array  $args The arguments.
+	 * @return string
+	 */
+	public function alter_replacement( $replacement, $args ) {
+		if ( isset( $args['block']['blockName'] ) && 'generateblocks/media' === $args['block']['blockName'] ) {
+			$src = $args['block']['attrs']['htmlAttributes']['src'] ?? '';
+
+			if ( $src && $src === $args['tag'] && is_int( $replacement ) ) {
+				$url = wp_get_attachment_url( $replacement, 'full' );
+
+				if ( $url ) {
+					$replacement = $url;
+				}
+			}
+		}
+
+		return $replacement;
 	}
 
 	/**

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -101,6 +101,29 @@ class GenerateBlocks_Register_Dynamic_Tag {
 				$full_tag = self::maybe_prepend_protocol( $content, $full_tag );
 				$replacement = $data['return']( [], $block, $instance );
 
+				/**
+				 * Allow developers to filter the replacement.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param string $replacement The replacement.
+				 * @param string $full_tag The full tag.
+				 * @param mixed  $content The replacement.
+				 * @param array  $block The block.
+				 * @param Object $instance The block instance.
+				 */
+				$replacement = apply_filters(
+					'generateblocks_dynamic_tag_replacement',
+					$replacement,
+					[
+						'tag'      => $full_tag,
+						'content'  => $content,
+						'block'    => $block,
+						'instance' => $instance,
+						'options'  => [],
+					]
+				);
+
 				if ( ! $replacement ) {
 					// If we have no replacement, don't output the block.
 					// There's an option to output the block even if there's no replacement within
@@ -144,6 +167,29 @@ class GenerateBlocks_Register_Dynamic_Tag {
 					$options          = self::parse_options( $options_string, $tag_name );
 					$replacement      = $data['return']( $options, $block, $instance );
 					$render_if_empty  = $options['renderIfEmpty'] ?? false;
+
+					/**
+					 * Allow developers to filter the replacement.
+					 *
+					 * @since 2.0.0
+					 *
+					 * @param string $replacement The replacement.
+					 * @param string $full_tag The full tag.
+					 * @param mixed  $content The replacement.
+					 * @param array  $block The block.
+					 * @param Object $instance The block instance.
+					 */
+					$replacement = apply_filters(
+						'generateblocks_dynamic_tag_replacement',
+						$replacement,
+						[
+							'tag'      => $full_tag,
+							'content'  => $content,
+							'block'    => $block,
+							'instance' => $instance,
+							'options'  => $options,
+						]
+					);
 
 					if ( ! $replacement && ! $render_if_empty ) {
 						$content = '';

--- a/src/blocks/media/components/Image.jsx
+++ b/src/blocks/media/components/Image.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef } from '@wordpress/element';
 import { ImagePlaceholder } from './ImagePlaceholder.jsx';
 import { useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { isURL } from '@wordpress/url';
 
 export function Image( {
 	elementAttributes,
@@ -43,7 +44,7 @@ export function Image( {
 	] );
 
 	const imageSrc = useMemo( () => {
-		if ( dynamicTagValue?.[ 0 ]?.replacement ) {
+		if ( dynamicTagValue?.[ 0 ]?.replacement && isURL( dynamicTagValue?.[ 0 ]?.replacement ) ) {
 			return dynamicTagValue?.[ 0 ]?.replacement;
 		}
 


### PR DESCRIPTION
If a dynamic tag returns an ID in an image src, we should take that ID and try to get the URL.