### PR TITLE
Dynamic Tags - Remove get_queried_object_id

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -373,8 +373,6 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 			$id = absint( $options['id'] );
 		} elseif ( 'user' === $fallback_type ) {
 			$id = get_current_user_id();
-		} elseif ( ! $is_loop_item && ( is_tax() || is_category() || is_tag() || is_archive() ) ) {
-			$id = get_queried_object_id();
 		} else {
 			$id = get_the_ID();
 		}


### PR DESCRIPTION
Reference:  https://generate.support/topic/new-dynamic-tags-wont-render-on-front-end/#post-144381 

This was breaking the dynamic tags ID lookup when the dynamic tag was used in “content template” such as a loop item for an archive page.   Removing this has had no adverse effects, archive_title still works as expected, etc. 