### PR TITLE
Refactor: Improve media ID extraction

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -548,6 +548,35 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 			}
 		}
 
+		// If our image `src` is an ID, add the `data-media-id` attribute so we can alter the image output later.
+		if ( isset( $args['block']['blockName'] ) && 'generateblocks/media' === $args['block']['blockName'] ) {
+			$src = $args['block']['attrs']['htmlAttributes']['src'] ?? '';
+
+			if ( $src && $src === $args['tag'] && class_exists( 'WP_HTML_Tag_Processor' ) ) {
+				$processor = new WP_HTML_Tag_Processor( $content );
+
+				if ( $processor->next_tag( 'img' ) ) {
+					$media_id    = 0;
+					$replacement = $args['original_replacement'];
+
+					if ( is_int( $replacement ) ) {
+						$media_id = $replacement;
+					} elseif ( generateblocks_str_starts_with( $args['tag'], '{featured_image_url' ) ) {
+						$media_id = GenerateBlocks_Dynamic_Tag_Callbacks::get_featured_image_id(
+							$args['options'],
+							$args['block'],
+							$args['instance']
+						);
+					}
+
+					if ( $media_id ) {
+						$processor->set_attribute( 'data-media-id', $media_id );
+						$content = $processor->get_updated_html();
+					}
+				}
+			}
+		}
+
 		return $content;
 	}
 

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -163,13 +163,13 @@ class GenerateBlocks_Register_Dynamic_Tag {
 				preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER );
 
 				foreach ( $matches as $match ) {
-					$full_tag         = $match[0];
-					$full_tag         = self::maybe_prepend_protocol( $content, $full_tag );
-					$options_string   = $match[2] ?? '';
-					$options          = self::parse_options( $options_string, $tag_name );
-					$replacement      = $data['return']( $options, $block, $instance );
-					$og_replacement   = $replacement; // Keep a copy of this in case it's manipulated via filter.
-					$render_if_empty  = $options['renderIfEmpty'] ?? false;
+					$full_tag        = $match[0];
+					$full_tag        = self::maybe_prepend_protocol( $content, $full_tag );
+					$options_string  = $match[2] ?? '';
+					$options         = self::parse_options( $options_string, $tag_name );
+					$replacement     = $data['return']( $options, $block, $instance );
+					$og_replacement  = $replacement; // Keep a copy of this in case it's manipulated via filter.
+					$render_if_empty = $options['renderIfEmpty'] ?? false;
 
 					/**
 					 * Allow developers to filter the replacement.

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -98,8 +98,9 @@ class GenerateBlocks_Register_Dynamic_Tag {
 			$full_tag = $opening_tag . '}';
 
 			if ( generateblocks_str_contains( $content, $full_tag ) ) {
-				$full_tag = self::maybe_prepend_protocol( $content, $full_tag );
-				$replacement = $data['return']( [], $block, $instance );
+				$full_tag       = self::maybe_prepend_protocol( $content, $full_tag );
+				$replacement    = $data['return']( [], $block, $instance );
+				$og_replacement = $replacement; // Keep a copy of this in case it's manipulated via filter.
 
 				/**
 				 * Allow developers to filter the replacement.
@@ -147,11 +148,12 @@ class GenerateBlocks_Register_Dynamic_Tag {
 					'generateblocks_before_dynamic_tag_replace',
 					$content,
 					[
-						'tag'         => $full_tag,
-						'replacement' => $replacement,
-						'block'       => $block,
-						'instance'    => $instance,
-						'options'     => [],
+						'tag'                  => $full_tag,
+						'replacement'          => $replacement,
+						'original_replacement' => $og_replacement,
+						'block'                => $block,
+						'instance'             => $instance,
+						'options'              => [],
 					]
 				);
 
@@ -166,6 +168,7 @@ class GenerateBlocks_Register_Dynamic_Tag {
 					$options_string   = $match[2] ?? '';
 					$options          = self::parse_options( $options_string, $tag_name );
 					$replacement      = $data['return']( $options, $block, $instance );
+					$og_replacement   = $replacement; // Keep a copy of this in case it's manipulated via filter.
 					$render_if_empty  = $options['renderIfEmpty'] ?? false;
 
 					/**
@@ -211,11 +214,12 @@ class GenerateBlocks_Register_Dynamic_Tag {
 						'generateblocks_before_dynamic_tag_replace',
 						$content,
 						[
-							'tag'         => $full_tag,
-							'replacement' => $replacement,
-							'block'       => $block,
-							'instance'    => $instance,
-							'options'     => $options,
+							'tag'                  => $full_tag,
+							'replacement'          => $replacement,
+							'original_replacement' => $og_replacement,
+							'block'                => $block,
+							'instance'             => $instance,
+							'options'              => $options,
 						]
 					);
 

--- a/src/blocks/media/components/BlockSettings.jsx
+++ b/src/blocks/media/components/BlockSettings.jsx
@@ -152,10 +152,6 @@ export function BlockSettings( {
 							src: value,
 						};
 
-						if ( newHtmlAttributes?.[ 'data-media-id' ] ) {
-							delete newHtmlAttributes[ 'data-media-id' ];
-						}
-
 						setAttributes( {
 							htmlAttributes: newHtmlAttributes,
 						} );
@@ -167,13 +163,6 @@ export function BlockSettings( {
 							...htmlAttributes,
 							src: value,
 						};
-						const featuredImageIdTag = value.startsWith( '{featured_image_url' )
-							? value.replace( '{featured_image_url', '{featured_image_id' )
-							: null;
-
-						if ( featuredImageIdTag ) {
-							newHtmlAttributes[ 'data-media-id' ] = featuredImageIdTag;
-						}
 
 						setAttributes( {
 							htmlAttributes: newHtmlAttributes,

--- a/src/blocks/media/edit.js
+++ b/src/blocks/media/edit.js
@@ -83,10 +83,6 @@ function EditBlock( props ) {
 				width: image.width,
 			};
 
-			if ( newAttributes?.[ 'data-media-id' ] ) {
-				delete newAttributes[ 'data-media-id' ];
-			}
-
 			setAttributes( {
 				htmlAttributes: newAttributes,
 				mediaId: image.id ?? 0,

--- a/src/blocks/query/templates.js
+++ b/src/blocks/query/templates.js
@@ -258,7 +258,6 @@ export const templates = [
 								htmlAttributes: {
 									src: '{featured_image_url}',
 									alt: '{post_title}',
-									'data-media-id': '{featured_image_id}',
 								},
 								styles: {
 									marginBottom: '30px',


### PR DESCRIPTION
Instead of relying on JS to add/remove the `data-media-id` attribute when using a dynamic featured image URL, this PR uses PHP to automatically add the data attribute if necessary.