### PR TITLE
Fix: Pass query data to loop items

### DIFF
--- a/includes/blocks/class-looper.php
+++ b/includes/blocks/class-looper.php
@@ -106,6 +106,7 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 					array(
 						'postType'                 => 'post',
 						'postId'                   => 0,
+						'generateblocks/queryData' => $block->context['generateblocks/queryData'] ?? [],
 						'generateblocks/loopIndex' => 1,
 						'generateblocks/loopItem'  => [ 'ID' => 0 ],
 					)
@@ -125,6 +126,7 @@ class GenerateBlocks_Block_Looper extends GenerateBlocks_Block {
 							array(
 								'postType'                 => get_post_type(),
 								'postId'                   => get_the_ID(),
+								'generateblocks/queryData' => $block->context['generateblocks/queryData'] ?? [],
 								'generateblocks/loopIndex' => $offset + $query->current_post + 1,
 								'generateblocks/loopItem'  => self::sanitize_loop_item( $post ),
 							)


### PR DESCRIPTION
This fixes a bug where query data wasn't being consistently passed to loop items, resulting in things like post classes not being output etc...