### PR TITLE
Fix: Block multi-selection CSS generation

### DIFF
--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -115,6 +115,7 @@ export function withStyles( WrappedComponent ) {
 
 		useGenerateCSSEffect( {
 			selector,
+			getSelector,
 			styles: frontendStyles,
 			setAttributes,
 			getCss,


### PR DESCRIPTION
closes #1446 
alternative to #1450 
requires https://github.com/EDGE22-Studios/block-styles/pull/7

Major benefit here is it doesn't change how CSS is generated (via a hook). Therefore it doesn't break other functionality like #1450 (copy/paste styles).