### PR TITLE
Fix: Image selection in WP 6.8

### DIFF
--- a/src/blocks/media/editor.scss
+++ b/src/blocks/media/editor.scss
@@ -1,3 +1,3 @@
 img[data-gb-id][role="button"] {
-	pointer-events: auto;
+	pointer-events: auto; // https://github.com/WordPress/gutenberg/blob/20c77f5e3510053e2a20e3258288fceb7b0c7521/packages/block-editor/src/components/block-draggable/content.scss#L23
 }

--- a/src/blocks/media/editor.scss
+++ b/src/blocks/media/editor.scss
@@ -1,0 +1,3 @@
+img[data-gb-id][role="button"] {
+	pointer-events: auto;
+}


### PR DESCRIPTION
WordPress added `pointer-events: none` to images in the editor as of WP 6.8. This broke our image selection logic in the editor.