### PR TITLE
Tweak: Render loop items via callbacks

### DIFF
--- a/includes/blocks/class-looper.php
+++ b/includes/blocks/class-looper.php
@@ -131,7 +131,7 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 								'generateblocks/loopItem'  => self::sanitize_loop_item( $post ),
 							)
 						)
-					)->render( array( 'dynamic' => false ) );
+					)->render();
 				}
 			}
 


### PR DESCRIPTION
closes #1477 

This ensures that our Loop Item blocks actually called their `render_block` functions for each item in the loop.