### PR TITLE
Revert change to meta handler

### DIFF
--- a/includes/class-meta-handler.php
+++ b/includes/class-meta-handler.php
@@ -208,12 +208,7 @@ class GenerateBlocks_Meta_Handler extends GenerateBlocks_Singleton {
 		);
 
 		if ( is_numeric( $id ) ) {
-			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, $single_only );
-
-			// If it's an array with only one item, return it directly.
-			if ( is_array( $meta ) && 1 === count( $meta ) ) {
-				$meta = $meta[0];
-			}
+			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, false );
 		} else {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $parent_name );
 		}


### PR DESCRIPTION
This reverts a previous change that was made to accomodate post meta stored in a nested array structure. Upon reflection, I think that we don’t need to support this as a first-party use case and it will complicate everything else to support it in this manner now. 