### PR TITLE
Tweak: Improve Grid selector shortcuts

### DIFF
--- a/src/blocks/element/components/BlockSettings.jsx
+++ b/src/blocks/element/components/BlockSettings.jsx
@@ -77,7 +77,7 @@ export function BlockSettings( {
 			<OpenPanel
 				{ ...panelProps }
 				title={ __( 'Grid', 'generateblocks' ) }
-				shouldRender={ 'grid' === getStyleValue( 'display', currentAtRule ) }
+				shouldRender={ 'grid' === getStyleValue( 'display' ) }
 				panelId="grid"
 			>
 				<BaseControl
@@ -87,7 +87,19 @@ export function BlockSettings( {
 					<GridColumnSelector
 						value={ getStyleValue( 'gridTemplateColumns', currentAtRule ) }
 						onClick={ ( value ) => {
+							if ( value === getStyleValue( 'gridTemplateColumns', currentAtRule ) ) {
+								// If the same layout is clicked, remove the layout.
+								onStyleChange( 'gridTemplateColumns', '', currentAtRule );
+								return;
+							}
+
 							onStyleChange( 'gridTemplateColumns', value, currentAtRule );
+
+							if ( '' !== currentAtRule ) {
+								// Don't add/remove blocks for at rules.
+								return;
+							}
+
 							const selectedLayout = layouts.find( ( { layout } ) => layout === value );
 							const selectedLayoutDivCount = selectedLayout?.divs || 0;
 							const innerBlocksCount = getBlock( clientId ).innerBlocks.length;


### PR DESCRIPTION
This improves the grid shortcuts when using our Grid variation.

It does the following:

1. Shows the shortcuts as long as the desktop (no at-rule) style has `display: grid`, which means our Grid variation is active.
2. Changes the `grid-template-columns` value for the current at rule.
3. Only affects the blocks (adds/removes them) when no at-rule is selected.
4. Allows you to click a selected layout to remove it, bringing it in line with our control in the Styles panel.