### PR TITLE
Fix: Deeply nested queries

### DIFF
--- a/includes/blocks/class-loop-item.php
+++ b/includes/blocks/class-loop-item.php
@@ -28,7 +28,7 @@ class GenerateBlocks_Block_Loop_Item extends GenerateBlocks_Block {
 	 * @param object $block         The block.
 	 */
 	public static function render_block( $attributes, $block_content, $block ) {
-		$query_type = $block->context['generateblocks/queryType'] ?? null;
+		$query_type = $block->context['generateblocks/queryData']['type'] ?? null;
 
 		if ( GenerateBlocks_Block_Query::TYPE_WP_QUERY === $query_type ) {
 			$post_classes = get_post_class();

--- a/includes/blocks/class-looper.php
+++ b/includes/blocks/class-looper.php
@@ -54,8 +54,8 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 	 * @return string  The rendered content.
 	 */
 	public static function render_loop_items( $attributes, $block ) {
-		$query_data = $block->context['generateblocks/queryData'] ?? null;
-		$query_type = $block->context['generateblocks/queryType'] ?? null;
+		$query_data = $block->context['generateblocks/queryData']['data'] ?? null;
+		$query_type = $block->context['generateblocks/queryData']['type'] ?? null;
 		$output     = '';
 
 		if ( GenerateBlocks_Block_Query::TYPE_WP_QUERY === $query_type ) {
@@ -85,7 +85,7 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 	 * @return string  The rendered content.
 	 */
 	public static function render_wp_query( $query, $attributes, $block ) {
-		$query_id     = $block->context['generateblocks/queryId'] ?? null;
+		$query_id     = $block->context['generateblocks/queryData']['id'] ?? null;
 		$page_key     = $query_id ? 'query-' . $query_id . '-page' : 'query-page';
 		$per_page     = $query->query_vars['posts_per_page'] ?? get_option( 'posts_per_page', 10 );
 		$page         = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
@@ -106,7 +106,6 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 					array(
 						'postType'                 => 'post',
 						'postId'                   => 0,
-						'generateblocks/queryType' => GenerateBlocks_Block_Query::TYPE_WP_QUERY,
 						'generateblocks/loopIndex' => 1,
 						'generateblocks/loopItem'  => [ 'ID' => 0 ],
 					)
@@ -126,7 +125,6 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 							array(
 								'postType'                 => get_post_type(),
 								'postId'                   => get_the_ID(),
-								'generateblocks/queryType' => GenerateBlocks_Block_Query::TYPE_WP_QUERY,
 								'generateblocks/loopIndex' => $offset + $query->current_post + 1,
 								'generateblocks/loopItem'  => self::sanitize_loop_item( $post ),
 							)

--- a/includes/blocks/class-query-no-results.php
+++ b/includes/blocks/class-query-no-results.php
@@ -21,7 +21,7 @@ class GenerateBlocks_Block_Query_No_Results extends GenerateBlocks_Block {
 	 * @param array  $block         The block.
 	 */
 	public static function render_block( $attributes, $block_content, $block ) {
-		$no_results = $block->context['generateblocks/noResults'] ?? false;
+		$no_results = $block->context['generateblocks/queryData']['noResults'] ?? false;
 
 		if ( ! $no_results ) {
 			return '';

--- a/includes/blocks/class-query-page-numbers.php
+++ b/includes/blocks/class-query-page-numbers.php
@@ -21,14 +21,14 @@ class GenerateBlocks_Block_Query_Page_Numbers extends GenerateBlocks_Block {
 	 * @param object $block         The block.
 	 */
 	public static function render_block( $attributes, $block_content, $block ) {
-		$query_id      = $block->context['generateblocks/queryId'] ?? null;
+		$query_id      = $block->context['generateblocks/queryData']['id'] ?? null;
 		$page_key      = $query_id ? 'query-' . $query_id . '-page' : 'query-page';
 		$page          = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
-		$args          = $block->context['generateblocks/query'] ?? [];
+		$args          = $block->context['generateblocks/queryData']['args'] ?? [];
 		$per_page      = $args['posts_per_page'] ?? apply_filters( 'generateblocks_query_per_page_default', 10, $args );
 		$content       = '';
 		$mid_size      = isset( $block->attributes['midSize'] ) ? (int) $block->attributes['midSize'] : null;
-		$inherit_query = $block->context['generateblocks/inheritQuery'] ?? false;
+		$inherit_query = $block->context['generateblocks/queryData']['inherit'] ?? false;
 
 		if ( $inherit_query ) {
 			$paginate_args = [ 'prev_next' => false ];
@@ -39,8 +39,8 @@ class GenerateBlocks_Block_Query_Page_Numbers extends GenerateBlocks_Block {
 
 			$content = paginate_links( $paginate_args );
 		} else {
-			$query_data = $block->context['generateblocks/queryData'] ?? null;
-			$max_pages  = $block->context['generateblocks/maxPages'] ?? 0;
+			$query_data = $block->context['generateblocks/queryData']['data'] ?? null;
+			$max_pages  = $block->context['generateblocks/queryData']['maxPages'] ?? 0;
 
 			if ( ! $query_data ) {
 				return '';
@@ -96,7 +96,7 @@ class GenerateBlocks_Block_Query_Page_Numbers extends GenerateBlocks_Block {
 			return '';
 		}
 
-		$pagination_type    = $block->context['generateblocks/paginationType'] ?? '';
+		$pagination_type    = $block->context['generateblocks/queryData']['paginationType'] ?? '';
 		$instant_pagination = GenerateBlocks_Block_Query::TYPE_INSTANT_PAGINATION === $pagination_type;
 
 		if ( $instant_pagination && class_exists( 'WP_HTML_Tag_Processor' ) ) {

--- a/includes/blocks/class-query.php
+++ b/includes/blocks/class-query.php
@@ -127,11 +127,16 @@ class GenerateBlocks_Block_Query extends GenerateBlocks_Block {
 			new WP_Block(
 				$block->parsed_block,
 				array(
-					'generateblocks/noResults' => $query_data['no_results'],
-					'generateblocks/queryData' => $query_data['data'],
-					'generateblocks/query'     => $query_data['args'],
-					'generateblocks/queryType' => $query_type,
-					'generateblocks/maxPages'  => $max_pages,
+					'generateblocks/queryData' => [
+						'id'             => $attributes['uniqueId'] ?? '',
+						'noResults'      => $query_data['no_results'],
+						'data'           => $query_data['data'],
+						'args'           => $query_data['args'],
+						'type'           => $query_type,
+						'maxPages'       => $max_pages,
+						'inherit'        => $attributes['inheritQuery'] ?? false,
+						'paginationType' => $pagination_type,
+					],
 				)
 			)
 		)->render( array( 'dynamic' => false ) );

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -700,9 +700,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_previous_posts_page_url( $options, $block, $instance ) {
-		$page_key      = isset( $instance->context['generateblocks/queryId'] ) ? 'query-' . $instance->context['generateblocks/queryId'] . '-page' : 'query-page';
+		$query_id      = $instance->context['generateblocks/queryData']['id'] ?? '';
+		$page_key      = $query_id ? 'query-' . $query_id . '-page' : 'query-page';
 		$page          = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
-		$inherit_query = $instance->context['generateblocks/inheritQuery'] ?? false;
+		$inherit_query = $instance->context['generateblocks/queryData']['inherit'] ?? false;
 		$output   = '';
 
 		if ( $inherit_query ) {
@@ -727,10 +728,11 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 	 * @return string
 	 */
 	public static function get_next_posts_page_url( $options, $block, $instance ) {
-		$page_key      = isset( $instance->context['generateblocks/queryId'] ) ? 'query-' . $instance->context['generateblocks/queryId'] . '-page' : 'query-page';
+		$query_id      = $instance->context['generateblocks/queryData']['id'] ?? '';
+		$page_key      = $query_id ? 'query-' . $query_id . '-page' : 'query-page';
 		$page          = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ]; // phpcs:ignore -- No data processing happening.
-		$args          = $instance->context['generateblocks/query'] ?? [];
-		$inherit_query = $instance->context['generateblocks/inheritQuery'] ?? false;
+		$args          = $instance->context['generateblocks/queryData']['args'] ?? [];
+		$inherit_query = $instance->context['generateblocks/queryData']['inherit'] ?? false;
 		$per_page      = $args['posts_per_page'] ?? apply_filters( 'generateblocks_query_per_page_default', 10, $args );
 		$output        = '';
 
@@ -747,8 +749,8 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 				$output = next_posts( $wp_query->max_num_pages, false );
 			}
 		} else {
-			$query_data  = $instance->context['generateblocks/queryData'] ?? null;
-			$query_type  = $instance->context['generateblocks/queryType'] ?? GenerateBlocks_Block_Query::TYPE_WP_QUERY;
+			$query_data  = $instance->context['generateblocks/queryData']['data'] ?? null;
+			$query_type  = $instance->context['generateblocks/queryData']['type'] ?? null;
 			$is_wp_query = GenerateBlocks_Block_Query::TYPE_WP_QUERY === $query_type;
 
 			if ( ! $query_data || ( ! $is_wp_query && ! is_array( $query_data ) ) ) {

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -768,9 +768,9 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 	 */
 	public function before_tag_replace( $content, $args ) {
 		if ( in_array( 'instant-pagination', $args['supports'], true ) ) {
-			$pagination_type    = $args['instance']->context['generateblocks/paginationType'] ?? '';
+			$pagination_type    = $args['instance']->context['generateblocks/queryData']['paginationType'] ?? '';
 			$instant_pagination = GenerateBlocks_Block_Query::TYPE_INSTANT_PAGINATION === $pagination_type;
-			$query_id           = $args['instance']->context['generateblocks/queryId'] ?? '';
+			$query_id           = $args['instance']->context['generateblocks/queryData']['id'] ?? '';
 
 			if ( $instant_pagination && class_exists( 'WP_HTML_Tag_Processor' ) ) {
 				$pagination_processor = new WP_HTML_Tag_Processor( $content );

--- a/src/blocks/element/block.json
+++ b/src/blocks/element/block.json
@@ -62,7 +62,6 @@
     },
 	"usesContext": [
 		"generateblocks/queryData",
-		"generateblocks/maxPages",
 		"generateblocks/queryType",
 		"generateblocks/paginationType",
 		"postId"

--- a/src/blocks/loop-item/block.json
+++ b/src/blocks/loop-item/block.json
@@ -53,7 +53,6 @@
 	],
 	"usesContext": [
 		"generateblocks/queryData",
-		"generateblocks/maxPages",
 		"generateblocks/queryType",
 		"generateblocks/loopIndex",
 		"generateblocks/loopItem",

--- a/src/blocks/looper/block.json
+++ b/src/blocks/looper/block.json
@@ -68,8 +68,6 @@
 		"generateblocks/query",
 		"generateblocks/inheritQuery",
 		"generateblocks/queryData",
-		"generateblocks/maxPages",
-		"generateblocks/noResults",
 		"generateblocks/queryType",
 		"generateblocks/loopIndex",
 		"generateblocks/loopItem"

--- a/src/blocks/query-no-results/block.json
+++ b/src/blocks/query-no-results/block.json
@@ -17,5 +17,5 @@
 		"html": false
     },
     "editorScript": "file:./index.js",
-	"usesContext": [ "generateblocks/noResults" ]
+	"usesContext": [ "generateblocks/queryData" ]
 }

--- a/src/blocks/query-page-numbers/block.json
+++ b/src/blocks/query-page-numbers/block.json
@@ -54,7 +54,6 @@
 	],
 	"usesContext": [
 		"generateblocks/queryData",
-		"generateblocks/maxPages",
 		"generateblocks/queryType",
 		"generateblocks/query",
 		"generateblocks/queryId",

--- a/src/blocks/query/block.json
+++ b/src/blocks/query/block.json
@@ -59,10 +59,6 @@
 			"type": "object",
 			"default": {}
 		},
-		"queryData": {
-			"type": "object",
-			"default": {}
-		},
 		"inheritQuery": {
 			"type": "boolean",
 			"default": false

--- a/src/blocks/query/components/QueryInspectorControls.jsx
+++ b/src/blocks/query/components/QueryInspectorControls.jsx
@@ -60,23 +60,24 @@ export function QueryInspectorControls( { attributes, setAttributes, context } )
 					help={ selectedQueryType?.help }
 				/>
 			) }
+
+			<SelectControl
+				label={ __( 'Pagination type', 'generateblocks' ) }
+				value={ attributes.paginationType }
+				options={ [
+					{
+						label: __( 'Standard', 'generateblocks' ),
+						value: 'standard',
+					},
+					{
+						label: __( 'Instant', 'generateblocks' ),
+						value: 'instant',
+					},
+				] }
+				onChange={ ( value ) => setAttributes( { paginationType: value } ) }
+			/>
 			{ 'WP_Query' === attributes.queryType && (
 				<>
-					<SelectControl
-						label={ __( 'Pagination type', 'generateblocks' ) }
-						value={ attributes.paginationType }
-						options={ [
-							{
-								label: __( 'Standard', 'generateblocks' ),
-								value: 'standard',
-							},
-							{
-								label: __( 'Instant', 'generateblocks' ),
-								value: 'instant',
-							},
-						] }
-						onChange={ ( value ) => setAttributes( { paginationType: value } ) }
-					/>
 					<ToggleControl
 						label={ __( 'Inherit query from template', 'generateblocks' ) }
 						help={ __( 'Toggle to use the global query context that is set with the current template, such as an archive or search.', 'generateblocks' ) }

--- a/src/blocks/query/templates.js
+++ b/src/blocks/query/templates.js
@@ -122,6 +122,9 @@ export const TEMPLATES = [
 							[ 'generateblocks/text', {
 								tagName: 'h2',
 								content: '{{post_title link:post}}',
+								styles: {
+									marginBottom: '5px',
+								},
 							} ],
 							[ 'generateblocks/text', {
 								tagName: 'p',

--- a/src/blocks/text/block.json
+++ b/src/blocks/text/block.json
@@ -77,7 +77,6 @@
 		"postType",
 		"generateblocks/query",
 		"generateblocks/queryData",
-		"generateblocks/maxPages",
 		"generateblocks/queryType",
 		"generateblocks/inheritQuery",
 		"generateblocks/queryId",


### PR DESCRIPTION
closes #1627 

It turns out that combining the use of JS context (provided by `block.json` using a block attribute) and PHP context (provided via the `WP_Block()` class) can result in your values becoming out of sync.

In the referenced issue, the problem was that `queryType` was correct (passed via JS), but `queryData` was a step behind (PHP context).

In this PR, I decided to group all of our PHP context into a single value (`generateblocks/queryData`). This name doesn't conflict with any of the JS context names.

Then, in all of our PHP, I referenced the PHP context instead of using the JS context values.

JS context still exists for the editor, but should no longer be used on the frontend.

Things to test:

- [x] Regular post query
- [x] Standard pagination
- [x] Instant pagination
- [x] Option query
- [x] Post meta query
- [x] Nested queries
- [x] Queries in No Results