### PR TITLE
Fix: Dynamic tag parsing all content at once

### DIFF
--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -104,11 +104,13 @@ class GenerateBlocks_Register_Dynamic_Tag {
 	 * @return string
 	 */
 	public static function replace_tags( $content, $block, $instance ) {
-		if ( ! generateblocks_str_contains( $content, '{{' ) ) {
+		$block_html = $block['innerHTML'] ?? $content;
+
+		if ( ! generateblocks_str_contains( $block_html, '{{' ) ) {
 			return $content;
 		}
 
-		$matches = self::find_matches( $content, self::$tags );
+		$matches = self::find_matches( $block_html, self::$tags );
 
 		foreach ( $matches as $match ) {
 			$tag_name = $match[1] ?? '';

--- a/includes/dynamic-tags/class-register-dynamic-tag.php
+++ b/includes/dynamic-tags/class-register-dynamic-tag.php
@@ -104,7 +104,9 @@ class GenerateBlocks_Register_Dynamic_Tag {
 	 * @return string
 	 */
 	public static function replace_tags( $content, $block, $instance ) {
-		$block_html = $block['innerHTML'] ?? $content;
+		$block_html = ! empty( $block['innerHTML'] )
+			? $block['innerHTML']
+			: $content;
 
 		if ( ! generateblocks_str_contains( $block_html, '{{' ) ) {
 			return $content;
@@ -121,7 +123,7 @@ class GenerateBlocks_Register_Dynamic_Tag {
 
 			$data           = self::$tags[ $tag_name ];
 			$full_tag       = $match[0];
-			$full_tag       = self::maybe_prepend_protocol( $content, $full_tag );
+			$full_tag       = self::maybe_prepend_protocol( $block_html, $full_tag );
 			$options_string = isset( $match[2] ) ? ltrim( $match[2], ' ' ) : '';
 			$options        = self::parse_options( $options_string, $tag_name );
 			$replacement    = $data['return']( $options, $block, $instance );

--- a/readme.txt
+++ b/readme.txt
@@ -145,6 +145,7 @@ GenerateBlocks was built to work hand-in-hand with [GeneratePress](https://gener
 * Fix: Font family filter in the styles builder
 * Fix: `UnitControl` values starting with a dash
 * Fix: Image block selection in WP 6.8
+* Fix: Dynamic tag parsing all blocks in Container at once
 * Tweak: Improve editor performance
 * Tweak: Always show popular user meta fields in dropdown
 * Tweak: Add support for device visibility feature in Pro


### PR DESCRIPTION
This fixes a bug where our dynamic tag parsing was searching the full `$content` provided by the block.

This meant that blocks with inner blocks (like the Container) were having their entire content searched for dynamic tags and replaced.

The result of this meant that all HTML inside of a block like the Container was being searched and parsed.

For example, if you add a non-supported block like a Paragraph and give it a dynamic tag and placed it inside a Container, the system would try to parse the tag even though it's not supported in the system. The result would be that the entire Container block would not render if that dynamic tag didn't return a value.

This PR tries to search the HTML of the individual block itself.