### PR TITLE
Tweak: Remove Container Queries in free

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@edge22/block-styles": "^1.1.33",
 				"@edge22/components": "^1.1.49",
-				"@edge22/styles-builder": "^1.2.49",
+				"@edge22/styles-builder": "^1.2.50",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
 				"@wordpress/components": "^25.10.0",
@@ -2039,9 +2039,9 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.49",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.49.tgz",
-			"integrity": "sha512-wBPcjcWJZ92thDNbTD2/s9yOHRkOqIG217z6hRzfKDSEKRWPfxVtzpzrH25f/RXy5svdHPTUkIqirzIIGg1lIg==",
+			"version": "1.2.50",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.50.tgz",
+			"integrity": "sha512-NXmrrfv6PmmReNT1jBaodWB2nXAdnaqeVCQhK5o0jLlTW+xXBHyD+MuJZeOBjzF2gp0PN5VxE5dlVKAfh9MCuA==",
 			"dependencies": {
 				"@wordpress/components": "^28.12.0",
 				"@wordpress/icons": "^9.48.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@edge22/block-styles": "^1.1.33",
 		"@edge22/components": "^1.1.49",
-		"@edge22/styles-builder": "^1.2.49",
+		"@edge22/styles-builder": "^1.2.50",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",
 		"@wordpress/components": "^25.10.0",


### PR DESCRIPTION
Since free doesn't allow for custom at-rules, it doesn't make sense to show the Container Query options.