### PR TITLE
Fix: Missing loop item tag name option

### DIFF
--- a/src/blocks/loop-item/components/BlockSettings.jsx
+++ b/src/blocks/loop-item/components/BlockSettings.jsx
@@ -80,7 +80,7 @@ export function BlockSettings( {
 				{ ...panelProps }
 				panelId="settings"
 			>
-				{ '' !== atRule && (
+				{ '' === atRule && (
 					<>
 						<TagNameControl
 							blockName="generateblocks/loop-item"


### PR DESCRIPTION
closes https://github.com/tomusborne/generateblocks/issues/1862