### PR TITLE
Fix: Image styles on transform

### DIFF
--- a/src/blocks/image/transforms.js
+++ b/src/blocks/image/transforms.js
@@ -118,12 +118,29 @@ const transforms = {
 					metaData.name = blockLabel;
 				}
 
+				const customStyles = {};
+
+				if ( ! styles.width ) {
+					customStyles.width = 'auto';
+				}
+
+				if ( ! styles.height ) {
+					customStyles.height = 'auto';
+				}
+
+				if ( ! styles.maxWidth ) {
+					customStyles.maxWidth = '100%';
+				}
+
 				return createBlock( 'generateblocks/media', {
 					tagName: 'img',
 					mediaId,
 					htmlAttributes: newHtmlAttributes,
 					linkHtmlAttributes,
-					styles,
+					styles: {
+						...styles,
+						...customStyles,
+					},
 					globalClasses,
 					metadata: metaData,
 				} );
@@ -205,12 +222,29 @@ const transforms = {
 					metaData.name = blockLabel;
 				}
 
+				const customStyles = {};
+
+				if ( ! styles.width ) {
+					customStyles.width = 'auto';
+				}
+
+				if ( ! styles.height ) {
+					customStyles.height = 'auto';
+				}
+
+				if ( ! styles.maxWidth ) {
+					customStyles.maxWidth = '100%';
+				}
+
 				const imageBlock = createBlock( 'generateblocks/media', {
 					tagName: 'img',
 					mediaId,
 					htmlAttributes: newHtmlAttributes,
 					linkHtmlAttributes,
-					styles,
+					styles: {
+						...styles,
+						...customStyles,
+					},
 					globalClasses,
 					metadata: metaData,
 				} );


### PR DESCRIPTION
This sets our default width, height and max-width options when transforming a v1 image.