### PR TITLE
Feature: Allow list tag names in loops

### DIFF
--- a/src/blocks/element/components/BlockSettings.jsx
+++ b/src/blocks/element/components/BlockSettings.jsx
@@ -14,6 +14,7 @@ import {
 	GridColumnSelector,
 	gridColumnLayouts as layouts,
 	DynamicTagsOnboarder,
+	IdAttributeControl,
 } from '@components/index.js';
 import { useBlockStyles } from '@hooks/useBlockStyles';
 import { getElementType } from '../utils/getElementType';
@@ -158,6 +159,18 @@ export function BlockSettings( {
 						</Notice>
 					</BaseControl>
 				) }
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
+					} }
+				/>
 			</OpenPanel>
 
 			<OpenPanel

--- a/src/blocks/loop-item/block.json
+++ b/src/blocks/loop-item/block.json
@@ -20,7 +20,8 @@
 			"enum": [
 				"div",
 				"article",
-				"a"
+				"a",
+				"li"
 			]
 		},
 		"styles": {

--- a/src/blocks/loop-item/components/BlockSettings.jsx
+++ b/src/blocks/loop-item/components/BlockSettings.jsx
@@ -7,6 +7,7 @@ import {
 	ApplyFilters,
 	URLControls,
 	TagNameControl,
+	IdAttributeControl,
 } from '@components/index.js';
 import { useBlockStyles } from '@hooks/useBlockStyles';
 
@@ -85,6 +86,18 @@ export function BlockSettings( {
 						</Notice>
 					</BaseControl>
 				) }
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
+					} }
+				/>
 			</OpenPanel>
 		</ApplyFilters>
 	);

--- a/src/blocks/looper/block.json
+++ b/src/blocks/looper/block.json
@@ -25,7 +25,9 @@
 				"header",
 				"footer",
 				"nav",
-				"main"
+				"main",
+				"ul",
+				"ol"
 			]
 		},
 		"styles": {

--- a/src/blocks/looper/components/BlockSettings.jsx
+++ b/src/blocks/looper/components/BlockSettings.jsx
@@ -5,6 +5,7 @@ import { OpenPanel } from '@edge22/components';
 import {
 	ApplyFilters,
 	GridColumnSelector,
+	TagNameControl,
 } from '@components/index.js';
 import { moreDesignOptions } from '@utils';
 import { useBlockStyles } from '@hooks/useBlockStyles';
@@ -25,6 +26,10 @@ export function BlockSettings( {
 		attributes,
 		setAttributes,
 	};
+
+	const {
+		tagName,
+	} = attributes;
 
 	return (
 		<ApplyFilters
@@ -57,7 +62,15 @@ export function BlockSettings( {
 				{ ...panelProps }
 				title={ __( 'Settings', 'generateblocks' ) }
 				panelId="settings"
-			/>
+			>
+				<TagNameControl
+					blockName="generateblocks/looper"
+					value={ tagName }
+					onChange={ ( value ) => {
+						setAttributes( { tagName: value } );
+					} }
+				/>
+			</OpenPanel>
 		</ApplyFilters>
 	);
 }

--- a/src/blocks/looper/components/BlockSettings.jsx
+++ b/src/blocks/looper/components/BlockSettings.jsx
@@ -5,6 +5,7 @@ import { OpenPanel } from '@edge22/components';
 import {
 	ApplyFilters,
 	GridColumnSelector,
+	IdAttributeControl,
 	TagNameControl,
 } from '@components/index.js';
 import { moreDesignOptions } from '@utils';
@@ -29,6 +30,7 @@ export function BlockSettings( {
 
 	const {
 		tagName,
+		htmlAttributes,
 	} = attributes;
 
 	return (
@@ -68,6 +70,18 @@ export function BlockSettings( {
 					value={ tagName }
 					onChange={ ( value ) => {
 						setAttributes( { tagName: value } );
+					} }
+				/>
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
 					} }
 				/>
 			</OpenPanel>

--- a/src/blocks/media/components/BlockSettings.jsx
+++ b/src/blocks/media/components/BlockSettings.jsx
@@ -13,6 +13,7 @@ import {
 	URLControls,
 	DynamicTagsOnboarder,
 	UnitControl,
+	IdAttributeControl,
 } from '@components/index.js';
 import { useBlockStyles } from '@hooks/useBlockStyles';
 
@@ -245,6 +246,18 @@ export function BlockSettings( {
 							htmlAttributes: {
 								...htmlAttributes,
 								alt: value,
+							},
+						} );
+					} }
+				/>
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
 							},
 						} );
 					} }

