### PR TITLE
Refactor: Improve how local block styles are set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "generateblocks",
-	"version": "2.0.0-alpha.1",
+	"version": "2.0.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "generateblocks",
-			"version": "2.0.0-alpha.1",
+			"version": "2.0.0-alpha.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@edge22/block-styles": "^1.1.27",
+				"@edge22/block-styles": "^1.1.28",
 				"@edge22/components": "^1.1.37",
-				"@edge22/styles-builder": "^1.2.31",
+				"@edge22/styles-builder": "^1.2.32",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
 				"@wordpress/components": "^25.10.0",
@@ -2128,9 +2128,9 @@
 			}
 		},
 		"node_modules/@edge22/block-styles": {
-			"version": "1.1.27",
-			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.27.tgz",
-			"integrity": "sha512-yw9b83sGuzRUn1Xpxj7PPHXi1T5doi+0lJh/2OY9hgDM3gxZZjPTv92eSudHOm8D++vmj+6ujc0f66MDYKL/Pg==",
+			"version": "1.1.28",
+			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.28.tgz",
+			"integrity": "sha512-75Np4pCCzZmb/ICcAdDTgIbBx616nqVujKLW6t6a6O2dpYbeZXpsljEqr7Vo+YqYvv63+j3zwuVy8jXN00uhRw==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",
@@ -2174,9 +2174,9 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.31",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.31.tgz",
-			"integrity": "sha512-9KA+x29AOvD4I+lOga2aD12KkLXJ9VOdmNnz72uFV/tocsh+VaGUgqRzGk/n0XU5jMnSlvDJV7bLYqWrVt0tjg==",
+			"version": "1.2.32",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.32.tgz",
+			"integrity": "sha512-IcP0qvFT4hIIWMZ3QQ2ngu9QsfFBFVMQq6gPiYaTkmksX/icEunzeuylJsScv+UPeB4NKvD+GyZ61/QkE0z50Q==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"url": "https://generateblocks.com/support"
 	},
 	"dependencies": {
-		"@edge22/block-styles": "^1.1.27",
+		"@edge22/block-styles": "^1.1.28",
 		"@edge22/components": "^1.1.37",
-		"@edge22/styles-builder": "^1.2.31",
+		"@edge22/styles-builder": "^1.2.32",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",
 		"@wordpress/components": "^25.10.0",

--- a/src/components/block-styles-builder/BlockStylesBuilder.jsx
+++ b/src/components/block-styles-builder/BlockStylesBuilder.jsx
@@ -1,20 +1,25 @@
 import { applyFilters } from '@wordpress/hooks';
 
-import { StylesBuilder, defaultAtRules } from '@edge22/styles-builder';
-import { TABS_STORAGE_KEY } from '@edge22/block-styles';
+import {
+	StylesBuilder,
+	defaultAtRules,
+	getStylesObject,
+	deleteStylesObjectKey,
+	updateStylesObjectKey,
+} from '@edge22/styles-builder';
+import {
+	TABS_STORAGE_KEY,
+} from '@edge22/block-styles';
 import { useBlockStyles } from '@hooks/useBlockStyles';
 
 export function BlockStylesBuilder( { attributes, setAttributes, shortcuts, onStyleChange, name } ) {
 	const {
-		getStyles,
-		deleteStyle,
 		atRule,
 		setAtRule,
 		nestedRule,
 		setNestedRule,
 		setDeviceType,
 		getPreviewDevice,
-		updateKey,
 		deviceType,
 		setGlobalStyle,
 		cancelEditGlobalStyle,
@@ -33,17 +38,18 @@ export function BlockStylesBuilder( { attributes, setAttributes, shortcuts, onSt
 		{ name }
 	);
 
+	const { styles } = attributes;
+	const currentStyles = getStylesObject( styles, atRule, nestedRule );
+
 	return (
 		<StylesBuilder
 			key={ attributes?.globalClasses }
 			currentSelector={ currentStyle?.selector }
-			styles={ getStyles( atRule, nestedRule ) }
-			allStyles={ getStyles() }
-			onDeleteStyle={ ( property ) => {
-				deleteStyle( property );
-
-				const updatedStyles = getStyles();
-				setAttributes( { styles: updatedStyles } );
+			styles={ currentStyles }
+			allStyles={ styles }
+			onDeleteStyle={ ( property, nestedRuleValue ) => {
+				const newStyles = deleteStylesObjectKey( styles, property, nestedRuleValue );
+				setAttributes( { styles: newStyles } );
 			} }
 			nestedRule={ nestedRule }
 			atRule={ atRule }
@@ -53,11 +59,9 @@ export function BlockStylesBuilder( { attributes, setAttributes, shortcuts, onSt
 				setAtRule( value );
 				setDeviceType( getPreviewDevice( value, deviceType, defaultAtRules ) );
 			} }
-			onUpdateKey={ ( oldKey, newKey ) => {
-				updateKey( oldKey, newKey );
-
-				const updatedStyles = getStyles();
-				setAttributes( { styles: updatedStyles } );
+			onUpdateKey={ ( oldKey, newKey, nestedRuleValue ) => {
+				const newStyles = updateStylesObjectKey( styles, oldKey, newKey, nestedRuleValue );
+				setAttributes( { styles: newStyles } );
 			} }
 			selectorShortcuts={ shortcuts.selectorShortcuts }
 			visibleSelectors={ shortcuts.visibleShortcuts }

--- a/src/editor/stores.js
+++ b/src/editor/stores.js
@@ -1,12 +1,10 @@
 import { register } from '@wordpress/data';
 import {
 	currentStyleStore,
-	stylesStore,
 	atRuleStore,
 	nestedRuleStore,
 } from '../store/block-styles';
 
 register( currentStyleStore );
-register( stylesStore );
 register( atRuleStore );
 register( nestedRuleStore );

--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -48,13 +48,7 @@ export function withStyles( WrappedComponent ) {
 			return getSelector( name, uniqueId );
 		}, [ name, uniqueId ] );
 
-		const frontendStyles = useMemo( () => {
-			if ( Array.isArray( styles ) ) {
-				return {};
-			}
-
-			return styles;
-		}, [ JSON.stringify( styles ) ] );
+		const frontendStyles = Array.isArray( styles ) ? {} : styles;
 
 		function onStyleChange( property, value = '', atRuleValue = '', nestedRuleValue = '' ) {
 			const newStyles = typeof property === 'object'

--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -3,30 +3,15 @@ import { useMemo, useState, useLayoutEffect } from '@wordpress/element';
 import { defaultAtRules, getCss } from '@edge22/styles-builder';
 import {
 	useAtRuleEffect,
-	useGenerateCSSEffect,
 	useStyleSelectorEffect,
 	useUpdateEditorCSSEffect,
-	useSyncStyles,
+	useGenerateCSSEffect,
+	useSetStyleAttributes,
+	buildChangedStylesObject,
+	getSelector,
 } from '@edge22/block-styles';
 
 import { useBlockStyles } from '@hooks/useBlockStyles';
-
-function getSelector( blockName, uniqueId ) {
-	const selectors = {
-		'generateblocks/text': 'text',
-		'generateblocks/element': 'element',
-		'generateblocks/loop-item': 'loop-item',
-		'generateblocks/looper': 'looper',
-		'generateblocks/media': 'media',
-		'generateblocks/query': 'query',
-		'generateblocks/query-page-numbers': 'query-page-numbers',
-		'generateblocks/shape': 'shape',
-	};
-
-	if ( selectors[ blockName ] ) {
-		return `.gb-${ selectors[ blockName ] }-${ uniqueId }`;
-	}
-}
 
 export function withStyles( WrappedComponent ) {
 	return ( ( props ) => {
@@ -50,10 +35,9 @@ export function withStyles( WrappedComponent ) {
 			currentStyle,
 			setCurrentStyle,
 			setNestedRule,
-			setStyles,
-			addStyle,
-			getStyles,
 		} = useBlockStyles();
+
+		const setStyleAttributes = useSetStyleAttributes( props, { getCss } );
 
 		const [ isPreviewingBlock, setIsPreviewingBlock ] = useState( false );
 		const selector = useMemo( () => {
@@ -73,10 +57,12 @@ export function withStyles( WrappedComponent ) {
 		}, [ JSON.stringify( styles ) ] );
 
 		function onStyleChange( property, value = '', atRuleValue = '', nestedRuleValue = '' ) {
-			addStyle( property, value, atRuleValue, nestedRuleValue );
+			const newStyles = typeof property === 'object'
+				? property
+				: { [ property ]: value };
+			const changedStyles = buildChangedStylesObject( newStyles, atRuleValue, nestedRuleValue );
 
-			const updatedStyles = getStyles();
-			setAttributes( { styles: updatedStyles } );
+			setStyleAttributes( changedStyles );
 		}
 
 		function getStyleValue( property, atRuleValue = '', nestedRuleValue = '' ) {
@@ -118,6 +104,7 @@ export function withStyles( WrappedComponent ) {
 			styles: frontendStyles,
 			setAttributes,
 			getCss,
+			css,
 		} );
 
 		useStyleSelectorEffect( {
@@ -127,7 +114,6 @@ export function withStyles( WrappedComponent ) {
 			setCurrentStyle,
 			setNestedRule,
 			setAtRule,
-			setStyles,
 			styles: frontendStyles,
 		} );
 
@@ -136,13 +122,6 @@ export function withStyles( WrappedComponent ) {
 			getCss,
 			styles: frontendStyles,
 			isPreviewingBlock,
-		} );
-
-		useSyncStyles( {
-			isSelected,
-			stylesAttribute: frontendStyles,
-			styles: getStyles(),
-			setStyles,
 		} );
 
 		return (

--- a/src/hooks/useBlockStyles.js
+++ b/src/hooks/useBlockStyles.js
@@ -4,12 +4,9 @@ import { applyFilters } from '@wordpress/hooks';
 import { useDeviceType, getPreviewDevice, useCurrentAtRule } from '@edge22/block-styles';
 import { defaultAtRules } from '@edge22/styles-builder';
 
-import { currentStyleStore, stylesStore, atRuleStore, nestedRuleStore } from '../store/block-styles';
+import { currentStyleStore, atRuleStore, nestedRuleStore } from '../store/block-styles';
 
 export function useBlockStyles() {
-	const { getStyles } = useSelect( stylesStore );
-	const { setStyles } = useDispatch( stylesStore );
-	const { addStyle, deleteStyle, updateKey } = useDispatch( stylesStore );
 	const atRule = useSelect( ( select ) => select( atRuleStore ).getAtRule() );
 	const { setAtRule } = useDispatch( atRuleStore );
 	const nestedRule = useSelect( ( select ) => select( nestedRuleStore ).getNestedRule() );
@@ -23,10 +20,6 @@ export function useBlockStyles() {
 	const cancelEditGlobalStyle = applyFilters( 'generateblocks.useBlockStyles.cancelEditGlobalStyle', () => {} );
 
 	return {
-		setStyles,
-		getStyles,
-		addStyle,
-		deleteStyle,
 		atRule,
 		nestedRule,
 		setAtRule,
@@ -34,7 +27,6 @@ export function useBlockStyles() {
 		setNestedRule,
 		setDeviceType,
 		deviceType,
-		updateKey,
 		setCurrentStyle,
 		currentStyle,
 		getPreviewDevice,

--- a/src/store/block-styles.js
+++ b/src/store/block-styles.js
@@ -6,9 +6,6 @@ import {
 	nestedRuleActions,
 	nestedRuleSelectors,
 	nestedRuleReducer,
-	styleActions,
-	styleSelectors,
-	styleReducer,
 	atRuleActions,
 	atRuleSelectors,
 	atRuleReducer,
@@ -38,14 +35,5 @@ export const nestedRuleStore = createReduxStore(
 		reducer: nestedRuleReducer,
 		actions: nestedRuleActions,
 		selectors: nestedRuleSelectors,
-	}
-);
-
-export const stylesStore = createReduxStore(
-	'gb-block-styles',
-	{
-		reducer: styleReducer,
-		actions: styleActions,
-		selectors: styleSelectors,
 	}
 );


### PR DESCRIPTION
This PR makes it so our local blocks use the `styles` attribute as their styles store, instead of having a separate styles store we have to constantly sync with.

requires https://github.com/EDGE22-Studios/block-styles/pull/9
requires https://github.com/EDGE22-Studios/styles-builder/pull/17