### PR TITLE
Tweak: Standardize input heights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@dnd-kit/modifiers": "^7.0.0",
 				"@dnd-kit/sortable": "^8.0.0",
 				"@dnd-kit/utilities": "^3.2.2",
-				"@edge22/block-styles": "^1.1.25",
+				"@edge22/block-styles": "^1.1.26",
 				"@edge22/components": "^1.1.29",
 				"@edge22/styles-builder": "^1.2.22",
 				"@wordpress/block-editor": "^12.12.0",
@@ -2131,9 +2131,9 @@
 			}
 		},
 		"node_modules/@edge22/block-styles": {
-			"version": "1.1.25",
-			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.25.tgz",
-			"integrity": "sha512-+xw8+M1IRjtz1bGa1Ym13YY1qeZQw9DaOjBefrZbpZlu9jIhWeID0M5f/4aiGhVwgo/ypNFRVlnpQ+K0p+EXEA==",
+			"version": "1.1.26",
+			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.26.tgz",
+			"integrity": "sha512-trn8OOm5Lz4bAoP97J0NPZBjcJVNnWCZ+2hTRQ3bvc3kBb9UXPJyNzjOOf7IOa1iNoWGAkL7LTXDIrUlQS0F0g==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@dnd-kit/modifiers": "^7.0.0",
 		"@dnd-kit/sortable": "^8.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
-		"@edge22/block-styles": "^1.1.25",
+		"@edge22/block-styles": "^1.1.26",
 		"@edge22/components": "^1.1.29",
 		"@edge22/styles-builder": "^1.2.22",
 		"@wordpress/block-editor": "^12.12.0",

--- a/src/components/image-upload/ImageUpload.jsx
+++ b/src/components/image-upload/ImageUpload.jsx
@@ -52,7 +52,6 @@ export function ImageUpload( {
 							<Button
 								onClick={ open }
 								variant="secondary"
-								size="compact"
 							>
 								{ __( 'Browse', 'generateblocks' ) }
 							</Button>

--- a/src/components/url-controls/URLControls.jsx
+++ b/src/components/url-controls/URLControls.jsx
@@ -52,7 +52,7 @@ export function URLControls( {
 				id="gb-url-controls__link"
 				htmlFor="gb-url-controls__link-input"
 			>
-				<Stack layout="flex" direction="horizontal" wrap={ false } gap="0">
+				<Stack layout="flex" direction="horizontal" wrap={ false } gap="5px">
 					<URLInput
 						id="gb-url-controls__link-input"
 						className={ 'gb-url-controls__link-input' }

--- a/src/components/url-controls/editor.scss
+++ b/src/components/url-controls/editor.scss
@@ -13,3 +13,22 @@
 		}
 	}
 }
+
+
+.components-popover__content {
+	.gb-url-controls {
+		.gb-stack {
+			align-items: center;
+		}
+
+		input[type="text"] {
+			height: 35px !important;
+		}
+
+		.components-button {
+			height: 35px !important;
+			min-height: 35px !important;
+			padding: 0 10px;
+		}
+	}
+}

--- a/src/dynamic-tags/components/DynamicTagModal.jsx
+++ b/src/dynamic-tags/components/DynamicTagModal.jsx
@@ -41,7 +41,6 @@ export function DynamicTagModal( {
 			aria-expanded={ isOpen }
 			icon={ getIcon( 'database' ) }
 			label={ __( 'Dynamic tags', 'generateblocks' ) }
-			size="compact"
 		/>;
 
 		return (


### PR DESCRIPTION
This PR standardizes input heights in the "Settings" panel of our Block Styles.

There was a mix of input heights due to a change WordPress is going to make in the future.

Instead, this PR increases the height of the controls a little across all of our controls.