--- a/src/blocks/query-page-numbers/components/BlockSettings.jsx
+++ b/src/blocks/query-page-numbers/components/BlockSettings.jsx
@@ -1,11 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import { RangeControl, SelectControl } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
+import { RangeControl } from '@wordpress/components';
 
 import { OpenPanel } from '@edge22/components';
 
 import {
 	ApplyFilters,
+	IdAttributeControl,
+	TagNameControl,
 } from '@components/index.js';
 
 export function BlockSettings( {
@@ -18,13 +19,8 @@ export function BlockSettings( {
 	const {
 		midSize,
 		tagName,
+		htmlAttributes,
 	} = attributes;
-
-	const tagNames = getBlockType( 'generateblocks/query-page-numbers' )?.attributes?.tagName?.enum;
-	const tagNameOptions = tagNames.map( ( tag ) => ( {
-		label: tag,
-		value: tag,
-	} ) );
 
 	const panelProps = {
 		name,
@@ -56,11 +52,24 @@ export function BlockSettings( {
 					max="10"
 				/>
 
-				<SelectControl
-					label={ __( 'Tag Name' ) }
+				<TagNameControl
+					blockName="generateblocks/query-page-numbers"
 					value={ tagName }
-					options={ tagNameOptions }
-					onChange={ ( value ) => setAttributes( { tagName: value } ) }
+					onChange={ ( value ) => {
+						setAttributes( { tagName: value } );
+					} }
+				/>
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
+					} }
 				/>
 			</OpenPanel>
 		</ApplyFilters>

--- a/src/blocks/query/components/BlockSettings.jsx
+++ b/src/blocks/query/components/BlockSettings.jsx
@@ -4,6 +4,8 @@ import { OpenPanel } from '@edge22/components';
 
 import {
 	ApplyFilters,
+	IdAttributeControl,
+	TagNameControl,
 } from '@components/index.js';
 
 import { QueryInspectorControls } from './QueryInspectorControls';
@@ -19,6 +21,11 @@ export function BlockSettings( {
 		attributes,
 		setAttributes,
 	};
+
+	const {
+		tagName,
+		htmlAttributes,
+	} = attributes;
 
 	return (
 		<ApplyFilters
@@ -42,7 +49,27 @@ export function BlockSettings( {
 				{ ...panelProps }
 				title={ __( 'Settings', 'generateblocks' ) }
 				panelId="settings"
-			/>
+			>
+				<TagNameControl
+					blockName="generateblocks/query"
+					value={ tagName }
+					onChange={ ( value ) => {
+						setAttributes( { tagName: value } );
+					} }
+				/>
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
+					} }
+				/>
+			</OpenPanel>
 		</ApplyFilters>
 	);
 }

--- a/src/blocks/shape/components/BlockSettings.jsx
+++ b/src/blocks/shape/components/BlockSettings.jsx
@@ -5,6 +5,7 @@ import { OpenPanel, IconControl } from '@edge22/components';
 import {
 	ApplyFilters,
 	ColorPickerControls,
+	IdAttributeControl,
 	UnitControl,
 } from '@components/index.js';
 import { moreDesignOptions } from '@utils';
@@ -36,6 +37,7 @@ export function BlockSettings( {
 	const {
 		html,
 		className,
+		htmlAttributes,
 	} = attributes;
 
 	const {
@@ -133,7 +135,19 @@ export function BlockSettings( {
 				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
-			/>
+			>
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
+					} }
+				/>
+			</OpenPanel>
 		</ApplyFilters>
 	);
 }

--- a/src/blocks/text/components/BlockSettings.jsx
+++ b/src/blocks/text/components/BlockSettings.jsx
@@ -9,6 +9,7 @@ import {
 	URLControls,
 	TagNameControl,
 	DynamicTagsOnboarder,
+	IdAttributeControl,
 } from '@components/index.js';
 import { useBlockStyles } from '@hooks/useBlockStyles';
 import generalSvgs from '@components/icon-picker/svgs-general';
@@ -93,6 +94,18 @@ export function BlockSettings( {
 						if ( 'a' === value && ! getStyleValue( 'display', currentAtRule ) ) {
 							onStyleChange( 'display', 'block' );
 						}
+					} }
+				/>
+
+				<IdAttributeControl
+					value={ htmlAttributes.id }
+					onChange={ ( value ) => {
+						setAttributes( {
+							htmlAttributes: {
+								...htmlAttributes,
+								id: value,
+							},
+						} );
 					} }
 				/>
 			</OpenPanel>

--- a/src/components/IdAttributeControl/IdAttributeControl.jsx
+++ b/src/components/IdAttributeControl/IdAttributeControl.jsx
@@ -1,0 +1,11 @@
+import { TextControl } from '@wordpress/components';
+
+export function IdAttributeControl( { value, onChange } ) {
+	return (
+		<TextControl
+			label="HTML ID"
+			value={ value }
+			onChange={ onChange }
+		/>
+	);
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -43,6 +43,7 @@ import { TagNameToolbar } from './TagNameToolbar/TagNameToolbar';
 import { BlockAppender } from './block-appender/BlockAppender';
 import SelectQueryParameter from './inspector-controls/SelectQueryParameter';
 import AddQueryParameterButton from './inspector-controls/AddQueryParameterButton';
+import { IdAttributeControl } from './IdAttributeControl/IdAttributeControl';
 
 export {
 	AdvancedSelect,
@@ -93,4 +94,5 @@ export {
 	BlockAppender,
 	SelectQueryParameter,
 	AddQueryParameterButton,
+	IdAttributeControl,
 };


### PR DESCRIPTION
This PR enables our Looper and Loop Item blocks to be lists.

It also adds an ID attribute control to our blocks.