### PR TITLE
Tweak: Handle HTML entities in styles object

### DIFF
--- a/includes/class-enqueue-css.php
+++ b/includes/class-enqueue-css.php
@@ -190,6 +190,8 @@ class GenerateBlocks_Enqueue_CSS {
 			wp_register_style( 'generateblocks', false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_enqueue_style( 'generateblocks' );
 
+			$css = html_entity_decode( $css, ENT_QUOTES, 'UTF-8' );
+
 			wp_add_inline_style(
 				'generateblocks',
 				wp_strip_all_tags( $css ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -251,6 +253,8 @@ class GenerateBlocks_Enqueue_CSS {
 			if ( defined( 'FS_CHMOD_FILE' ) ) {
 				$chmod_file = FS_CHMOD_FILE;
 			}
+
+			$content = html_entity_decode( $content, ENT_QUOTES, 'UTF-8' );
 
 			if ( ! $filesystem->put_contents( $this->file( 'path' ), wp_strip_all_tags( $content ), $chmod_file ) ) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "2.0.0-rc.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@edge22/block-styles": "^1.1.37",
+				"@edge22/block-styles": "^1.1.38",
 				"@edge22/components": "^1.1.51",
-				"@edge22/styles-builder": "^1.2.60",
+				"@edge22/styles-builder": "^1.2.61",
 				"@tanstack/react-query": "^5.62.11",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
@@ -1994,14 +1994,27 @@
 			}
 		},
 		"node_modules/@edge22/block-styles": {
-			"version": "1.1.37",
-			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.37.tgz",
-			"integrity": "sha512-EwJinbAW5+xqvfi4Fmf2MX3M/bV/VislmxC27b0y2lFkYExXAXH81PSPNhh2BHiWktR73yhqFLgJWY8CWAwPMw==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/@edge22/block-styles/-/block-styles-1.1.38.tgz",
+			"integrity": "sha512-hOo+PnUoie8NDxO0vMjUosQ61GQaBxpjWLZtcyyu3oF9ilYvLcjQPKrtI7LMCfTuHI2otmMlLNXnph9ZB9RY6A==",
 			"dependencies": {
+				"@wordpress/html-entities": "^4.16.0",
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",
 				"fast-deep-equal": "^3.1.3",
 				"react-use": "^17.5.1"
+			}
+		},
+		"node_modules/@edge22/block-styles/node_modules/@wordpress/html-entities": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.16.0.tgz",
+			"integrity": "sha512-wnCtif4GsQ3gZgINN2GK6+yLH+vIsW3ASvUfdUlxYMcvMagNhJsqaE6dqsnKkezD8q/WNL7zv82BDyGSLKeHNQ==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@edge22/components": {
@@ -2088,9 +2101,9 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.60",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.60.tgz",
-			"integrity": "sha512-T2yfnF/YWg7j3xGGHmZIgtNJHfEgZN6UW50JEuH8t48RVODmh5tFINN2qWDvHu4+Q8l5e6aG9R2rhhfkzPk4zA==",
+			"version": "1.2.61",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.61.tgz",
+			"integrity": "sha512-WY94hZQQT0nvFBErz6q8WLx5nRUevh0P+BE3EsNZ0ki7OUJfEhKIx15MEIdnYknJi4w3dra68D/+8GDrgNjayw==",
 			"dependencies": {
 				"@wordpress/components": "^28.12.0",
 				"@wordpress/icons": "^9.48.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"url": "https://generateblocks.com/support"
 	},
 	"dependencies": {
-		"@edge22/block-styles": "^1.1.37",
+		"@edge22/block-styles": "^1.1.38",
 		"@edge22/components": "^1.1.51",
-		"@edge22/styles-builder": "^1.2.60",
+		"@edge22/styles-builder": "^1.2.61",
 		"@tanstack/react-query": "^5.62.11",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",

--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -9,6 +9,7 @@ import {
 	buildChangedStylesObject,
 	getSelector,
 	Style,
+	useDecodeStyleKeys,
 } from '@edge22/block-styles';
 
 import { useBlockStyles } from '@hooks/useBlockStyles';
@@ -94,6 +95,11 @@ export function withStyles( WrappedComponent ) {
 			selector,
 			setCurrentStyle,
 			setNestedRule,
+		} );
+
+		useDecodeStyleKeys( {
+			styles,
+			setAttributes,
 		} );
 
 		return (


### PR DESCRIPTION
requires https://github.com/EDGE22-Studios/block-styles/pull/18

We convert encoded entities for editor use, and we handle encoded entities that make their way into the saved CSS.