### PR TITLE
Tweak: Add upgrade menu item

### DIFF
--- a/assets/css/dashboard-global.css
+++ b/assets/css/dashboard-global.css
@@ -16,3 +16,15 @@
 	font-size: 18px;
 	margin-top: 1px;
 }
+
+#adminmenu #toplevel_page_generateblocks a[href="admin.php?page=generateblocks-upgrade"] {
+	font-weight: 600;
+	background-color: #0171d5;
+	color: #fff;
+	margin: 3px 10px 0;
+	display: block;
+	text-align: center;
+	border-radius: 3px;
+	transition: all .3s;
+	box-shadow: 0 0 0;
+}

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -24,6 +24,22 @@ function generateblocks_register_dashboard() {
 		'generateblocks_do_dashboard'
 	);
 
+	$show_upgrade_menu = apply_filters(
+		'generateblocks_show_upgrade_menu',
+		! defined( 'GENERATEBLOCKS_PRO_VERSION' )
+	);
+
+	if ( $show_upgrade_menu ) {
+		add_submenu_page(
+			'generateblocks',
+			__( 'Upgrade', 'generateblocks' ),
+			__( 'Upgrade', 'generateblocks' ),
+			'manage_options',
+			'generateblocks-upgrade',
+			'generateblocks_do_dashboard'
+		);
+	}
+
 	add_action( "admin_print_styles-$dashboard", 'generateblocks_enqueue_dashboard_scripts' );
 }
 
@@ -172,6 +188,14 @@ function generateblocks_dashboard_navigation() {
 		)
 	);
 
+	if ( ! defined( 'GENERATEBLOCKS_PRO_VERSION' ) ) {
+		$tabs['pro'] = array(
+			'name'  => __( 'Get Pro', 'generateblocks' ),
+			'url'   => 'https://generatepress.com/blocks/',
+			'class' => '',
+		);
+	}
+
 	// Don't print any markup if we only have one tab.
 	if ( count( $tabs ) === 1 ) {
 		return;
@@ -223,4 +247,19 @@ function generateblocks_do_dashboard() {
 			<div id="gblocks-dashboard" />
 		</div>
 	<?php
+}
+
+add_action( 'admin_init', 'generateblocks_do_upgrade_redirect' );
+/**
+ * Redirect to the sales page when landing on the upgrade page.
+ */
+function generateblocks_do_upgrade_redirect() {
+	if ( empty( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	if ( 'generateblocks-upgrade' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		wp_redirect( 'https://generatepress.com/blocks' ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		exit;
+	}
 }


### PR DESCRIPTION
We have next to no upsell messages in the admin when Pro isn't activated.

This PR adds an "Upgrade" menu item to the GenerateBlocks menu when GB Pro isn't activated.

![upgrade](https://github.com/user-attachments/assets/99b47229-3f49-41d6-b7c6-841103f94dab)

This can be disabled with a simple filter if needed:

`add_filter( 'generateblocks_show_upgrade_menu', '__return_false' );`