### PR TITLE
Fix: Styles getting mixed up on atRule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.0.0-beta.7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@edge22/block-styles": "^1.1.35",
+				"@edge22/block-styles": "^1.1.36",
 				"@edge22/components": "^1.1.51",
 				"@edge22/styles-builder": "^1.2.53",
 				"@tanstack/react-query": "^5.62.11",
@@ -1994,9 +1994,9 @@
 			}
 		},
 		"node_modules/@edge22/block-styles": {
-			"version": "1.1.35",
-			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.35.tgz",
-			"integrity": "sha512-xSFdPN6Is9qU+ziNEEKKT6xsbWEPts0kA60WdhiHs/jqPfRCxytIUKyXVLoneUPY4g2mm7szI24M/ZLmW7KbHQ==",
+			"version": "1.1.36",
+			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.36.tgz",
+			"integrity": "sha512-/lvnvf0XXlRbvwCjZYfwndb7ODzWQEzSCqOADNAt1t9GkeQSofGzB9ZzI97H3ZCJRnaP5qUQUtLJeA41QcXBMw==",
 			"dependencies": {
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"url": "https://generateblocks.com/support"
 	},
 	"dependencies": {
-		"@edge22/block-styles": "^1.1.35",
+		"@edge22/block-styles": "^1.1.36",
 		"@edge22/components": "^1.1.51",
 		"@edge22/styles-builder": "^1.2.53",
 		"@tanstack/react-query": "^5.62.11",

--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -93,8 +93,6 @@ export function withStyles( WrappedComponent ) {
 			selector,
 			setCurrentStyle,
 			setNestedRule,
-			setAtRule,
-			styles: frontendStyles,
 		} );
 
 		return (


### PR DESCRIPTION
This fixes a bug where styles get mixed up among blocks when:

1. In an at-rule.
2. Switching between blocks.

This happens for at-rules and not nested rules because at-rules are also set on render in `useAtRuleEffect`.