### PR TITLE
Restore original meta-handler single param value

### DIFF
--- a/includes/class-meta-handler.php
+++ b/includes/class-meta-handler.php
@@ -208,7 +208,7 @@ class GenerateBlocks_Meta_Handler extends GenerateBlocks_Singleton {
 		);
 
 		if ( is_numeric( $id ) ) {
-			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, false );
+			$meta = $pre_value ? $pre_value : call_user_func( $callable, $id, $parent_name, true );
 		} else {
 			$meta = $pre_value ? $pre_value : call_user_func( $callable, $parent_name );
 		}


### PR DESCRIPTION
Before the reverted tweak this was true, but it was accidentally set to false. 