### PR TITLE
Fix: Block transform error

### DIFF
--- a/src/utils/convertLegacyHtmlAttributes.js
+++ b/src/utils/convertLegacyHtmlAttributes.js
@@ -1,4 +1,4 @@
-export function convertLegacyHtmlAttributes( oldHtmlAttributes ) {
+export function convertLegacyHtmlAttributes( oldHtmlAttributes = [] ) {
 	let newHtmlAttributes = {};
 
 	if ( oldHtmlAttributes.length > 0 ) {


### PR DESCRIPTION
closes #1457 

This fixes a bug where the v1 to v2 block transform throws a runtime error if GBP isn't activated.