### PR TITLE
Tweak: Remove extra block setting labels

### DIFF
--- a/src/blocks/element/components/BlockSettings.jsx
+++ b/src/blocks/element/components/BlockSettings.jsx
@@ -63,11 +63,11 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Link Destination', 'generateblocks' ) }
 				shouldRender={ 'a' === tagName && '' === currentAtRule }
 				panelId="link-destination"
 			>
 				<URLControls
+					label={ __( 'Link Destination', 'generateblocks' ) }
 					setAttributes={ setAttributes }
 					htmlAttributes={ htmlAttributes }
 					context={ context }
@@ -76,7 +76,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Grid', 'generateblocks' ) }
 				shouldRender={
 					'grid' === getStyleValue( 'display' ) &&
 					(
@@ -150,7 +149,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
 			>
@@ -180,17 +178,22 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Shapes', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="shapes"
 			>
-				<Button
-					variant="secondary"
-					size="compact"
-					onClick={ () => setOpenShapeLibrary( true ) }
+				<BaseControl
+					label={ __( 'Shape', 'generateblocks' ) }
+					id="shape"
 				>
-					{ __( 'Open Shape Library', 'generateblocks' ) }
-				</Button>
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ () => setOpenShapeLibrary( true ) }
+						style={ { display: 'block' } }
+					>
+						{ __( 'Open Shape Library', 'generateblocks' ) }
+					</Button>
+				</BaseControl>
 
 				{ !! openShapeLibrary && (
 					<IconModal
@@ -243,11 +246,11 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Inline Background Image', 'generateblocks' ) }
 				shouldRender={ 'container' === getElementType( tagName ) && '' === currentAtRule }
 				panelId="inline-background-image"
 			>
 				<InlineBackgroundImage
+					label={ __( 'Inline Background Image', 'generateblocks' ) }
 					htmlAttributes={ htmlAttributes }
 					setAttributes={ setAttributes }
 					styles={ styles }

--- a/src/blocks/element/components/InlineBackgroundImage.jsx
+++ b/src/blocks/element/components/InlineBackgroundImage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from '@wordpress/element';
 
 import { ImageUpload } from '@components/index.js';
 
-export function InlineBackgroundImage( { htmlAttributes, setAttributes, styles, onStyleChange, context } ) {
+export function InlineBackgroundImage( { htmlAttributes, setAttributes, styles, onStyleChange, context, label } ) {
 	const inlineBackgroundURL = useMemo( () => {
 		const { style = '' } = htmlAttributes;
 
@@ -110,6 +110,7 @@ export function InlineBackgroundImage( { htmlAttributes, setAttributes, styles, 
 
 	return (
 		<ImageUpload
+			label={ label }
 			value={ inlineBackgroundURL }
 			onInsert={ ( value ) => {
 				onChange( value );

--- a/src/blocks/loop-item/components/BlockSettings.jsx
+++ b/src/blocks/loop-item/components/BlockSettings.jsx
@@ -46,11 +46,11 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Link Destination', 'generateblocks' ) }
 				shouldRender={ 'a' === tagName && '' === currentAtRule }
 				panelId="link-destination"
 			>
 				<URLControls
+					label={ __( 'Link Destination', 'generateblocks' ) }
 					setAttributes={ setAttributes }
 					htmlAttributes={ htmlAttributes }
 					context={ context }
@@ -59,7 +59,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
 			>

--- a/src/blocks/looper/components/BlockSettings.jsx
+++ b/src/blocks/looper/components/BlockSettings.jsx
@@ -43,13 +43,13 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Design', 'generateblocks' ) }
 				dropdownOptions={ [
 					moreDesignOptions,
 				] }
 				panelId="design"
 			>
 				<GridColumnSelector
+					label={ __( 'Layout', 'generateblocks' ) }
 					value={ getStyleValue( 'gridTemplateColumns', currentAtRule ) }
 					onClick={ ( value ) => {
 						onStyleChange( 'display', 'grid', currentAtRule );
@@ -60,7 +60,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				panelId="settings"
 			>
 				<TagNameControl

--- a/src/blocks/media/components/BlockSettings.jsx
+++ b/src/blocks/media/components/BlockSettings.jsx
@@ -141,7 +141,6 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
 			>

--- a/src/blocks/query-page-numbers/components/BlockSettings.jsx
+++ b/src/blocks/query-page-numbers/components/BlockSettings.jsx
@@ -37,7 +37,6 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				panelId="settings"
 			>
 				<RangeControl

--- a/src/blocks/query/components/BlockSettings.jsx
+++ b/src/blocks/query/components/BlockSettings.jsx
@@ -1,5 +1,3 @@
-import { __ } from '@wordpress/i18n';
-
 import { OpenPanel } from '@edge22/components';
 
 import {
@@ -35,7 +33,6 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Query Parameters', 'generateblocks' ) }
 				panelId="query-parameters"
 			>
 				<QueryInspectorControls
@@ -45,7 +42,6 @@ export function BlockSettings( {
 			</OpenPanel>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				panelId="settings"
 			>
 				<TagNameControl

--- a/src/blocks/shape/components/BlockSettings.jsx
+++ b/src/blocks/shape/components/BlockSettings.jsx
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import { Flex, FlexBlock } from '@wordpress/components';
+
 import { OpenPanel, IconControl } from '@edge22/components';
 import { UnitControl } from '@edge22/styles-builder';
 
@@ -81,11 +83,11 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Shape', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="shape"
 			>
 				<IconControl
+					label={ __( 'Shape', 'generateblocks' ) }
 					value={ html }
 					onChange={ ( value ) => setAttributes( { html: value } ) }
 					onClear={ () => setAttributes( { html: '' } ) }
@@ -99,25 +101,30 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Design', 'generateblocks' ) }
 				dropdownOptions={ [
 					moreDesignOptions,
 				] }
 				panelId="design"
 			>
-				<UnitControl
-					id="width"
-					label={ __( 'Width', 'generateblocks' ) }
-					value={ getStyleValue( 'width', currentAtRule, 'svg' ) }
-					onChange={ ( value ) => onStyleChange( 'width', value, currentAtRule, 'svg' ) }
-				/>
+				<Flex>
+					<FlexBlock>
+						<UnitControl
+							id="width"
+							label={ __( 'Width', 'generateblocks' ) }
+							value={ getStyleValue( 'width', currentAtRule, 'svg' ) }
+							onChange={ ( value ) => onStyleChange( 'width', value, currentAtRule, 'svg' ) }
+						/>
+					</FlexBlock>
 
-				<UnitControl
-					id="height"
-					label={ __( 'Height', 'generateblocks' ) }
-					value={ getStyleValue( 'height', currentAtRule, 'svg' ) }
-					onChange={ ( value ) => onStyleChange( 'height', value, currentAtRule, 'svg' ) }
-				/>
+					<FlexBlock>
+						<UnitControl
+							id="height"
+							label={ __( 'Height', 'generateblocks' ) }
+							value={ getStyleValue( 'height', currentAtRule, 'svg' ) }
+							onChange={ ( value ) => onStyleChange( 'height', value, currentAtRule, 'svg' ) }
+						/>
+					</FlexBlock>
+				</Flex>
 
 				<ColorPickerControls
 					items={ shapeColorControls }
@@ -129,7 +136,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
 			/>

--- a/src/blocks/text/components/BlockSettings.jsx
+++ b/src/blocks/text/components/BlockSettings.jsx
@@ -67,11 +67,11 @@ export function BlockSettings( {
 		>
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Link Destination', 'generateblocks' ) }
 				shouldRender={ 'a' === tagName && '' === currentAtRule }
 				panelId="link-destination"
 			>
 				<URLControls
+					label={ __( 'Link Destination', 'generateblocks' ) }
 					setAttributes={ setAttributes }
 					htmlAttributes={ htmlAttributes }
 					context={ context }
@@ -80,7 +80,6 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Settings', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="settings"
 			>
@@ -99,11 +98,11 @@ export function BlockSettings( {
 
 			<OpenPanel
 				{ ...panelProps }
-				title={ __( 'Icon', 'generateblocks' ) }
 				shouldRender={ '' === currentAtRule }
 				panelId="icon"
 			>
 				<IconControl
+					label={ __( 'Icon', 'generateblocks' ) }
 					value={ icon }
 					onChange={ ( value ) => {
 						// If the user hasn't done this before, align the icon and text.

--- a/src/components/image-upload/ImageUpload.jsx
+++ b/src/components/image-upload/ImageUpload.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { BaseControl, Button, TextControl } from '@wordpress/components';
+import { BaseControl, Button, TextControl, useBaseControlProps } from '@wordpress/components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { Stack } from '@edge22/components';
 import { DynamicTagModal } from '../../dynamic-tags';
@@ -16,11 +16,12 @@ export function ImageUpload( {
 	onInsertDynamicTag,
 	context,
 } ) {
+	const { baseControlProps, controlProps } = useBaseControlProps( {
+		label,
+	} );
+
 	return (
-		<BaseControl
-			label={ label }
-			id=""
-		>
+		<BaseControl { ...baseControlProps }>
 			<Stack
 				className="gb-image-upload-stack"
 				layout="flex"
@@ -30,6 +31,7 @@ export function ImageUpload( {
 			>
 				{ !! showInput && (
 					<TextControl
+						{ ...controlProps }
 						value={ value }
 						onChange={ ( newValue ) => onInsert( newValue ) }
 						style={ { marginBottom: 0 } }

--- a/src/components/url-controls/URLControls.jsx
+++ b/src/components/url-controls/URLControls.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { BaseControl, ToggleControl } from '@wordpress/components';
+import { BaseControl, ToggleControl, useBaseControlProps } from '@wordpress/components';
 import { URLInput } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 
@@ -45,16 +45,16 @@ export function URLControls( {
 		}
 	}, [ target, rel ] );
 
+	const { baseControlProps, controlProps } = useBaseControlProps( {
+		label,
+	} );
+
 	return (
 		<div className="gb-url-controls components-base-control">
-			<BaseControl
-				label={ label }
-				id="gb-url-controls__link"
-				htmlFor="gb-url-controls__link-input"
-			>
+			<BaseControl { ...baseControlProps }>
 				<Stack layout="flex" direction="horizontal" wrap={ false } gap="5px">
 					<URLInput
-						id="gb-url-controls__link-input"
+						{ ...controlProps }
 						className={ 'gb-url-controls__link-input' }
 						value={ url }
 						onChange={ ( value ) => {


### PR DESCRIPTION
This removes the extra block setting panel labels, so we rely on the actual control labels only.