### PR TITLE
Tweak: Button link toolbar location

### DIFF
--- a/src/blocks/text/edit.js
+++ b/src/blocks/text/edit.js
@@ -6,7 +6,6 @@ import { compose } from '@wordpress/compose';
 import { BlockStyles, withUniqueId } from '@edge22/block-styles';
 
 import { withDynamicTag } from '../../hoc/withDynamicTag';
-import { LinkBlockToolbar } from '../../components/link-block-toolbar/LinkBlockToolbar.jsx';
 import { Icon } from './components/Icon.jsx';
 import RootElement from '../../components/root-element/index.js';
 import { BlockSettings } from './components/BlockSettings';
@@ -42,7 +41,6 @@ function EditBlock( props ) {
 		icon,
 		iconLocation,
 		iconOnly,
-		htmlAttributes = {},
 	} = attributes;
 
 	useEffect( () => {
@@ -170,13 +168,6 @@ function EditBlock( props ) {
 				label={ __( 'Choose tag name', 'generateblocks' ) }
 				tagName={ tagName }
 				onChange={ ( value ) => setAttributes( { tagName: value } ) }
-			/>
-
-			<LinkBlockToolbar
-				setAttributes={ setAttributes }
-				htmlAttributes={ htmlAttributes }
-				tagName={ tagName }
-				context={ context }
 			/>
 
 			{ ! iconOnly && (

--- a/src/editor/button-link-toolbar.js
+++ b/src/editor/button-link-toolbar.js
@@ -1,0 +1,43 @@
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { LinkBlockToolbar } from '@components/link-block-toolbar';
+
+const withButtonLinkToolbar = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		const {
+			name,
+			attributes,
+			setAttributes,
+			context,
+		} = props;
+
+		const {
+			tagName,
+			htmlAttributes,
+		} = attributes;
+
+		if ( 'generateblocks/text' !== name || tagName !== 'a' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+
+				<LinkBlockToolbar
+					setAttributes={ setAttributes }
+					htmlAttributes={ htmlAttributes }
+					tagName={ tagName }
+					context={ context }
+				/>
+			</>
+		);
+	};
+}, 'withButtonLinkToolbar' );
+
+addFilter(
+	'editor.BlockEdit',
+	'generateblocks/blockControls/buttonLinkToolbar',
+	withButtonLinkToolbar,
+	100
+);

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -2,6 +2,7 @@ import wpDomReady from '@wordpress/dom-ready';
 
 import './stores.js';
 import './disable-blocks.js';
+import './button-link-toolbar.js';
 import './editor.scss';
 
 wpDomReady( () => {


### PR DESCRIPTION
This moves the link toolbar for the Button block all the way to the right, so it's more consistent with other link toolbar buttons.