### PR TITLE
Dynamic Tags - Add Options and sub field support

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -210,8 +210,8 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			return is_string( $parent_value ) ? $parent_value : '';
 		}
 
-		$sub_name     = $parts[1];
-		$sub_value    = self::maybe_get_property( $parent_value, $sub_name );
+		$sub_name  = $parts[1];
+		$sub_value = self::maybe_get_property( $parent_value, $sub_name );
 
 		if ( is_array( $sub_value ) || is_object( $sub_value ) ) {
 			return self::get_value(
@@ -331,7 +331,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_post_meta( $options ) {
 		$id          = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$key         = $options['key'] ?? '';
-		$key_parts   = explode( '.', $key );
+		$key_parts   = array_map( 'trim', explode( '.', $key ) );
 		$parent_name = $key_parts[0];
 
 		if ( empty( $key ) ) {
@@ -356,7 +356,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			$key
 		);
 
-		$meta   = is_string( $pre_value ) ? $pre_value : get_post_meta( $id, $parent_name, true );
+		$meta   = $pre_value ? $pre_value : get_post_meta( $id, $parent_name, true );
 		$value  = self::get_value( $key, $meta );
 		$output = '';
 
@@ -517,7 +517,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		$id          = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$user_id     = get_post_field( 'post_author', $id );
 		$key         = $options['key'] ?? '';
-		$key_parts   = explode( '.', $key );
+		$key_parts   = array_map( 'trim', explode( '.', $key ) );
 		$parent_name = $key_parts[0];
 		$output      = '';
 
@@ -651,7 +651,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_term_meta( $options ) {
 		$id          = GenerateBlocks_Dynamic_Tags::get_id( $options );
 		$key         = $options['key'] ?? '';
-		$key_parts   = explode( '.', $key );
+		$key_parts   = array_map( 'trim', explode( '.', $key ) );
 		$parent_name = $key_parts[0];
 
 		if ( empty( $key ) ) {
@@ -676,7 +676,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			$key
 		);
 
-		$meta   = is_string( $pre_value ) ? $pre_value : get_term_meta( $id, $parent_name, true );
+		$meta   = $pre_value ? $pre_value : get_term_meta( $id, $parent_name, true );
 		$value  = self::get_value( $key, $meta );
 		$output = '';
 
@@ -700,7 +700,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	public static function get_user_meta( $options ) {
 		$id          = GenerateBlocks_Dynamic_Tags::get_id( $options, 'user' );
 		$key         = $options['key'] ?? '';
-		$key_parts   = explode( '.', $key );
+		$key_parts   = array_map( 'trim', explode( '.', $key ) );
 		$parent_name = $key_parts[0];
 
 		if ( empty( $key ) ) {
@@ -725,7 +725,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			$key
 		);
 
-		$meta   = is_string( $pre_value ) ? $pre_value : get_user_meta( $id, $parent_name, true );
+		$meta   = $pre_value ? $pre_value : get_user_meta( $id, $parent_name, true );
 		$value  = self::get_value( $key, $meta );
 		$output = '';
 
@@ -750,7 +750,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 		$id          = 'option';
 		$default     = $options['default'] ?? '';
 		$key         = $options['key'] ?? '';
-		$key_parts   = explode( '.', $key );
+		$key_parts   = array_map( 'trim', explode( '.', $key ) );
 		$parent_name = $key_parts[0];
 
 		if ( empty( $key ) ) {
@@ -775,7 +775,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			$key
 		);
 
-		$meta   = is_string( $pre_value ) ? $pre_value : get_option( $parent_name, $default );
+		$meta   = null !== $pre_value ? $pre_value : get_option( $parent_name, $default );
 		$value  = self::get_value( $key, $meta );
 		$output = '';
 

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -649,7 +649,7 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_user_meta( $options ) {
-		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options );
+		$id     = GenerateBlocks_Dynamic_Tags::get_id( $options, 'user' );
 		$key    = $options['key'] ?? '';
 
 		if ( empty( $key ) ) {

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -98,7 +98,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'Post Meta', 'generateblocks' ),
 				'tag'    => 'post_meta',
 				'type'   => 'post',
-				'supports' => [],
+				'supports' => [ 'meta' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_post_meta' ],
 			]
 		);
@@ -128,7 +128,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'Comments Count', 'generateblocks' ),
 				'tag'    => 'comments_count',
 				'type'   => 'post',
-				'supports' => [ 'link' ],
+				'supports' => [ 'link', 'comments' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_the_comments_count' ],
 			]
 		);
@@ -138,7 +138,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'Comments URL', 'generateblocks' ),
 				'tag'    => 'comments_url',
 				'type'   => 'post',
-				'supports' => [],
+				'supports' => [ 'comments' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_the_comments_url' ],
 			]
 		);
@@ -148,7 +148,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'Author Meta', 'generateblocks' ),
 				'tag'    => 'author_meta',
 				'type'   => 'author',
-				'supports' => [],
+				'supports' => [ 'meta' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_author_meta' ],
 			]
 		);
@@ -208,7 +208,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'Term Meta', 'generateblocks' ),
 				'tag'    => 'term_meta',
 				'type'   => 'term',
-				'supports' => [],
+				'supports' => [ 'meta' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_term_meta' ],
 			]
 		);
@@ -218,8 +218,18 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'title'  => __( 'User Meta', 'generateblocks' ),
 				'tag'    => 'user_meta',
 				'type'   => 'user',
-				'supports' => [],
+				'supports' => [ 'meta' ],
 				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_user_meta' ],
+			]
+		);
+
+		new GenerateBlocks_Register_Dynamic_Tag(
+			[
+				'title'  => __( 'Option', 'generateblocks' ),
+				'tag'    => 'option',
+				'type'   => 'option',
+				'supports' => [ 'meta' ],
+				'return' => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_option' ],
 			]
 		);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@dnd-kit/utilities": "^3.2.2",
 				"@edge22/block-styles": "^1.1.21",
 				"@edge22/components": "^1.1.14",
-				"@edge22/styles-builder": "^1.2.1",
+				"@edge22/styles-builder": "^1.2.3",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
 				"@wordpress/components": "^25.10.0",
@@ -2224,9 +2224,9 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.1.tgz",
-			"integrity": "sha512-Gk4vOMSmWcS/CQlokqqJ9vI6S3qsLmBhwebHkz2YyOc8DCXMDiZk3bHj5I+9ij3FKfhP3ChkrmWBwXAmZJQiug==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.3.tgz",
+			"integrity": "sha512-6wwRkpRPxSlXuoVG8qYfeg7Bvil7HjtmrTLmRwQBuciNI2EWasQPFTaZKBrQM+cjxD6BrPMYIkr14gOAb0W+HA==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@dnd-kit/utilities": "^3.2.2",
 		"@edge22/block-styles": "^1.1.21",
 		"@edge22/components": "^1.1.14",
-		"@edge22/styles-builder": "^1.2.1",
+		"@edge22/styles-builder": "^1.2.3",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",
 		"@wordpress/components": "^25.10.0",


### PR DESCRIPTION
### New
- Adds support for getting site options
- Added universal sub-field support for native and 3rd party meta fields. If you have an array or object meta value, you can retrieve a sub key on it, nested at any level of depth you wish. 

### Improved
- Improved logic around values handling

### Fixed
- Fixed various UI and logic errors