### PR TITLE
Add: `generateblocks_default_button_attributes` filter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
 		"generateBlocksPatternLibrary": "readonly",
 		"generateblocksBlockMedia": "readonly",
 		"generateBlocksEditor": "readonly",
-		"generateblocksDashboard": "readonly"
+		"generateblocksDashboard": "readonly",
+		"generateblocksBlockText": "readonly"
 	},
 	"env": {
 	  "browser": true,

--- a/includes/general.php
+++ b/includes/general.php
@@ -29,6 +29,33 @@ function generateblocks_do_block_editor_assets() {
 		]
 	);
 
+	wp_localize_script(
+		'generateblocks-text-editor-script',
+		'generateblocksBlockText',
+		[
+			'defaultButtonAttributes' => apply_filters(
+				'generateblocks_default_button_attributes',
+				[
+					'styles' => [
+						'display' => 'inline-flex',
+						'alignItems' => 'center',
+						'backgroundColor' => '#215bc2',
+						'color' => '#ffffff',
+						'paddingTop' => '1rem',
+						'paddingRight' => '2rem',
+						'paddingBottom' => '1rem',
+						'paddingLeft' => '2rem',
+						'textDecoration' => 'none',
+						'&:is(:hover, :focus)' => [
+							'backgroundColor' => '#1a4a9b',
+						],
+						'color' => '#ffffff',
+					],
+				]
+			),
+		]
+	);
+
 	global $pagenow;
 
 	$generateblocks_deps = array( 'wp-blocks', 'wp-i18n', 'wp-editor', 'wp-element', 'wp-compose', 'wp-data' );

--- a/src/blocks/text/index.js
+++ b/src/blocks/text/index.js
@@ -54,21 +54,7 @@ registerBlockVariation(
 		icon: getIcon( 'button' ),
 		attributes: {
 			tagName: 'a',
-			styles: {
-				display: 'inline-flex',
-				alignItems: 'center',
-				backgroundColor: '#215bc2',
-				color: '#ffffff',
-				paddingTop: '1rem',
-				paddingRight: '2rem',
-				paddingBottom: '1rem',
-				paddingLeft: '2rem',
-				textDecoration: 'none',
-				'&:is(:hover, :focus)': {
-					backgroundColor: '#1a4a9b',
-					color: '#ffffff',
-				},
-			},
+			...generateblocksBlockText.defaultButtonAttributes,
 		},
 		isActive: ( blockAttributes ) => 'button' === getElementType( blockAttributes.tagName ),
 	},


### PR DESCRIPTION
This filter allows you to do the following:

```
add_filter( 'generateblocks_default_button_attributes', function() {
	return [
		'globalClasses' => [ 'gbp-button--primary' ],
	];
} );
```

This will make it so every "Button" block you add to your website starts off with the global style, and not any local styles.