### PR TITLE
Bug - Looper children break when loop data is empty

### DIFF
--- a/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
+++ b/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
@@ -179,7 +179,7 @@ export function LoopInnerBlocksRenderer( props ) {
 	);
 
 	const loopItemsContext = useMemo( () => {
-		if ( hasResolvedData && Array.isArray( data ) ) {
+		if ( hasResolvedData && data?.length ) {
 			let { posts_per_page: perPage = 10, offset = 0 } = query;
 
 			// Ensure the params are a valid integer for comparison.


### PR DESCRIPTION
Fixes an error in the condition that handles rendering data in the editor. This fixes an error that caused the inspector controls to disappear for all of the innerBlocks of the looper.