### PR TITLE
Tweak: Load permissions earlier in editor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
 		"generateblocksBlockMedia": "readonly",
 		"generateBlocksEditor": "readonly",
 		"generateblocksDashboard": "readonly",
-		"generateblocksBlockText": "readonly"
+		"generateblocksBlockText": "readonly",
+		"gbPermissions": "readonly"
 	},
 	"env": {
 	  "browser": true,

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -39,3 +39,31 @@ function generateblocks_do_activate( $network_wide = false ) {
 		update_option( 'generateblocks_do_activation_redirect', true );
 	}
 }
+
+/**
+ * Output permissions for use in admin objects.
+ *
+ * @deprecated 2.1.0
+ * @return void
+ */
+function generateblocks_admin_head_scripts() {
+	$permissions = apply_filters(
+		'generateblocks_permissions',
+		[
+			'isAdminUser'       => current_user_can( 'manage_options' ),
+			'canEditPosts'      => current_user_can( 'edit_posts' ),
+			'isGbProActive'     => is_plugin_active( 'generateblocks-pro/plugin.php' ),
+			'isGpPremiumActive' => is_plugin_active( 'gp-premium/gp-premium.php' ),
+		]
+	);
+
+	$permission_object = wp_json_encode( $permissions );
+
+	echo sprintf(
+		'<script>
+				const gbPermissions = %s;
+				Object.freeze( gbPermissions );
+		</script>',
+		$permission_object // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	);
+}

--- a/includes/general.php
+++ b/includes/general.php
@@ -676,7 +676,7 @@ function generateblocks_set_editor_permissions() {
 	);
 
 	$permission_object = wp_json_encode( $permissions );
-	wp_register_script( 'generateblocks-editor-permissions', '', [], '', false );
+	wp_register_script( 'generateblocks-editor-permissions', '', [], '1.0', false );
 	wp_enqueue_script( 'generateblocks-editor-permissions' );
 	$script = sprintf(
 		'const gbPermissions = %s;

--- a/includes/general.php
+++ b/includes/general.php
@@ -658,13 +658,13 @@ function generateblocks_do_block_editor_styles( $editor_settings ) {
 	return $editor_settings;
 }
 
-add_action( 'admin_head', 'generateblocks_admin_head_scripts', 0 );
+add_action( 'enqueue_block_editor_assets', 'generateblocks_set_editor_permissions', 0 );
 /**
- * Output permissions for use in admin objects.
+ * Output permissions for use in the editor.
  *
  * @return void
  */
-function generateblocks_admin_head_scripts() {
+function generateblocks_set_editor_permissions() {
 	$permissions = apply_filters(
 		'generateblocks_permissions',
 		[
@@ -676,14 +676,14 @@ function generateblocks_admin_head_scripts() {
 	);
 
 	$permission_object = wp_json_encode( $permissions );
-
-	echo sprintf(
-		'<script>
-				const gbPermissions = %s;
-				Object.freeze( gbPermissions );
-		</script>',
-		$permission_object // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	wp_register_script( 'generateblocks-editor-permissions', '' );
+	wp_enqueue_script( 'generateblocks-editor-permissions' );
+	$script = sprintf(
+		'const gbPermissions = %s;
+		Object.freeze( gbPermissions );',
+		$permission_object
 	);
+	wp_add_inline_script( 'generateblocks-editor-permissions', $script );
 }
 
 add_filter( 'render_block', 'generateblocks_do_html_attributes_escaping', 20, 2 );

--- a/includes/general.php
+++ b/includes/general.php
@@ -676,7 +676,7 @@ function generateblocks_set_editor_permissions() {
 	);
 
 	$permission_object = wp_json_encode( $permissions );
-	wp_register_script( 'generateblocks-editor-permissions', '' );
+	wp_register_script( 'generateblocks-editor-permissions', '', [], '', false );
 	wp_enqueue_script( 'generateblocks-editor-permissions' );
 	$script = sprintf(
 		'const gbPermissions = %s;

--- a/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
+++ b/src/blocks/looper/components/LoopInnerBlocksRenderer.jsx
@@ -44,7 +44,7 @@ function useWpQuery( shouldRequest = true, { query, attributes, selectedBlock, c
 
 	const {
 		isAdminUser = false,
-	} = gbPermissions; // eslint-disable-line
+	} = gbPermissions ?? {};
 
 	const [ data, setData ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );


### PR DESCRIPTION
This loads our `gbPermissions` object earlier than our other scripts in the editor, so it's readily available.