### PR TITLE
Fix: Show correct at-rule style value in block settings

### DIFF
--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -62,7 +62,7 @@ export function withStyles( WrappedComponent ) {
 		function getStyleValue( property, atRuleValue = '', nestedRuleValue = '' ) {
 			if ( nestedRuleValue ) {
 				if ( atRuleValue ) {
-					return styles?.[ atRuleValue ]?.[ nestedRuleValue ]?.[ property ] ?? '';
+					return styles?.[ nestedRuleValue ]?.[ atRuleValue ]?.[ property ] ?? '';
 				}
 
 				return styles?.[ nestedRuleValue ]?.[ property ] ?? '';


### PR DESCRIPTION
Fixes second part of this issue: https://github.com/tomusborne/generateblocks/issues/1730