### PR TITLE
Fix: Allow `download` attribute to have a value

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2162,6 +2162,19 @@ function generateblocks_with_escaped_attributes( $content, $args = [] ) {
 			$attribute_value = $processor->get_attribute( $name );
 			$escaped_value   = generateblocks_get_escaped_html_attribute( $name, $attribute_value );
 
+			// WordPress strips out the `download` value by default, even though it's acceptable to give it a value.
+			// If we have a `download` attribute, let's re-add the value if it exists.
+			if ( 'download' === $name ) {
+				$attributes_with_download = $block_html_attributes;
+
+				if ( 2 === $max_tags && 0 === $tags_processed ) {
+					$attributes_with_download = $link_html_attributes;
+				}
+
+				$download_value = $attributes_with_download[ $name ] ?? true;
+				$escaped_value = generateblocks_get_escaped_html_attribute( $name, $download_value );
+			}
+
 			$processor->set_attribute( $name, $escaped_value );
 			$updated = true;
 		}


### PR DESCRIPTION
closes https://github.com/tomusborne/generateblocks-pro/issues/849

WordPress doesn't allow `download` to have a value: https://github.com/WordPress/gutenberg/blob/a579f73cf5e546f3e639b1eae2cef55bf31c6848/packages/blocks/src/api/validation/index.js#L433-L434