### PR TITLE
fix: update comments count option key to match callback expectation

### DIFF
--- a/includes/dynamic-tags/class-dynamic-tags.php
+++ b/includes/dynamic-tags/class-dynamic-tags.php
@@ -178,7 +178,7 @@ class GenerateBlocks_Dynamic_Tags extends GenerateBlocks_Singleton {
 						'placeholder' => __( 'No comments', 'generateblocks' ),
 						'type'        => 'text',
 					],
-					'one' => [
+					'single' => [
 						'label'       => __( 'One comment text', 'generateblocks' ),
 						'placeholder' => __( 'One comment', 'generateblocks' ),
 						'type'        => 'text',


### PR DESCRIPTION
Fix comments count dynamic tag not using custom text for single comment.

The tag callback expects `single` as the option key, but registration used `one`. Updated registration to use correct key name.