### PR TITLE
Fix: Disable image links in the editor

### DIFF
--- a/src/blocks/media/components/Image.jsx
+++ b/src/blocks/media/components/Image.jsx
@@ -114,7 +114,7 @@ export function Image( {
 					{ linkHtmlAttributes.href ? (
 						<a
 							{ ...linkHtmlAttributes }
-							href="#"
+							href={ undefined }
 						>
 							{ image }
 						</a>


### PR DESCRIPTION
closes https://github.com/tomusborne/generateblocks/issues/1894