### PR TITLE
Tweak: Switch required tag option logic

### DIFF
--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -125,12 +125,11 @@ class GenerateBlocks_Register_Dynamic_Tag {
 					]
 				);
 
+				// Tags are required to have a value by default. Since this tag has no options,
+				// we can remove the block and break out of the loop if there is no replacement.
 				if ( ! $replacement ) {
-					// If we have no replacement, don't output the block.
-					// There's an option to output the block even if there's no replacement within
-					// the next condition.
 					$content = '';
-					continue;
+					break;
 				}
 
 				/**
@@ -163,13 +162,13 @@ class GenerateBlocks_Register_Dynamic_Tag {
 				preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER );
 
 				foreach ( $matches as $match ) {
-					$full_tag        = $match[0];
-					$full_tag        = self::maybe_prepend_protocol( $content, $full_tag );
-					$options_string  = $match[2] ?? '';
-					$options         = self::parse_options( $options_string, $tag_name );
-					$replacement     = $data['return']( $options, $block, $instance );
-					$og_replacement  = $replacement; // Keep a copy of this in case it's manipulated via filter.
-					$render_if_empty = $options['renderIfEmpty'] ?? false;
+					$full_tag       = $match[0];
+					$full_tag       = self::maybe_prepend_protocol( $content, $full_tag );
+					$options_string = $match[2] ?? '';
+					$options        = self::parse_options( $options_string, $tag_name );
+					$replacement    = $data['return']( $options, $block, $instance );
+					$og_replacement = $replacement; // Keep a copy of this in case it's manipulated via filter.
+					$required       = isset( $options['required'] ) && 'false' === $options['required'] ? false : true;
 
 					/**
 					 * Allow developers to filter the replacement.
@@ -194,9 +193,11 @@ class GenerateBlocks_Register_Dynamic_Tag {
 						]
 					);
 
-					if ( '' === $replacement && ! $render_if_empty ) {
+					// If this tag is required for the block to render and there is no replacement,
+					// we can remove the block and break out of the loop.
+					if ( $required && ! $replacement ) {
 						$content = '';
-						continue;
+						break;
 					}
 
 					/**

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -164,7 +164,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 		multiple: __( '%s comments', 'generateblocks' ),
 	} );
 	const [ linkTo, setLinkTo ] = useState( '' );
-	const [ renderIfEmpty, setRenderIfEmpty ] = useState( false );
+	const [ required, setRequired ] = useState( true );
 	const [ separator, setSeparator ] = useState( '' );
 	const currentPostId = currentPost?.id ?? 0;
 
@@ -260,7 +260,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			one = null,
 			multiple = null,
 			link = null,
-			renderIfEmpty: renderIfEmptyParam = null,
+			required: requiredParam = true,
 			sep = null,
 			tax = null,
 			...extraParams
@@ -313,8 +313,8 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			setLinkTo( link );
 		}
 
-		if ( renderIfEmptyParam ) {
-			setRenderIfEmpty( true );
+		if ( 'false' === requiredParam ) {
+			setRequired( false );
 		}
 
 		if ( extraParams ) {
@@ -366,8 +366,8 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			options.push( `sep:${ separator }` );
 		}
 
-		if ( renderIfEmpty ) {
-			options.push( 'renderIfEmpty' );
+		if ( ! required ) {
+			options.push( 'required:false' );
 		}
 
 		if ( taxonomySource && 'term' === dynamicTagType ) {
@@ -409,7 +409,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 		metaKey,
 		commentsCountText,
 		linkTo,
-		renderIfEmpty,
+		required,
 		taxonomySource,
 		termSource,
 		separator,
@@ -612,11 +612,11 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 					/>
 
 					<CheckboxControl
-						label={ __( 'Render block if empty', 'generateblocks' ) }
+						label={ __( 'Required to render', 'generateblocks' ) }
 						className="gb-dynamic-tag-select__render-if-empty"
-						checked={ !! renderIfEmpty }
-						onChange={ setRenderIfEmpty }
-						help={ __( 'Render the block even if this dynamic tag has no value.', 'generateblocks' ) }
+						checked={ !! required }
+						onChange={ setRequired }
+						help={ __( 'This tag must output a value for the block to be rendered.', 'generateblocks' ) }
 					/>
 
 					<Button


### PR DESCRIPTION
This PR flips the logic when it comes to dynamic tags that have no value.

By default, all tags are required to have a value. If one of the tags in a block has no value, the entire block will not render.

This can be prevented by adding `required:false` to any non-essential tags.