### PR TITLE
Fix - Query loop preview is broken when not using Post Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "generateblocks",
-	"version": "2.0.0-beta.1",
+	"version": "2.0.0-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "generateblocks",
-			"version": "2.0.0-beta.1",
+			"version": "2.0.0-beta.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@edge22/block-styles": "^1.1.30",

--- a/src/blocks/loop-item/edit.js
+++ b/src/blocks/loop-item/edit.js
@@ -99,6 +99,8 @@ function EditBlock( props ) {
 		};
 	}, [ tagName ] );
 
+	console.log( context );
+
 	return (
 		<>
 			<InspectorControls>
@@ -125,7 +127,7 @@ function EditBlock( props ) {
 					<button
 						className="gb-block-preview__toggle"
 						data-block-id={ clientId }
-						data-context-post-id={ context?.postId ?? 0 }
+						data-context-post-id={ context?.postId ?? context?.[ 'generateblocks/loopIndex' ] ?? 0 }
 						onClick={ () => {
 							setAttributes( { isBlockPreview: false } );
 						} }

--- a/src/blocks/loop-item/edit.js
+++ b/src/blocks/loop-item/edit.js
@@ -99,8 +99,6 @@ function EditBlock( props ) {
 		};
 	}, [ tagName ] );
 
-	console.log( context );
-
 	return (
 		<>
 			<InspectorControls>

--- a/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
+++ b/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
@@ -32,7 +32,7 @@ function BlockPreview( { blocks, isHidden } ) {
 
 const MemoizedBlockPreview = memo( BlockPreview );
 
-function setIsBlockPreview( innerBlocks, contextPostId = '' ) {
+function setIsBlockPreview( innerBlocks, contextPostId = null ) {
 	return innerBlocks.map( ( block ) => {
 		const { clientId = '' } = block;
 
@@ -281,9 +281,11 @@ export function LoopInnerBlocksRenderer( props ) {
 
 	return hasResolvedData ? loopItemsContext.map( ( loopItemContext, index ) => {
 		// Include index in case the postId is the same for all loop items.
-		const key = `${ loopItemContext.postId }-${ index }`;
-		const isActive = loopItemContext.postId ===
-			( parseInt( activeBlockContextId, 10 ) || loopItemsContext[ 0 ]?.postId );
+		const contextId = loopItemContext?.postId ?? loopItemContext?.[ 'generateblocks/loopIndex' ] ?? index;
+		const firstContextId = loopItemsContext[ 0 ]?.postId ?? loopItemsContext[ 0 ]?.[ 'generateblocks/loopIndex' ] ?? 0;
+		const key = `${ contextId }-${ index }`;
+		const activeId = parseInt( activeBlockContextId, 10 );
+		const isActive = contextId ? contextId === ( activeId || firstContextId ) : false;
 
 		return (
 			<BlockContextProvider

--- a/src/hoc/withHtmlAttributes.js
+++ b/src/hoc/withHtmlAttributes.js
@@ -76,7 +76,7 @@ export function withHtmlAttributes( WrappedComponent ) {
 			...otherAttributes,
 			style: inlineStyleObject,
 			'data-gb-id': uniqueId,
-			'data-context-post-id': context?.postId ?? 0,
+			'data-context-post-id': context?.postId ?? context?.[ 'generateblocks/loopIndex' ] ?? 0,
 		};
 		const frontendHtmlAttributes = useMemo( () => {
 			if ( Array.isArray( htmlAttributes ) ) {


### PR DESCRIPTION
This ensures the preview works correctly when a postId isn’t set in the block’s context. 