### PR TITLE
Fix: Excerpt tag not previewing

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -502,6 +502,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 		$content      = $request->get_param( 'content' );
 		$context      = $request->get_param( 'context' );
 		$client_id    = $request->get_param( 'clientId' );
+		$block        = $request->get_param( 'block' ) ?? [];
 		$post_id      = $context['postId'] ?? 0;
 		$fallback_id  = $post_id;
 		$instance     = new stdClass();
@@ -562,7 +563,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 
 					$replacements[] = [
 						'original' => "{{{$tag}}}",
-						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$content}}}", [], $instance ),
+						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$content}}}", $block, $instance ),
 						'fallback'    => $fallback,
 					];
 				} elseif ( ! generateblocks_str_contains( $tag, 'id:' ) ) {
@@ -571,13 +572,13 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 
 					$replacements[] = [
 						'original' => "{{{$tag}}}",
-						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$content}}}", [], $instance ),
+						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$content}}}", $block, $instance ),
 						'fallback'    => $fallback,
 					];
 				} else {
 					$replacements[] = [
 						'original' => "{{{$tag}}}",
-						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$tag}}}", [], $instance ),
+						'replacement' => GenerateBlocks_Register_Dynamic_Tag::replace_tags( "{{{$tag}}}", $block, $instance ),
 						'fallback'    => $fallback,
 					];
 				}

--- a/src/dynamic-tags/utils.js
+++ b/src/dynamic-tags/utils.js
@@ -1,7 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 
-export async function replaceTags( { content, context = {}, clientId } ) {
+export async function replaceTags( { content, context = {}, clientId, block = {} } ) {
 	// Define an async function to fetch data
 	try {
 		const response = await apiFetch( {
@@ -11,6 +11,7 @@ export async function replaceTags( { content, context = {}, clientId } ) {
 				content,
 				context: applyFilters( 'generateblocks.editor.preview.context', context, { content, clientId } ),
 				clientId,
+				block,
 			},
 		} );
 

--- a/src/editor/style-html-attribute.js
+++ b/src/editor/style-html-attribute.js
@@ -28,8 +28,9 @@ addFilter(
 	'generateblocks.editor.htmlAttributes.style',
 	'generateblocks/styleWithReplacements',
 	async( style, props ) => {
-		const { context, clientId } = props;
+		const { context, clientId, attributes } = props;
 
+		const { uniqueId } = attributes;
 		const previewEnabled = 'enabled' === generateBlocksEditor?.dynamicTagsPreview;
 
 		if ( ! previewEnabled ) {
@@ -53,7 +54,16 @@ addFilter(
 			return cache[ blockCacheKey ][ style ];
 		}
 
-		const replacements = await replaceTags( { content: style, context, clientId } );
+		const replacements = await replaceTags( {
+			content: style,
+			context,
+			clientId,
+			block: {
+				attrs: {
+					uniqueId,
+				},
+			},
+		} );
 
 		if ( ! replacements.length ) {
 			return style;

--- a/src/hoc/withDynamicTag.js
+++ b/src/hoc/withDynamicTag.js
@@ -38,6 +38,7 @@ export function withDynamicTag( WrappedComponent ) {
 			content,
 			htmlAttributes,
 			tagName,
+			uniqueId,
 		} = attributes;
 
 		const [ dynamicTagValue, setDynamicTagValue ] = useState( '' );
@@ -85,7 +86,16 @@ export function withDynamicTag( WrappedComponent ) {
 			}
 
 			async function fetchData() {
-				const response = await replaceTags( { content: contentValue, context, clientId } );
+				const response = await replaceTags( {
+					content: contentValue,
+					context,
+					clientId,
+					block: {
+						attrs: {
+							uniqueId,
+						},
+					},
+				} );
 
 				setDynamicTagValue( response );
 
@@ -102,6 +112,7 @@ export function withDynamicTag( WrappedComponent ) {
 			isSavingPost,
 			blockCacheKey,
 			isSelected,
+			uniqueId,
 		] );
 
 		return (


### PR DESCRIPTION
related https://github.com/tomusborne/generateblocks/pull/1715

We need to pass the `uniqueId` to the dynamic tag replacement function now.