### PR TITLE
Feature: `{{post_date}}` tag

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -248,43 +248,35 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	}
 
 	/**
-	 * Get the published date.
+	 * Get the post date.
 	 *
 	 * @param array  $options The options.
 	 * @param object $block The block.
 	 * @param object $instance The block instance.
 	 * @return string
 	 */
-	public static function get_published_date( $options, $block, $instance ) {
+	public static function get_post_date( $options, $block, $instance ) {
 		$id = GenerateBlocks_Dynamic_Tags::get_id( $options, 'post', $instance );
 
 		if ( ! $id ) {
 			return self::output( '', $options, $instance );
 		}
 
+		$type   = $options['type'] ?? 'published';
 		$format = $options[ self::DATE_FORMAT_KEY ] ?? '';
 		$output = get_the_date( $format, $id );
 
-		return self::output( $output, $options, $instance );
-	}
-
-	/**
-	 * Get the modified date.
-	 *
-	 * @param array  $options The options.
-	 * @param object $block The block.
-	 * @param object $instance The block instance.
-	 * @return string
-	 */
-	public static function get_modified_date( $options, $block, $instance ) {
-		$id = GenerateBlocks_Dynamic_Tags::get_id( $options, 'post', $instance );
-
-		if ( ! $id ) {
-			return self::output( '', $options, $instance );
+		if ( 'modified' === $type ) {
+			$output = get_the_modified_date( $format, $id );
 		}
 
-		$format = $options[ self::DATE_FORMAT_KEY ] ?? '';
-		$output = get_the_modified_date( $format, $id );
+		if ( 'modifiedOnly' === $type ) {
+			$modified_date = get_the_modified_date( $format, $id );
+
+			if ( $modified_date === $output ) {
+				$output = '';
+			}
+		}
 
 		return self::output( $output, $options, $instance );
 	}

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -99,10 +99,10 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 					'type' => [
 						'type'    => 'select',
 						'label'   => __( 'Date type', 'generateblocks' ),
-						'default' => 'published',
+						'default' => '',
 						'options' => [
 							[
-								'value' => 'published',
+								'value' => '',
 								'label' => __( 'Published', 'generateblocks' ),
 							],
 							[

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -91,21 +91,32 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 
 		new GenerateBlocks_Register_Dynamic_Tag(
 			[
-				'title'    => __( 'Published Date', 'generateblocks' ),
-				'tag'      => 'published_date',
+				'title'    => __( 'Post Date', 'generateblocks' ),
+				'tag'      => 'post_date',
 				'type'     => 'post',
 				'supports' => [ 'date', 'link', 'source' ],
-				'return'   => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_published_date' ],
-			]
-		);
-
-		new GenerateBlocks_Register_Dynamic_Tag(
-			[
-				'title'    => __( 'Modified Date', 'generateblocks' ),
-				'tag'      => 'modified_date',
-				'type'     => 'post',
-				'supports' => [ 'date', 'link', 'source' ],
-				'return'   => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_modified_date' ],
+				'options'  => [
+					'type' => [
+						'type'    => 'select',
+						'label'   => __( 'Date type', 'generateblocks' ),
+						'default' => 'published',
+						'options' => [
+							[
+								'value' => 'published',
+								'label' => __( 'Published', 'generateblocks' ),
+							],
+							[
+								'value' => 'modified',
+								'label' => __( 'Modified', 'generateblocks' ),
+							],
+							[
+								'value' => 'modifiedOnly',
+								'label' => __( 'Modified Only', 'generateblocks' ),
+							],
+						],
+					],
+				],
+				'return'   => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_post_date' ],
 			]
 		);
 
@@ -219,6 +230,10 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 						'type'  => 'select',
 						'label' => __( 'Default URL', 'generateblocks' ),
 						'options' => [
+							[
+								'label' => __( 'Default', 'generateblocks' ),
+								'value' => '',
+							],
 							'404',
 							'retro',
 							'robohash',

--- a/includes/general.php
+++ b/includes/general.php
@@ -296,6 +296,7 @@ function generateblocks_do_block_editor_assets() {
 			'hasGPFontLibrary'   => function_exists( 'generatepress_is_module_active' )
 				? generatepress_is_module_active( 'generate_package_font_library', 'GENERATE_FONT_LIBRARY' )
 				: false,
+			'dateFormat' => get_option( 'date_format' ),
 		]
 	);
 

--- a/src/blocks/query/templates.js
+++ b/src/blocks/query/templates.js
@@ -121,7 +121,7 @@ export const TEMPLATES = [
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',
-								content: '{{modified_date}}',
+								content: '{{post_date type:published}}',
 								styles: {
 									fontSize: '14px',
 								},
@@ -169,7 +169,7 @@ export const TEMPLATES = [
 									marginBottom: '0px',
 									fontSize: '14px',
 								},
-								content: '{{modified_date}}',
+								content: '{{post_date type:published}}',
 							} ],
 						],
 					],
@@ -219,7 +219,7 @@ export const TEMPLATES = [
 									marginBottom: '30px',
 									fontSize: '14px',
 								},
-								content: '{{modified_date}}',
+								content: '{{post_date type:published}}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',
@@ -283,7 +283,7 @@ export const TEMPLATES = [
 									marginBottom: '30px',
 									fontSize: '14px',
 								},
-								content: '{{modified_date}}',
+								content: '{{post_date type:published}}',
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -100,22 +100,16 @@ function getTagSpecificControls( options, extraTagParams, setExtraTagParams ) {
 		}
 
 		if ( Array.isArray( choices ) ) {
-			props.options = [
-				{
-					value: '',
-					label: __( 'Default', 'generateblocks' ),
-				},
-				...choices.map( ( choice ) => {
-					if ( 'object' === typeof choice ) {
-						return {
-							value: choice.value,
-							label: choice?.label ?? choice.value,
-						};
-					}
+			props.options = choices.map( ( choice ) => {
+				if ( 'object' === typeof choice ) {
+					return {
+						value: choice.value,
+						label: choice?.label ?? choice.value,
+					};
+				}
 
-					return { label: choice, value: choice };
-				} ),
-			];
+				return { label: choice, value: choice };
+			} );
 		}
 
 		if ( 'number' === type ) {
@@ -257,6 +251,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 	const debouncedSetLinkToKey = useDebounce( setLinkToKey, 200 );
 	const [ required, setRequired ] = useState( true );
 	const [ imageSize, setImageSize ] = useState( 'full' );
+	const [ dateFormat, setDateFormat ] = useState( '' );
 	const [ dynamicTag, setDynamicTag ] = useState( '' );
 	const [ dynamicTagData, setDynamicTagData ] = useState( () => {
 		if ( dynamicTag ) {
@@ -269,6 +264,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 	const dynamicTagType = dynamicTagData?.type ?? 'post';
 	const tagSupportsMeta = dynamicTagSupports?.includes( 'meta' ) || dynamicTagSupports?.includes( 'properties' );
 	const tagSupportsImageSize = dynamicTagSupports?.includes( 'image-size' );
+	const tagSupportsDate = dynamicTagSupports?.includes( 'date' );
 	const tagSupportsTaxonomy = dynamicTagSupports?.includes( 'taxonomy' );
 	const showSource = dynamicTagSupports?.includes( 'source' );
 	const contextPostId = context?.postId ?? 0;
@@ -331,6 +327,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 		setUserSource( '' );
 		setMetaKey( '' );
 		setImageSize( 'full' );
+		setDateFormat( '' );
 
 		// Check if there are any tag specific controls with default values to set.
 		const defaultExtraTagParams = {};
@@ -377,6 +374,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			required: requiredParam = true,
 			tax = null,
 			size = null,
+			dateFormat: dateFormatParam = null,
 			...extraParams
 		} = parsedTag?.params;
 
@@ -420,6 +418,10 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 
 		if ( size ) {
 			setImageSize( size );
+		}
+
+		if ( dateFormatParam ) {
+			setDateFormat( dateFormatParam );
 		}
 
 		if ( 'false' === requiredParam ) {
@@ -514,6 +516,10 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			options.push( `size:${ imageSize }` );
 		}
 
+		if ( dateFormat ) {
+			options.push( `dateFormat:${ dateFormat }` );
+		}
+
 		if ( ! required ) {
 			options.push( 'required:false' );
 		}
@@ -565,6 +571,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 		extraTagParams,
 		imageSize,
 		tagSupportsTaxonomy,
+		dateFormat,
 	] );
 
 	const interactiveTagNames = [ 'a', 'button' ];
@@ -746,6 +753,15 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 							value={ imageSize }
 							options={ imageSizeOptions }
 							onChange={ setImageSize }
+						/>
+					) }
+
+					{ tagSupportsDate && (
+						<TextControl
+							label={ __( 'Date Format', 'generateblocks' ) }
+							value={ dateFormat }
+							onChange={ setDateFormat }
+							help={ __( 'Enter a valid date format. Leave blank to use the default format.', 'generateblocks' ) }
 						/>
 					) }
 

--- a/src/dynamic-tags/components/DynamicTagSelect.jsx
+++ b/src/dynamic-tags/components/DynamicTagSelect.jsx
@@ -337,7 +337,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 			for ( const option in options ) {
 				const { default: defaultValue = null } = options[ option ];
 
-				if ( null !== defaultValue ) {
+				if ( ! [ null, '' ].includes( defaultValue ) ) {
 					defaultExtraTagParams[ option ] = defaultValue;
 				}
 			}
@@ -760,6 +760,7 @@ export function DynamicTagSelect( { onInsert, tagName, selectedText, currentPost
 						<TextControl
 							label={ __( 'Date Format', 'generateblocks' ) }
 							value={ dateFormat }
+							placeholder={ generateBlocksEditor?.dateFormat ?? '' }
 							onChange={ setDateFormat }
 							help={ __( 'Enter a valid date format. Leave blank to use the default format.', 'generateblocks' ) }
 						/>


### PR DESCRIPTION
closes #1505

This PR replaces the `{{published_date}}` and `{{modified_date}}` dynamic tags with a single `{{post_date}}` tag.

This tag can be configured to show the `published`, `modified` or `modifiedOnly`.

It also adds a `dateFormat` input to the UI.