### PR TITLE
Add fallback option to featured image

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -318,7 +318,11 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			return self::output( '', $options, $instance );
 		}
 
-		$image_id = get_post_thumbnail_id( $id );
+		if (! has_post_thumbnail($id)) {
+			$image_id = $options['fallback'] ?? '';
+		} else {
+			$image_id = get_post_thumbnail_id($id);
+		}
 
 		if ( ! $image_id ) {
 			return self::output( '', $options, $instance );

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -139,6 +139,11 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 							'alt',
 						],
 					],
+					'fallback' => [
+						'type'    => 'number',
+						'label'   => __('Fallback Image ID', 'generateblocks'),
+						'help'    => __('Enter the ID of the image to use if the post does not have a featured image.', 'generateblocks'),
+					],
 				],
 				'return'   => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_featured_image' ],
 			]


### PR DESCRIPTION
It's not easy without using a hook / filter to set the fallback image for the featured image.

This pull request adds a number field option to the featured image that will be used if the post doesn't have a featured image.