### PR TITLE
Update Styles Builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@edge22/block-styles": "^1.1.41",
 				"@edge22/components": "^1.1.52",
-				"@edge22/styles-builder": "^1.2.68",
+				"@edge22/styles-builder": "^1.2.69",
 				"@tanstack/react-query": "^5.62.11",
 				"@wordpress/block-editor": "^12.12.0",
 				"@wordpress/blocks": "^12.21.0",
@@ -2101,13 +2101,14 @@
 			}
 		},
 		"node_modules/@edge22/styles-builder": {
-			"version": "1.2.68",
-			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.68.tgz",
-			"integrity": "sha512-1ruNt9vLAADGbDTVQqK1DvQpNJCXJTu/Ei9eVXHzNC3r74qE2IEnNVuFvDuy4cYjLVGAZ5+lVc+9MFzXx0Encg==",
+			"version": "1.2.69",
+			"resolved": "https://registry.npmjs.org/@edge22/styles-builder/-/styles-builder-1.2.69.tgz",
+			"integrity": "sha512-ogGn22cCQaqwCxZkv/M5oxcTmI2GWvMuuYSKRCm+Nvetqvz5Xvh0RZb/vANuBgvOqwF9Ri4f+zSkdannIsUyAQ==",
 			"dependencies": {
 				"@wordpress/components": "^28.12.0",
 				"@wordpress/icons": "^9.48.0",
 				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
 				"css-box-shadow": "^1.0.0-3",
 				"downshift": "^9.0.6",
 				"known-css-properties": "^0.30.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@edge22/block-styles": "^1.1.41",
 		"@edge22/components": "^1.1.52",
-		"@edge22/styles-builder": "^1.2.68",
+		"@edge22/styles-builder": "^1.2.69",
 		"@tanstack/react-query": "^5.62.11",
 		"@wordpress/block-editor": "^12.12.0",
 		"@wordpress/blocks": "^12.21.0",


### PR DESCRIPTION
* Add: Fallback preview support in color picker https://github.com/EDGE22-Studios/styles-builder/pull/72
* Add: Styles indicator to the "More" selectors dropdown https://github.com/EDGE22-Studios/styles-builder/pull/71
* Add: `static` value to the "Position" control https://github.com/EDGE22-Studios/styles-builder/pull/70
* Fix: Inability to type some units to the `UnitControl` https://github.com/EDGE22-Studios/styles-builder/pull/69