### PR TITLE
Fix: Allow trailing dynamic tag spaces

### DIFF
--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -120,7 +120,7 @@ class GenerateBlocks_Register_Dynamic_Tag {
 			$data           = self::$tags[ $tag_name ];
 			$full_tag       = $match[0];
 			$full_tag       = self::maybe_prepend_protocol( $content, $full_tag );
-			$options_string = isset( $match[2] ) ? trim( $match[2], ' ' ) : '';
+			$options_string = isset( $match[2] ) ? ltrim( $match[2], ' ' ) : '';
 			$options        = self::parse_options( $options_string, $tag_name );
 			$replacement    = $data['return']( $options, $block, $instance );
 			$og_replacement = $replacement;


### PR DESCRIPTION
This PR allows our dynamic tag options to end with a space.

For example: `{{terms_list id:12|option:value|sep:, }}`