### PR TITLE
Add url query param dynamic tag support

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -840,21 +840,16 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			return self::output( '', $options, $instance );
 		}
 
-		// Sanitize the key name
 		$key = sanitize_key( $options['key'] );
 
-		// Get the default value if set
 		$default = isset( $options['default'] ) ? sanitize_text_field( $options['default'] ) : '';
 
-		// Check if parameter exists and get its value
 		if ( ! isset( $_GET[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return self::output( $default, $options, $instance );
 		}
 
-		// Sanitize the value based on context
 		$raw_value = wp_unslash( $_GET[ $key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		// Handle arrays
 		$value = is_array( $raw_value ) 
 			? implode( $options['delimiter'], array_map( 'sanitize_text_field', $raw_value ) ) 
 			: sanitize_text_field( $raw_value );

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -854,6 +854,10 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 			? implode( $options['delimiter'], array_map( 'sanitize_text_field', $raw_value ) ) 
 			: sanitize_text_field( $raw_value );
 
+		if ( empty( $value ) ) {
+			return self::output( $default, $options, $instance );
+		}
+
 		return self::output( $value, $options, $instance );
 	}
 }

--- a/includes/dynamic-tags/class-dynamic-tag-callbacks.php
+++ b/includes/dynamic-tags/class-dynamic-tag-callbacks.php
@@ -826,4 +826,39 @@ class GenerateBlocks_Dynamic_Tag_Callbacks extends GenerateBlocks_Singleton {
 
 		return self::output( $output, $options, $instance );
 	}
+
+	/**
+	 * Get a URL query parameter value.
+	 *
+	 * @param array  $options The options.
+	 * @param array  $block The block.
+	 * @param object $instance The block instance.
+	 * @return string
+	 */
+	public static function get_url_param( $options, $block, $instance ) {
+		if ( empty( $options['key'] ) ) {
+			return self::output( '', $options, $instance );
+		}
+
+		// Sanitize the key name
+		$key = sanitize_key( $options['key'] );
+
+		// Get the default value if set
+		$default = isset( $options['default'] ) ? sanitize_text_field( $options['default'] ) : '';
+
+		// Check if parameter exists and get its value
+		if ( ! isset( $_GET[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return self::output( $default, $options, $instance );
+		}
+
+		// Sanitize the value based on context
+		$raw_value = wp_unslash( $_GET[ $key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Handle arrays
+		$value = is_array( $raw_value ) 
+			? implode( $options['delimiter'], array_map( 'sanitize_text_field', $raw_value ) ) 
+			: sanitize_text_field( $raw_value );
+
+		return self::output( $value, $options, $instance );
+	}
 }

--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -340,6 +340,36 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 				'return'   => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_media' ],
 			]
 		);
+
+		new GenerateBlocks_Register_Dynamic_Tag(
+			[
+				'title'       => __( 'URL Query Parameter', 'generateblocks' ),
+				'tag'         => 'url_param',
+				'type'        => 'site',
+				'supports'    => [],
+				'description' => __( 'Get a value from the URL query parameters.', 'generateblocks' ),
+				'options'     => [
+					'key' => [
+						'type'        => 'text',
+						'label'       => __( 'Parameter Key', 'generateblocks' ),
+						'help'        => __( 'Enter the query parameter key to retrieve.', 'generateblocks' ),
+						'required'    => true,
+					],
+					'default' => [
+						'type'        => 'text',
+						'label'       => __( 'Default Value', 'generateblocks' ),
+						'help'        => __( 'Value to show if the parameter is not present.', 'generateblocks' ),
+					],
+					'delimiter' => [
+						'type'        => 'text',
+						'label'       => __( 'Delimiter', 'generateblocks' ),
+						'help'        => __( 'Enter the delimiter for array values.', 'generateblocks' ),
+						'default'     => ',',
+					],
+				],
+				'return'      => [ 'GenerateBlocks_Dynamic_Tag_Callbacks', 'get_url_param' ],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
This adds the ability to use url query params to render content.

For example: `https://mydomain.com/?fname=Taylor`

`Hey {{url_param delimiter:,|key:fname|default:there}}` => `Hey Taylor`

Has support for:
- fallback if key doesn't exist or is empty after sanitisation
- Array values with ability to delimiter