### PR TITLE
Tweak: Load initial block editor CSS

### DIFF
--- a/src/hoc/withStyles.js
+++ b/src/hoc/withStyles.js
@@ -1,4 +1,5 @@
 import { useMemo } from '@wordpress/element';
+import { transformStyles } from '@wordpress/block-editor';
 
 import { defaultAtRules, getCss, cleanStylesObject } from '@edge22/styles-builder';
 import {
@@ -27,6 +28,7 @@ export function withStyles( WrappedComponent ) {
 		const {
 			uniqueId,
 			styles,
+			css,
 		} = attributes;
 
 		const {
@@ -73,6 +75,18 @@ export function withStyles( WrappedComponent ) {
 			return styles?.[ property ] ?? '';
 		}
 
+		const initialEditorCss = useMemo( () => {
+			if ( ! css ) {
+				return '';
+			}
+
+			const editorStyles = [ {
+				css,
+			} ];
+
+			return transformStyles( editorStyles, '.editor-styles-wrapper' )?.[ 0 ];
+		}, [] );
+
 		useAtRuleEffect( {
 			deviceType,
 			atRule,
@@ -109,6 +123,7 @@ export function withStyles( WrappedComponent ) {
 					getCss={ getCss }
 					styles={ frontendStyles }
 					clientId={ clientId }
+					initialEditorCss={ initialEditorCss }
 					name={ name }
 				/>
 				<WrappedComponent


### PR DESCRIPTION
This is a part of a change to improve the speed of editor CSS changes.

This particular change loads the editor CSS immediately, removing the initial flash of unstyled content.

related https://github.com/EDGE22-Studios/styles-builder/pull/66
related https://github.com/EDGE22-Studios/block-styles/pull/20