### PR TITLE
Update styles-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@edge22/block-styles": "^1.1.31",
 				"@edge22/components": "^1.1.43",
-				"@edge22/styles-builder": "^1.2.42",
+				"@edge22/styles-builder": "^1.2.43",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
 				"@wordpress/components": "^25.10.0",
@@ -2174,10 +2174,11 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.42",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.42.tgz",
-			"integrity": "sha512-7nD7H+rhMM+hhpFMzM/K0IDFM57TVo7EePPvt98Nqn8UuOad3R2cu09WPscdNyj8PpYHVQ472vKiMnwZN4pDhA==",
+			"version": "1.2.43",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.43.tgz",
+			"integrity": "sha512-+Zn5KRTbDcDdo9brtbp6QrYpl5Q+Qi8ys36leOFIyR6Z/Fb0xV9vMtX4I2dyTRe6vEyda6tqoHY67fDy/nfe1Q==",
 			"dependencies": {
+				"@wordpress/components": "^28.12.0",
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",
 				"color-parse": "^2.0.2",
@@ -2196,6 +2197,154 @@
 			},
 			"peerDependencies": {
 				"@edge22/components": "^1.1.31"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@ariakit/core": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.14.tgz",
+			"integrity": "sha512-hpzZvyYzGhP09S9jW1XGsU/FD5K3BKsH1eG/QJ8rfgEeUdPS7BvHPt5lHbOeJ2cMrRzBEvsEzLi1ivfDifHsVA=="
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@ariakit/react": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.15.tgz",
+			"integrity": "sha512-0V2LkNPFrGRT+SEIiObx/LQjR6v3rR+mKEDUu/3tq7jfCZ+7+6Q6EMR1rFaK+XMkaRY1RWUcj/rRDWAUWnsDww==",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.15"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@ariakit/react-core": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.15.tgz",
+			"integrity": "sha512-Up8+U97nAPJdyUh9E8BCEhJYTA+eVztWpHoo1R9zZfHd4cnBWAg5RHxEmMH+MamlvuRxBQA71hFKY/735fDg+A==",
+			"dependencies": {
+				"@ariakit/core": "0.4.14",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@wordpress/components": {
+			"version": "28.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.13.0.tgz",
+			"integrity": "sha512-JaGcXYtFCvHqa62dtxMAMhu6afvefFOuwfUTNiLYg60CA4UDITt6gf+qhpvKNOzVg4qQRw10o/nryrOMoMAEEg==",
+			"dependencies": {
+				"@ariakit/react": "^0.4.10",
+				"@babel/runtime": "7.25.7",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "0.1.3",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "*",
+				"@wordpress/compose": "*",
+				"@wordpress/date": "*",
+				"@wordpress/deprecated": "*",
+				"@wordpress/dom": "*",
+				"@wordpress/element": "*",
+				"@wordpress/escape-html": "*",
+				"@wordpress/hooks": "*",
+				"@wordpress/html-entities": "*",
+				"@wordpress/i18n": "*",
+				"@wordpress/icons": "*",
+				"@wordpress/is-shallow-equal": "*",
+				"@wordpress/keycodes": "*",
+				"@wordpress/primitives": "*",
+				"@wordpress/private-apis": "*",
+				"@wordpress/rich-text": "*",
+				"@wordpress/warning": "*",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.1.9",
+				"gradient-parser": "^0.1.5",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@wordpress/components/node_modules/gradient-parser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+			"integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/@wordpress/components/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@edge22/styles-builder/node_modules/framer-motion": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.12.0.tgz",
+			"integrity": "sha512-gZaZeqFM6pX9kMVti60hYAa75jGpSsGYWAHbBfIkuHN7DkVHVkxSxeNYnrGmHuM0zPkWTzQx10ZT+fDjn7N4SA==",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@edge22/styles-builder/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@edge22/block-styles": "^1.1.31",
 		"@edge22/components": "^1.1.43",
-		"@edge22/styles-builder": "^1.2.42",
+		"@edge22/styles-builder": "^1.2.43",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",
 		"@wordpress/components": "^25.10.0",


### PR DESCRIPTION
* Issue that made it impossible to type floating numbers (2.0, 2.05, etc)
* Improved unit parsing
* Add support for no units at all. This is helpful for things like Order where we want it to be a number but still let someone use a variable, calc, etc.
* Add unit tests