### PR TITLE
Fix: Dynamic tag select bugs

### DIFF
--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -164,7 +164,7 @@ function getVisibleTags( dynamicTags, context ) {
 }
 
 function getLinkToKeySourceId( linkTo, postRecord, postId, userId, termId ) {
-	if ( linkTo.includes( 'author' ) && postRecord ) {
+	if ( linkTo?.includes( 'author' ) && postRecord ) {
 		return postRecord?.post_author;
 	}
 
@@ -172,15 +172,15 @@ function getLinkToKeySourceId( linkTo, postRecord, postId, userId, termId ) {
 }
 
 function getLinkToType( linkTo ) {
-	if ( linkTo.includes( 'term' ) ) {
+	if ( linkTo?.includes( 'term' ) ) {
 		return 'term';
 	}
 
-	if ( linkTo.includes( 'author' ) ) {
+	if ( linkTo?.includes( 'author' ) ) {
 		return 'author';
 	}
 
-	if ( linkTo.includes( 'user' ) ) {
+	if ( linkTo?.includes( 'user' ) ) {
 		return 'user';
 	}
 
@@ -250,11 +250,11 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 	const postRecordArgs = useMemo( () => {
 		const options = {};
 		const load = [];
-		if ( 'author' === dynamicTagType || linkTo.includes( 'author' ) ) {
+		if ( 'author' === dynamicTagType || linkTo?.includes( 'author' ) ) {
 			load.push( 'author' );
-		} else if ( 'comment' === dynamicTagType || linkTo.includes( 'comment' ) ) {
+		} else if ( 'comment' === dynamicTagType || linkTo?.includes( 'comment' ) ) {
 			load.push( 'comments' );
-		} else if ( 'term' === dynamicTagType || linkTo.includes( 'term' ) ) {
+		} else if ( 'term' === dynamicTagType || linkTo?.includes( 'term' ) ) {
 			load.push( 'terms' );
 		} else if ( 'post' === dynamicTagType ) {
 			load.push( 'post' );
@@ -546,7 +546,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 	const interactiveTagNames = [ 'a', 'button' ];
 	const supportsLink = dynamicTagSupports.includes( 'link' );
 	const showLinkTo = supportsLink && ! interactiveTagNames.includes( tagName );
-	const showLinkToKey = showLinkTo && ( linkTo.includes( 'meta' ) || linkTo.includes( 'option' ) );
+	const showLinkToKey = showLinkTo && ( linkTo?.includes( 'meta' ) || linkTo?.includes( 'option' ) );
 	const linkToOptions = useMemo( () => {
 		if ( ! showLinkTo ) {
 			return [];

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -193,20 +193,20 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 	const allTags = generateBlocksEditor?.dynamicTags;
 	const availableTags = getVisibleTags( allTags, context );
 	const imageSizeOptions = useMemo( () => {
-		const imageSizes = generateBlocksInfo?.imageSizes ?? [];
+		const imageSizes = Array.isArray( generateBlocksInfo?.imageSizes )
+			? generateBlocksInfo.imageSizes
+			: Object.values( generateBlocksInfo?.imageSizes ?? {} );
 
-		return [
-			...imageSizes.map( ( size ) => {
-				const sanitizedSizeLabel = size
-					.replace( '-', ' ' )
-					.replace( '_', ' ' );
+		return imageSizes.map( ( size ) => {
+			const sanitizedSizeLabel = size
+				.replace( '-', ' ' )
+				.replace( '_', ' ' );
 
-				return {
-					value: size,
-					label: sanitizedSizeLabel.charAt( 0 ).toUpperCase() + sanitizedSizeLabel.slice( 1 ),
-				};
-			} ),
-		];
+			return {
+				value: size,
+				label: sanitizedSizeLabel.charAt( 0 ).toUpperCase() + sanitizedSizeLabel.slice( 1 ),
+			};
+		} );
 	}, [] );
 
 	// State.

--- a/src/dynamic-tags/editor.scss
+++ b/src/dynamic-tags/editor.scss
@@ -28,6 +28,15 @@
 
 	.components-combobox-control__suggestions-container {
 		position: relative;
+		padding: 0;
+
+		div {
+			padding: 0;
+		}
+
+		input.components-combobox-control__input[type=text] {
+			padding: 0 8px;
+		}
 
 		.components-form-token-field__suggestions-list {
 			position: absolute;


### PR DESCRIPTION
closes #1438 

This fixes a few bugs:

1. Clearing the `linkTo` comboxbox sets it to null, which causes a runtime error.
2. Activating WooCommerce changes the format of `imageSizes`. This PR normalizes the variable.
3. Inputs in the dynamic tag select are all the same height