### PR TITLE
Tweak: Separate style replacements

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -4,6 +4,7 @@ import './stores.js';
 import './disable-blocks.js';
 import './toolbar-appenders.js';
 import './global-max-width.js';
+import './style-html-attribute.js';
 import './editor.scss';
 
 wpDomReady( () => {

--- a/src/editor/style-html-attribute.js
+++ b/src/editor/style-html-attribute.js
@@ -1,43 +1,31 @@
 import { addFilter } from '@wordpress/hooks';
-import { useState, useEffect } from '@wordpress/element';
 import { replaceTags } from '../dynamic-tags/utils';
 
 addFilter(
 	'generateblocks.editor.htmlAttributes.style',
 	'generateblocks/styleWithReplacements',
-	( style, props ) => {
+	async( style, props ) => {
 		const { context } = props;
-		const [ styleValue, setStyleValue ] = useState( style );
 
-		useEffect( () => {
-			async function getReplacements() {
-				// Check if any replacements need to be made if not, do nothing.
-				if ( ! style.includes( '{{' ) ) {
-					setStyleValue( style );
-					return;
-				}
+		// Check if any replacements need to be made
+		if ( ! style.includes( '{{' ) ) {
+			return style;
+		}
 
-				const replacements = await replaceTags( style, context );
+		const replacements = await replaceTags( style, context );
 
-				if ( ! replacements.length ) {
-					setStyleValue( style );
-					return;
-				}
+		if ( ! replacements.length ) {
+			return style;
+		}
 
-				const withReplacements = replacements.reduce( ( acc, { original, replacement, fallback } ) => {
-					if ( ! replacement ) {
-						return acc.replaceAll( original, fallback );
-					}
-
-					return acc.replaceAll( original, replacement );
-				}, style );
-
-				setStyleValue( withReplacements ? withReplacements : style );
+		const withReplacements = replacements.reduce( ( acc, { original, replacement, fallback } ) => {
+			if ( ! replacement ) {
+				return acc.replaceAll( original, fallback );
 			}
 
-			getReplacements();
-		}, [ style, context ] );
+			return acc.replaceAll( original, replacement );
+		}, style );
 
-		return styleValue;
+		return withReplacements ? withReplacements : style;
 	}
 );

--- a/src/editor/style-html-attribute.js
+++ b/src/editor/style-html-attribute.js
@@ -1,0 +1,43 @@
+import { addFilter } from '@wordpress/hooks';
+import { useState, useEffect } from '@wordpress/element';
+import { replaceTags } from '../dynamic-tags/utils';
+
+addFilter(
+	'generateblocks.editor.htmlAttributes.style',
+	'generateblocks/styleWithReplacements',
+	( style, props ) => {
+		const { context } = props;
+		const [ styleValue, setStyleValue ] = useState( style );
+
+		useEffect( () => {
+			async function getReplacements() {
+				// Check if any replacements need to be made if not, do nothing.
+				if ( ! style.includes( '{{' ) ) {
+					setStyleValue( style );
+					return;
+				}
+
+				const replacements = await replaceTags( style, context );
+
+				if ( ! replacements.length ) {
+					setStyleValue( style );
+					return;
+				}
+
+				const withReplacements = replacements.reduce( ( acc, { original, replacement, fallback } ) => {
+					if ( ! replacement ) {
+						return acc.replaceAll( original, fallback );
+					}
+
+					return acc.replaceAll( original, replacement );
+				}, style );
+
+				setStyleValue( withReplacements ? withReplacements : style );
+			}
+
+			getReplacements();
+		}, [ style, context ] );
+
+		return styleValue;
+	}
+);

--- a/src/hoc/withHtmlAttributes.js
+++ b/src/hoc/withHtmlAttributes.js
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 
 import { useUpdateEffect } from 'react-use';
 
 import { convertInlineStyleStringToObject } from '@utils/convertInlineStyleStringToObject';
-import { replaceTags } from '../dynamic-tags/utils';
 
 export const booleanAttributes = [
 	'allowfullscreen',
@@ -74,37 +74,12 @@ export function withHtmlAttributes( WrappedComponent ) {
 			align,
 		} = attributes;
 
-		const [ styleWithReplacements, setStyleWithReplacements ] = useState( '' );
 		const { style = '', href, ...otherAttributes } = htmlAttributes;
-
-		useEffect( () => {
-			async function getReplacements() {
-			// Check if any replacements need to be made if not, do nothing.
-				if ( ! style.includes( '{{' ) ) {
-					setStyleWithReplacements( style );
-					return;
-				}
-
-				const replacements = await replaceTags( style, context );
-
-				if ( ! replacements.length ) {
-					setStyleWithReplacements( style );
-					return;
-				}
-
-				const withReplacements = replacements.reduce( ( acc, { original, replacement, fallback } ) => {
-					if ( ! replacement ) {
-						return acc.replaceAll( original, fallback );
-					}
-
-					return acc.replaceAll( original, replacement );
-				}, style );
-
-				setStyleWithReplacements( withReplacements ? withReplacements : style );
-			}
-
-			getReplacements();
-		}, [ style, context ] );
+		const styleValue = applyFilters(
+			'generateblocks.editor.htmlAttributes.style',
+			style,
+			{ ...props }
+		);
 
 		useUpdateEffect( () => {
 			const layoutClasses = [ 'alignwide', 'alignfull' ];
@@ -120,8 +95,8 @@ export function withHtmlAttributes( WrappedComponent ) {
 			setAttributes( { className: newClasses.join( ' ' ) } );
 		}, [ align ] );
 
-		const inlineStyleObject = typeof styleWithReplacements === 'string'
-			? convertInlineStyleStringToObject( styleWithReplacements )
+		const inlineStyleObject = typeof styleValue === 'string'
+			? convertInlineStyleStringToObject( styleValue )
 			: '';
 		const combinedAttributes = {
 			...otherAttributes,

--- a/src/hoc/withHtmlAttributes.js
+++ b/src/hoc/withHtmlAttributes.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { InspectorAdvancedControls } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
@@ -75,11 +75,21 @@ export function withHtmlAttributes( WrappedComponent ) {
 		} = attributes;
 
 		const { style = '', href, ...otherAttributes } = htmlAttributes;
-		const styleValue = applyFilters(
-			'generateblocks.editor.htmlAttributes.style',
-			style,
-			{ ...props }
-		);
+		const [ processedStyle, setProcessedStyle ] = useState( style );
+
+		useEffect( () => {
+			async function fetchProcessedStyle() {
+				const styleValue = await applyFilters(
+					'generateblocks.editor.htmlAttributes.style',
+					style,
+					{ ...props }
+				);
+
+				setProcessedStyle( styleValue );
+			}
+
+			fetchProcessedStyle();
+		}, [ style, props ] );
 
 		useUpdateEffect( () => {
 			const layoutClasses = [ 'alignwide', 'alignfull' ];
@@ -95,8 +105,8 @@ export function withHtmlAttributes( WrappedComponent ) {
 			setAttributes( { className: newClasses.join( ' ' ) } );
 		}, [ align ] );
 
-		const inlineStyleObject = typeof styleValue === 'string'
-			? convertInlineStyleStringToObject( styleValue )
+		const inlineStyleObject = typeof processedStyle === 'string'
+			? convertInlineStyleStringToObject( processedStyle )
 			: '';
 		const combinedAttributes = {
 			...otherAttributes,


### PR DESCRIPTION
In an effort to keep `withHtmlAttributes.js` synced between free and pro, this PR separates the logic for dynamic style replacements and puts it into a filter.

This will allow us to continue to keep the two files identical, even though pro doesn't have access to functions like `replaceTags()`.