### PR TITLE
Fix: Broken control

### DIFF
--- a/src/blocks/media/components/BlockSettings.jsx
+++ b/src/blocks/media/components/BlockSettings.jsx
@@ -1,12 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import { SelectControl, TextControl, Flex, FlexBlock } from '@wordpress/components';
-import { useEffect, useState, useMemo } from '@wordpress/element';
+import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs, isURL } from '@wordpress/url';
 import { applyFilters } from '@wordpress/hooks';
+import { debounce } from '@wordpress/compose';
 
 import { OpenPanel } from '@edge22/components';
-import { UnitControl, Control } from '@edge22/styles-builder';
+import { UnitControl } from '@edge22/styles-builder';
 
 import {
 	ApplyFilters,
@@ -52,6 +53,13 @@ export function BlockSettings( {
 	} = useBlockStyles();
 	const [ imageData, setImageData ] = useState( null );
 	const [ hasResolved, setHasResolved ] = useState( false );
+
+	const debouncedOnStyleChange = useCallback(
+		debounce( ( property, value, atRule ) => {
+			onStyleChange( property, value, atRule );
+		}, 250 ),
+		[ onStyleChange ]
+	);
 
 	useEffect( () => {
 		if ( ! isURL( htmlAttributes?.src ) ) {
@@ -220,32 +228,29 @@ export function BlockSettings( {
 
 				<Flex>
 					<FlexBlock>
-						<Control
-							as={ UnitControl }
+						<UnitControl
 							id="width"
 							label={ __( 'Width', 'generateblocks' ) }
 							value={ getStyleValue( 'width', currentAtRule ) }
-							onChange={ ( value ) => onStyleChange( 'width', value, currentAtRule ) }
+							onChange={ ( value ) => debouncedOnStyleChange( 'width', value, currentAtRule ) }
 							alwaysVisible={ true }
 							cssProp="width"
 						/>
 					</FlexBlock>
 
 					<FlexBlock>
-						<Control
-							as={ UnitControl }
+						<UnitControl
 							id="height"
 							label={ __( 'Height', 'generateblocks' ) }
 							value={ getStyleValue( 'height', currentAtRule ) }
-							onChange={ ( value ) => onStyleChange( 'height', value, currentAtRule ) }
+							onChange={ ( value ) => debouncedOnStyleChange( 'height', value, currentAtRule ) }
 							alwaysVisible={ true }
 							cssProp="height"
 						/>
 					</FlexBlock>
 				</Flex>
 
-				<Control
-					as={ TextControl }
+				<TextControl
 					label={ __( 'Alt text', 'generateblocks' ) }
 					value={ htmlAttributes?.alt ?? '' }
 					onChange={ ( value ) => {

--- a/src/blocks/query/components/ControlBuilder.jsx
+++ b/src/blocks/query/components/ControlBuilder.jsx
@@ -3,7 +3,6 @@ import { sprintf, __ } from '@wordpress/i18n';
 
 import { isArray, isObject } from 'lodash';
 import { SelectPostType, SelectPost, MultiSelect, SelectUser } from '@edge22/components';
-import { Control } from '@edge22/styles-builder';
 
 import { TaxonomyParameterControl } from './TaxonomyParameterControl';
 import { DateQueryControl } from './DateQueryControl';
@@ -19,7 +18,7 @@ function ControlComponent( props ) {
 
 	switch ( props?.type ) {
 		case 'text':
-			return <Control { ...standardProps } as={ TextControl } />;
+			return <TextControl { ...standardProps } />;
 		case 'number':
 			return (
 				<TextControl


### PR DESCRIPTION
The `<Control>` component can now only be used within the context of the Styles Builder.