### PR TITLE
Fix meta handler id handling

### DIFF
--- a/includes/class-meta-handler.php
+++ b/includes/class-meta-handler.php
@@ -205,7 +205,7 @@ class GenerateBlocks_Meta_Handler extends GenerateBlocks_Singleton {
 			$callable
 		);
 
-		if ( is_int( $id ) ) {
+		if ( is_int( $id ) || is_string( $id ) ) {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, true );
 		} else {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $parent_name );

--- a/includes/class-meta-handler.php
+++ b/includes/class-meta-handler.php
@@ -205,7 +205,7 @@ class GenerateBlocks_Meta_Handler extends GenerateBlocks_Singleton {
 			$callable
 		);
 
-		if ( is_int( $id ) || is_string( $id ) ) {
+		if ( is_numeric( $id ) ) {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, true );
 		} else {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $parent_name );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "generateblocks",
-	"version": "2.0.0-alpha.1",
+	"version": "2.0.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "generateblocks",
-			"version": "2.0.0-alpha.1",
+			"version": "2.0.0-alpha.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@edge22/block-styles": "^1.1.27",


### PR DESCRIPTION
Fixes comparison in get_meta that caused lookups to fail if a numeric ID was passed as a string. 